### PR TITLE
Add figma-from-code plugin 

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,6 +12,11 @@
       "name": "creating-prompts",
       "source": "./plugins/creating-prompts",
       "description": "Skills for creating new agent skills for Claude Code and VS Code Copilot"
+    },
+    {
+      "name": "figma-from-code",
+      "source": "./plugins/figma-from-code",
+      "description": "Rebuild a Figma file from a codebase — discover, tokenize, build components, assemble screens, validate"
     }
   ]
 }

--- a/plugins/figma-from-code/.claude-plugin/plugin.json
+++ b/plugins/figma-from-code/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "figma-from-code",
+  "description": "Rebuild a Figma file from a codebase — discover components, create variables/structure, build components tier-by-tier, assemble screens, and validate visual fidelity",
+  "version": "1.0.0",
+  "author": {
+    "name": "Bitovi",
+    "url": "https://www.bitovi.com"
+  }
+}

--- a/plugins/figma-from-code/README.md
+++ b/plugins/figma-from-code/README.md
@@ -1,0 +1,84 @@
+# Figma-from-Code Plugin
+
+Rebuild a Figma file **from your codebase**. This workflow discovers the React components of a running app + source, creates Figma variable collections and file structure, builds components tier-by-tier, composes full-page screens from those components, and validates visual fidelity against the live app.
+
+It ships two ways to run: as a **Workflow** (parallel, orchestrated, progress-tracked) and as a **skill tree** an agent can read and follow.
+
+## Skills
+
+| Skill | Description |
+|---|---|
+| `figma-from-code` | Entry skill — orchestrates the full 10-stage code-to-Figma rebuild. Thin dispatcher that delegates to per-stage sub-skills under its folder. |
+| `figma-setup-variables` | Companion — extracts design tokens from CSS/Tailwind into Figma variable collections (Phase 1). |
+| `figma-setup-file-structure` | Companion — creates the Figma page skeleton and foundations frames (Phase 2). |
+
+The `figma-from-code/` skill folder contains the staged sub-skills (`1-discovery-components/` … `10-validator/`), per-component step files, prompt templates, and helper scripts (`map-components.js`, `resolve-colors.js`, `compare.js`, `browser-server.js`, …).
+
+## What it does (10 stages)
+
+1. **0a — Component discovery**: browser crawl + static source scan → `component-map.json`, dependency tiers, existing Figma components.
+2. **0b — Icon/asset discovery**: scan for Lucide icons and SVG assets.
+3. **Normalize**: align component names with Figma conventions.
+4. **1 — Setup tokens**: create Figma variable collections (via `figma-setup-variables`).
+5. **2 — File structure**: create pages and foundation frames (via `figma-setup-file-structure`).
+6. **2.5 — Pre-capture**: screenshot every component and screen in the live app.
+7. **3 — Build components**: tier-by-tier (tiers sequential, components within a tier in parallel).
+8. **4 — Build screens**: compose full-page frames from built component instances.
+9. **5 — Validate**: compare Figma vs live app screenshots, report, and fix mismatches.
+
+## Prerequisites
+
+- **Figma MCP server** connected and authenticated (the `figma` plugin). The build/setup stages use `use_figma`, and require the `figma:figma-use` skill (mandatory before any `use_figma` call) and `figma:figma-generate-library`.
+- **Playwright** (`@playwright/test` with chromium installed) — used for the browser crawl, pre-capture screenshots, and pixel comparison.
+- **A running dev server** for the app you're rebuilding.
+- **Node.js 18+**.
+
+## Installation
+
+### Claude Code
+
+```
+/plugin marketplace add bitovi/ai-enablement-prompts
+/plugin install figma-from-code@bitovi-ai-enablement
+```
+
+### Manual (to run the Workflow orchestrator)
+
+The orchestrator ships under `workflows/`. To run it via the Workflow tool, place the files so the orchestrator can find the skill tree:
+
+- Skill tree → `.claude/skills/figma-from-code/` (default `skillDir`; override with `args.skillDir`).
+- Companion skills → `.claude/skills/figma-setup-variables/`, `.claude/skills/figma-setup-file-structure/`.
+- Orchestrator → `.claude/workflows/figma-from-code.js` (or run it by `scriptPath` directly).
+
+## Usage
+
+### As a Workflow (recommended — parallel + progress-tracked)
+
+```js
+Workflow({
+  scriptPath: ".claude/workflows/figma-from-code.js",
+  args: {
+    fileKey: "<figma-file-key>",        // REQUIRED
+    sourceDir: "src/",                   // your component/source root (default: "src/")
+    devServerUrl: "http://localhost:5173", // your running dev server (default shown)
+    startPhase: "phase0a",               // phase0a|phase0b|phase1|phase2|phase2_5|phase3|phase4|phase5
+    endPhase: null,                      // optional stop point
+    skillDir: ".claude/skills/figma-from-code" // override if installed elsewhere
+  }
+})
+```
+
+`fileKey` is **required** — the workflow errors out without it. All other args have neutral defaults; set `sourceDir` and `devServerUrl` to match your project.
+
+### As a skill
+
+```
+/figma-from-code:figma-from-code
+```
+
+Then follow the entry `SKILL.md`, which dispatches through the staged sub-skills.
+
+## Notes
+
+- This bundle was generalized from a real project. Paths and identifiers are placeholders (`<source-dir>`, `<tailwind-config>`, `<figma-file-key>`, `<dev-server-url>`) — supply your own via the workflow args.
+- A full run requires a live Figma file, a running dev server, and Playwright. There is no offline/dry-run mode.

--- a/plugins/figma-from-code/skills/figma-from-code/1-discovery-components/SKILL.md
+++ b/plugins/figma-from-code/skills/figma-from-code/1-discovery-components/SKILL.md
@@ -1,0 +1,280 @@
+# Skill: Component Discovery
+
+Discovers the complete component architecture of a web application by combining two methods: (1) browser crawling to find runtime components with routes and selectors, and (2) static code scanning to find all components including those not rendered during the crawl (modals, inline-edit variants, conditional renders, etc.). Produces a merged, topologically-sorted build order (leaves first, layouts last). Also inspects the target Figma file to report existing pages, variable collections, and components.
+
+## When to Use
+
+- Before running `figma-from-code` on a fresh Figma file
+- When the component hierarchy may have changed and you need an updated build order
+- Standalone audit of what components a site uses and how they nest
+- When resuming a build and `component-map.json` is missing
+
+## Prerequisites
+
+- Dev server running at `<dev-server-url>` (or custom URL)
+- Playwright installed (`node_modules/playwright-core`)
+
+## Required Inputs
+
+- `fileKey`: The Figma file key (for the Figma inspection step)
+- `devServerUrl` (optional, default `<dev-server-url>`): The running dev server URL
+
+## Output Files
+
+Written to `.temp/figma-from-code/`:
+
+| File                 | Contents                                            |
+| -------------------- | --------------------------------------------------- |
+| `component-map.json` | Authoritative tiered build order (machine-readable) |
+| `component-map.md`   | Human-readable report with Mermaid diagram          |
+
+## Workflow
+
+### 1. Ensure output directory exists
+
+```bash
+mkdir -p .temp/figma-from-code/
+```
+
+### 2. Verify dev server is running
+
+```bash
+curl -s --max-time 3 <dev-server-url> > /dev/null || echo "Dev server not running"
+```
+
+If not running, halt and tell the user to start the dev server.
+
+### 3. Run the component discovery script
+
+```bash
+node ${CLAUDE_SKILL_DIR}/10-validator/map-components.js \
+  "<dev-server-url>" --crawl --max-crawl 30 \
+  --markdown .temp/figma-from-code/component-map.md \
+  --output .temp/figma-from-code/component-map.json
+```
+
+This produces the **authoritative build order** — a topologically-sorted list of tiers where leaves come first and layouts come last. All subsequent phases of `figma-from-code` use this output, not the static `figma-component-dependency-map`.
+
+### 4. Normalize component names
+
+The DOM scanner extracts React component names from the fiber tree, which may differ from the Figma naming convention for icons and assets:
+
+- Lucide icons: scanner reads the internal `displayName` (e.g. `EllipsisVertical`) rather than the import alias used in code (e.g. `MoreVertical`)
+- SVG asset wrappers: scanner sees the wrapper component name (e.g. `CartonLogo`) rather than the Figma asset name (e.g. `Asset/CartonLogoSvg`)
+
+Run the normalization script to align names with Figma conventions. This requires `icons.json` from Phase 0b.
+
+```bash
+node ${CLAUDE_SKILL_DIR}/1-discovery-components/normalize-component-map.js \
+  .temp/figma-from-code/component-map.json \
+  .temp/figma-from-code/icons.json \
+  --write
+```
+
+If `icons.json` does not yet exist (Phase 0b hasn't run), skip this step — the orchestrator will re-run normalization after Phase 0b completes.
+
+The script resolves names via three strategies:
+
+1. **Direct icon match**: component name is a known icon import name → prefix with `Icon/`
+2. **Lucide alias resolution**: component name is a Lucide canonical name that differs from the import alias → resolve via `lucide-react` exports → prefix with `Icon/`
+3. **Asset prefix match**: component name is a prefix of a known asset name → prefix with `Asset/`
+
+### 5. Discover frontend source directories
+
+Run the code scanner in discovery mode to locate component directories:
+
+```bash
+node ${CLAUDE_SKILL_DIR}/1-discovery-components/discover-code-components.js \
+  --discover --root .
+```
+
+Read the JSON output. Present the discovered `componentDirectories` to the user for confirmation:
+
+> "Found these component source directories:
+>
+> - `<source-dir>/components` (52 components across your component subfolders)
+> - `<source-dir>/pages` (6 components)
+>
+> Are these correct? Any directories to exclude?"
+
+Wait for user confirmation. If the user wants to exclude a directory (e.g., a deprecated `ui/` folder), note it for the `--exclude` flag.
+
+### 6. Scan code for all components
+
+Run the code scanner in scan mode with the confirmed directories:
+
+```bash
+node ${CLAUDE_SKILL_DIR}/1-discovery-components/discover-code-components.js \
+  --scan {confirmed_dir_1} {confirmed_dir_2} \
+  --browser-map .temp/figma-from-code/component-map.json \
+  --output .temp/figma-from-code/component-map.json \
+  [--exclude {excluded_dirs}]
+```
+
+This merges code-discovered components into the browser-discovered map. Each component gains a `source` field (`"browser"`, `"code"`, or `"both"`) and a `codeDependencies` array. Tiers are **recomputed** from static import analysis to include all components. Browser data (`routes`, `selector`, `instances`) is preserved for components found by both methods.
+
+### 7. Read and summarize the output
+
+Read `.temp/figma-from-code/component-map.json` and extract:
+
+- `tiers[]` — the tiered build order (number of tiers varies per project)
+- `tree` — the merged component hierarchy
+- `componentCount` — total components to build
+- Source breakdown:
+  - `{bothCount}` found in browser + code
+  - `{codeOnlyCount}` found in code only
+  - `{browserOnlyCount}` found in browser only (no source file matched)
+
+### 8. Inspect the Figma file and match components
+
+Use `get_metadata` (fileKey) to retrieve all components and component sets from the Figma file. This returns every component with its `name` and `nodeId`.
+
+Build a lookup map from the Figma metadata: `{ componentName → nodeId }`.
+
+After normalization (step 4), component names in `component-map.json` use Figma conventions (`Icon/Bot`, `Asset/CartonLogoSvg`, `Button`). Match each component by exact name against the Figma lookup map.
+
+For each component in every tier of `component-map.json`, add a `figmaNodeId` field:
+
+- If a matching Figma component exists: set `figmaNodeId` to the node ID string (e.g. `"918:50"`)
+- If no match: set `figmaNodeId` to `null`
+
+Also use `use_figma` to do a read-only inspection for file-level state:
+
+- List all pages (names + IDs)
+- Check if variable collections already exist (`Palette`, `Semantic`, `Spacing`)
+- If a page named `Screens` already exists, list its top-level children. Each direct child frame is a pre-existing screen. Build `preExistingScreens` as `{ frameName: nodeId }` (e.g. `{ "ExamplePage": "123:456" }`). If no Screens page exists, set `preExistingScreens` to `{}`.
+
+### 8b. Ensure .figma/figma.json exists for every matched component
+
+For each Figma component returned by `get_metadata` (regardless of whether it appears in the runtime `component-map.json`), ensure a tracking record exists at `<source-dir>/components/{ComponentName}/.figma/figma.json`. Same schema and same folder-resolution rules as Step 6 of `${CLAUDE_SKILL_DIR}/7-build-component/SKILL.md`:
+
+```json
+{
+  "fileKey": "{figmaFileKey}",
+  "nodeId": "{nodeId}",
+  "url": "https://figma.com/design/{fileKey}?node-id={nodeIdWithDashes}",
+  "componentName": "Button",
+  "createdAt": "2026-05-15T14:32:00Z",
+  "updatedAt": "2026-05-15T14:32:00Z",
+  "dependencies": []
+}
+```
+
+**Behavior:**
+
+- **File missing:** create it. Set `createdAt` and `updatedAt` to the current ISO 8601 UTC timestamp. Create the `.figma/` folder first if it does not exist (use the namespace-aware path rules — `Icon/Bot` → `<source-dir>/components/Icon/Bot/.figma/figma.json`).
+- **File present:** do not modify it. This phase only seeds tracking files for components that lack one — refreshing `updatedAt` is `${CLAUDE_SKILL_DIR}/7-build-component/SKILL.md`'s job.
+
+Skip COMPONENT children of COMPONENT_SET nodes (variants) — only write tracking files for the top-level component or component set.
+
+**Failure handling:** if a write fails (permission, missing parent path that can't be created), log the failure and continue with the rest. Surface the count of failures in the final report (Step 10).
+
+### 9. Write updated output
+
+Re-write `.temp/figma-from-code/component-map.json` with the `figmaNodeId` field added to every component entry across all tiers. Also add a top-level `figma` summary object.
+
+> **Why this matters for later phases:** the orchestrator uses every component with a non-null `figmaNodeId` as the **immutable** `preExistingComponents` snapshot in `state.json`. The orchestrator's "Pre-Existing Components Rule" requires explicit user authorization before modifying, replacing, or deleting any of those nodes in later phases (Phase 3 rebuilds, Phase 5 fix-loops, ad-hoc cleanup). Accuracy of `figmaNodeId` matters — a missed match silently degrades that protection.
+
+```json
+{
+  "figma": {
+    "fileKey": "{fileKey}",
+    "pages": [{ "name": "...", "id": "..." }],
+    "variableCollections": ["Palette", "Semantic"] or [],
+    "existingComponentCount": 12,
+    "missingComponentCount": 5,
+    "preExistingScreens": { "ExamplePage": "123:456" }
+  },
+  "tiers": [
+    {
+      "tier": 1,
+      "components": [
+        { "name": "Button", "figmaNodeId": "918:50", ... },
+        { "name": "NewThing", "figmaNodeId": null, ... }
+      ]
+    }
+  ]
+}
+```
+
+### 10. Write discovery summary for the orchestrator
+
+Extract the data the orchestrator needs into a small summary file so it never has to read the full `component-map.json` (which can be 48KB+):
+
+```bash
+node -e "
+  const map = JSON.parse(require('fs').readFileSync('.temp/figma-from-code/component-map.json','utf-8'));
+  const tiers = map.tiers.map(t => ({ tier: t.tier, label: t.label || 'Tier ' + t.tier, components: t.components.map(c => c.name) }));
+  const builtComponents = {};
+  const preExistingComponents = {};
+  let bothCount = 0, codeOnlyCount = 0, browserOnlyCount = 0;
+  for (const t of map.tiers) {
+    for (const c of t.components) {
+      if (c.figmaNodeId) {
+        builtComponents[c.name] = c.figmaNodeId;
+        preExistingComponents[c.name] = c.figmaNodeId;
+      }
+      if (c.source === 'both') bothCount++;
+      else if (c.source === 'code') codeOnlyCount++;
+      else if (c.source === 'browser') browserOnlyCount++;
+    }
+  }
+  const componentCount = map.tiers.reduce((sum, t) => sum + t.components.length, 0);
+  const summary = {
+    buildOrder: { tierCount: tiers.length, tiers },
+    builtComponents,
+    preExistingComponents,
+    preExistingScreens: (map.figma && map.figma.preExistingScreens) || {},
+    componentCount,
+    sourceBreakdown: { both: bothCount, codeOnly: codeOnlyCount, browserOnly: browserOnlyCount },
+    figma: map.figma || null
+  };
+  require('fs').writeFileSync('.temp/figma-from-code/discovery-summary.json', JSON.stringify(summary, null, 2));
+  console.log('Discovery summary written: ' + componentCount + ' components across ' + tiers.length + ' tiers');
+"
+```
+
+Write to `.temp/figma-from-code/discovery-summary.json`. The orchestrator reads only this file (~3KB) instead of the full component-map.json.
+
+### 11. Report
+
+Report what exists in Figma vs what needs to be created, including the discovered build order and source breakdown:
+
+```
+Component Discovery complete:
+- {componentCount} components across {tierCount} tiers
+- Source breakdown: {bothCount} browser+code, {codeOnlyCount} code-only, {browserOnlyCount} browser-only
+- Tier 1 (leaves): {component list}
+- Tier 2: {component list}
+- ...
+- Tier {N} (top-level): {component list}
+
+Figma file state:
+- Pages: {existing page names}
+- Variable collections: {existing or "none"}
+- Already built: {count} components ({list})
+- Not yet built: {count} components ({list})
+```
+
+## Scripts Reference
+
+| Script                        | Location                                                                            | Purpose                                                                                                                                                                            |
+| ----------------------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `map-components.js`           | `${CLAUDE_SKILL_DIR}/10-validator/map-components.js`                     | Crawls routes, detects framework, discovers components, computes build order                                                                                                       |
+| `normalize-component-map.js`  | `${CLAUDE_SKILL_DIR}/1-discovery-components/normalize-component-map.js`  | Aligns scanner names with Figma conventions using icons.json + Lucide alias table                                                                                                  |
+| `discover-code-components.js` | `${CLAUDE_SKILL_DIR}/1-discovery-components/discover-code-components.js` | Auto-discovers frontend packages and scans source for all components. `--discover` mode finds directories; `--scan` mode parses imports, merges with browser map, recomputes tiers |
+
+Do NOT modify `map-components.js`.
+
+## Skip / Resume
+
+If called with `resume: true`, check whether `.temp/figma-from-code/component-map.json` exists on disk. If it does, skip the discovery run and read the existing file. If it's missing, re-run.
+
+## Error Handling
+
+| Scenario                               | Action                                                                    |
+| -------------------------------------- | ------------------------------------------------------------------------- |
+| Dev server not running                 | Halt, tell user to start the dev server                                   |
+| `map-components.js` fails              | Check Playwright installation, verify URL is accessible                   |
+| Figma `use_figma` read-only call fails | Report error but do not block — component discovery output is still valid |
+| Empty `component-map.json`             | Check that dev server is serving the app (not an error page)              |

--- a/plugins/figma-from-code/skills/figma-from-code/1-discovery-components/discover-code-components.js
+++ b/plugins/figma-from-code/skills/figma-from-code/1-discovery-components/discover-code-components.js
@@ -1,0 +1,599 @@
+#!/usr/bin/env node
+/**
+ * Discover React/Vue/Angular/Svelte components from source code.
+ *
+ * Two modes:
+ *   --discover [--root <dir>]
+ *       Auto-detect frontend packages and component directories.
+ *       Outputs JSON to stdout for the LLM to present to the user.
+ *
+ *   --scan <dir1> [dir2...] [--browser-map <path>] [--output <path>] [--exclude <name1,name2>]
+ *       Scan given directories for components, merge with browser-discovered
+ *       component-map, recompute dependency tiers, write output.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const args = process.argv.slice(2);
+
+function flag(name) {
+  const i = args.indexOf(name);
+  return i !== -1;
+}
+
+function flagValue(name) {
+  const i = args.indexOf(name);
+  if (i !== -1 && i + 1 < args.length) return args[i + 1];
+  return null;
+}
+
+function flagValues(name) {
+  const i = args.indexOf(name);
+  if (i === -1) return [];
+  const vals = [];
+  for (let j = i + 1; j < args.length; j++) {
+    if (args[j].startsWith('--')) break;
+    vals.push(args[j]);
+  }
+  return vals;
+}
+
+const FRONTEND_DEPS = new Set([
+  'react', 'react-dom', 'vue', '@vue/runtime-core', 'angular', '@angular/core',
+  'svelte', 'next', 'nuxt', 'solid-js', 'preact', 'lit', 'astro',
+]);
+
+const COMPONENT_EXTENSIONS = new Set(['.tsx', '.jsx', '.vue', '.svelte']);
+
+const EXCLUDED_PATTERNS = [
+  /\.test\./,
+  /\.stories\./,
+  /\.spec\./,
+  /^index\./,
+  /^types\./,
+  /^use[A-Z]/,
+];
+
+const SKIP_DIRS = new Set(['node_modules', '.temp', 'dist', 'build', '.next', '.nuxt', '.git', '.claude']);
+
+function isPascalCase(name) {
+  return /^[A-Z][A-Za-z0-9]+$/.test(name);
+}
+
+function isComponentFile(filePath) {
+  const ext = path.extname(filePath);
+  if (!COMPONENT_EXTENSIONS.has(ext)) return false;
+  const base = path.basename(filePath);
+  const nameWithoutExt = base.replace(ext, '');
+  if (!isPascalCase(nameWithoutExt)) return false;
+  if (EXCLUDED_PATTERNS.some((p) => p.test(base))) return false;
+  return true;
+}
+
+function walkDir(dir, excludeBasenames = new Set()) {
+  const results = [];
+  if (!fs.existsSync(dir)) return results;
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (SKIP_DIRS.has(entry.name)) continue;
+    if (excludeBasenames.has(entry.name)) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...walkDir(full, excludeBasenames));
+    } else if (entry.isFile() && isComponentFile(full)) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+function findPackageJsons(root) {
+  const results = [];
+  function walk(dir, depth) {
+    if (depth > 5) return;
+    if (!fs.existsSync(dir)) return;
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      const full = path.join(dir, entry.name);
+      if (entry.isFile() && entry.name === 'package.json') {
+        results.push(full);
+      } else if (entry.isDirectory()) {
+        walk(full, depth + 1);
+      }
+    }
+  }
+  walk(root, 0);
+  return results;
+}
+
+function isFrontendPackage(pkgJsonPath) {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
+    const allDeps = { ...pkg.dependencies, ...pkg.devDependencies };
+    for (const dep of Object.keys(allDeps)) {
+      if (FRONTEND_DEPS.has(dep)) return { name: pkg.name || path.basename(path.dirname(pkgJsonPath)), framework: dep };
+    }
+  } catch {}
+  return null;
+}
+
+function resolveSourceRoot(pkgDir) {
+  const candidates = ['src', 'app', 'lib', 'source'];
+  for (const c of candidates) {
+    const full = path.join(pkgDir, c);
+    if (fs.existsSync(full) && fs.statSync(full).isDirectory()) return full;
+  }
+  return pkgDir;
+}
+
+function findComponentDirs(sourceRoot) {
+  const componentFiles = walkDir(sourceRoot);
+  const dirCounts = {};
+  for (const f of componentFiles) {
+    const dir = path.dirname(f);
+    const rel = path.relative(sourceRoot, dir);
+    const topDir = rel.split(path.sep)[0] || '.';
+    if (!dirCounts[topDir]) dirCounts[topDir] = { path: path.join(sourceRoot, topDir), count: 0, subdirs: new Set() };
+    dirCounts[topDir].count++;
+    const parts = rel.split(path.sep);
+    if (parts.length > 1) dirCounts[topDir].subdirs.add(parts[1]);
+  }
+  return Object.values(dirCounts)
+    .filter((d) => d.count >= 3)
+    .map((d) => ({ path: d.path, componentCount: d.count, subdirs: [...d.subdirs].sort() }));
+}
+
+function resolveAliasBase(scanDirs) {
+  for (const dir of scanDirs) {
+    let search = dir;
+    for (let i = 0; i < 5; i++) {
+      const tsconfig = path.join(search, 'tsconfig.json');
+      if (fs.existsSync(tsconfig)) {
+        try {
+          const raw = fs.readFileSync(tsconfig, 'utf-8').replace(/\/\/.*/g, '').replace(/,\s*}/g, '}').replace(/,\s*]/g, ']');
+          const cfg = JSON.parse(raw);
+          const paths = cfg.compilerOptions?.paths;
+          if (paths) {
+            for (const [alias, targets] of Object.entries(paths)) {
+              if (alias.endsWith('/*') && targets.length > 0) {
+                const prefix = alias.slice(0, -2);
+                const target = targets[0].replace('/*', '');
+                const baseDir = path.resolve(search, cfg.compilerOptions?.baseUrl || '.', target);
+                return { prefix, baseDir, tsconfigDir: search };
+              }
+            }
+          }
+        } catch {}
+      }
+      const parent = path.dirname(search);
+      if (parent === search) break;
+      search = parent;
+    }
+  }
+  return null;
+}
+
+// ── Import parsing (adapted from check-prereqs.js) ──
+
+const NAMED_IMPORT_RE = /import\s+(?:type\s+)?\{([^}]+)\}\s+from\s+['"]([^'"]+)['"]/g;
+const DEFAULT_IMPORT_RE = /import\s+([A-Z][A-Za-z0-9_]+)\s+(?:,\s*\{[^}]*\}\s+)?from\s+['"]([^'"]+)['"]/g;
+
+function parseImports(source, filePath, aliasConfig, componentNameToPath) {
+  const deps = new Set();
+  const fileDir = path.dirname(filePath);
+
+  function resolveImportOrigin(origin) {
+    if (origin.startsWith('.')) {
+      return path.resolve(fileDir, origin);
+    }
+    if (aliasConfig && origin.startsWith(aliasConfig.prefix + '/')) {
+      const rest = origin.slice(aliasConfig.prefix.length + 1);
+      return path.resolve(aliasConfig.baseDir, rest);
+    }
+    return null;
+  }
+
+  function tryMatchComponent(names, origin) {
+    const resolved = resolveImportOrigin(origin);
+    if (!resolved) return;
+
+    for (const name of names) {
+      if (!isPascalCase(name)) continue;
+      if (componentNameToPath.has(name)) {
+        deps.add(name);
+      }
+    }
+  }
+
+  let m;
+  const src = source.toString();
+
+  const namedRe = new RegExp(NAMED_IMPORT_RE.source, 'g');
+  while ((m = namedRe.exec(src))) {
+    const origin = m[2];
+    const names = m[1]
+      .split(',')
+      .map((s) => s.trim().replace(/^type\s+/, '').split(/\s+as\s+/)[0])
+      .filter(Boolean);
+    tryMatchComponent(names, origin);
+  }
+
+  const defaultRe = new RegExp(DEFAULT_IMPORT_RE.source, 'g');
+  while ((m = defaultRe.exec(src))) {
+    const origin = m[2];
+    const name = m[1];
+    tryMatchComponent([name], origin);
+  }
+
+  return [...deps];
+}
+
+// ── Runtime tree relations ──
+
+// Walk the browser-discovered render tree and return a map of
+// parentName -> Set(direct child names). The tree encodes runtime containment
+// (App renders Header, pages render lists, etc.) that static import parsing
+// misses for router-rendered children.
+function extractTreeRelations(tree) {
+  const childrenOf = new Map();
+  function visit(node, parentName) {
+    if (Array.isArray(node)) {
+      for (const n of node) visit(n, parentName);
+      return;
+    }
+    if (!node || typeof node !== 'object') return;
+    const name = node.name;
+    if (name && parentName) {
+      if (!childrenOf.has(parentName)) childrenOf.set(parentName, new Set());
+      childrenOf.get(parentName).add(name);
+    }
+    for (const k of node.children || []) visit(k, name || parentName);
+  }
+  visit(tree, null);
+  return childrenOf;
+}
+
+// Extract a reliable DOM selector from a component's source. Only returns
+// anchors that are stable and unique enough to screenshot against —
+// data-testid first, then an explicit role. Returns null when no reliable
+// anchor exists (callers leave the selector unset rather than fabricate one).
+function extractSelectorHint(sourcePath) {
+  try {
+    const src = fs.readFileSync(sourcePath, 'utf-8');
+    const testId = src.match(/data-testid=["']([^"']+)["']/);
+    if (testId) return `[data-testid="${testId[1]}"]`;
+    const role = src.match(/\brole=["']([^"']+)["']/);
+    if (role) return `[role="${role[1]}"]`;
+  } catch {}
+  return null;
+}
+
+// ── Topological sort for tier computation ──
+
+function computeTiers(components) {
+  const nameSet = new Set(components.map((c) => c.name));
+  const adjList = new Map();
+  for (const c of components) {
+    const filteredDeps = (c.codeDependencies || []).filter((d) => nameSet.has(d));
+    adjList.set(c.name, new Set(filteredDeps));
+  }
+
+  const tiers = [];
+  const assigned = new Set();
+
+  while (assigned.size < nameSet.size) {
+    const tier = [];
+    for (const name of nameSet) {
+      if (assigned.has(name)) continue;
+      const deps = adjList.get(name) || new Set();
+      const unresolved = [...deps].filter((d) => !assigned.has(d));
+      if (unresolved.length === 0) tier.push(name);
+    }
+
+    if (tier.length === 0) {
+      const remaining = [...nameSet].filter((n) => !assigned.has(n));
+      console.error(`Warning: circular dependency detected among: ${remaining.join(', ')}. Placing all in current tier.`);
+      tier.push(...remaining);
+    }
+
+    tier.sort();
+    tiers.push(tier);
+    for (const name of tier) assigned.add(name);
+  }
+
+  return tiers;
+}
+
+// ── Mode: --discover ──
+
+function runDiscover() {
+  const root = path.resolve(flagValue('--root') || '.');
+  const pkgJsons = findPackageJsons(root);
+  const frontendPackages = [];
+
+  for (const pkgPath of pkgJsons) {
+    const result = isFrontendPackage(pkgPath);
+    if (result) {
+      const pkgDir = path.dirname(pkgPath);
+      const sourceRoot = resolveSourceRoot(pkgDir);
+      frontendPackages.push({
+        name: result.name,
+        framework: result.framework,
+        path: path.relative(root, pkgDir) || '.',
+        sourceRoot: path.relative(root, sourceRoot) || '.',
+      });
+    }
+  }
+
+  const allComponentDirs = [];
+  for (const pkg of frontendPackages) {
+    const absSourceRoot = path.resolve(root, pkg.sourceRoot);
+    const dirs = findComponentDirs(absSourceRoot);
+    for (const d of dirs) {
+      allComponentDirs.push({
+        path: path.relative(root, d.path),
+        componentCount: d.componentCount,
+        subdirs: d.subdirs,
+      });
+    }
+  }
+
+  const framework = frontendPackages.length > 0 ? frontendPackages[0].framework : 'unknown';
+
+  const output = {
+    framework,
+    frontendPackages,
+    componentDirectories: allComponentDirs,
+  };
+
+  console.log(JSON.stringify(output, null, 2));
+}
+
+// ── Mode: --scan ──
+
+function runScan() {
+  const scanDirs = flagValues('--scan');
+  const browserMapPath = flagValue('--browser-map');
+  const outputPath = flagValue('--output');
+  const excludeRaw = flagValue('--exclude');
+  const excludeSet = new Set(excludeRaw ? excludeRaw.split(',').map((s) => s.trim()) : []);
+
+  if (scanDirs.length === 0) {
+    console.error('Error: --scan requires at least one directory');
+    process.exit(2);
+  }
+
+  // 1. Find all component files
+  const allFiles = [];
+  for (const dir of scanDirs) {
+    const absDir = path.resolve(dir);
+    allFiles.push(...walkDir(absDir, excludeSet));
+  }
+
+  // 2. Build name→path map
+  const componentNameToPath = new Map();
+  const componentsByName = new Map();
+
+  for (const filePath of allFiles) {
+    const ext = path.extname(filePath);
+    const name = path.basename(filePath, ext);
+    if (componentNameToPath.has(name)) {
+      const existing = componentNameToPath.get(name);
+      console.error(`Warning: duplicate component name "${name}": ${existing} and ${filePath}. Keeping first.`);
+      continue;
+    }
+    componentNameToPath.set(name, filePath);
+    componentsByName.set(name, {
+      name,
+      source: 'code',
+      sourcePath: filePath,
+      codeDependencies: [],
+    });
+  }
+
+  // 3. Resolve alias config from tsconfig.json
+  const aliasConfig = resolveAliasBase(scanDirs.map((d) => path.resolve(d)));
+
+  // 4. Parse imports for each component
+  for (const [name, comp] of componentsByName) {
+    const source = fs.readFileSync(comp.sourcePath, 'utf-8');
+    const selfName = name;
+    const deps = parseImports(source, comp.sourcePath, aliasConfig, componentNameToPath);
+    comp.codeDependencies = deps.filter((d) => d !== selfName).sort();
+  }
+
+  // 5. Read browser-map if provided
+  let browserMap = null;
+  if (browserMapPath && fs.existsSync(browserMapPath)) {
+    try {
+      browserMap = JSON.parse(fs.readFileSync(browserMapPath, 'utf-8'));
+    } catch (err) {
+      console.error(`Warning: could not parse browser map at ${browserMapPath}: ${err.message}`);
+    }
+  }
+
+  // 6. Merge browser data
+  const browserComponents = new Map();
+  if (browserMap && browserMap.tiers) {
+    for (const tier of browserMap.tiers) {
+      for (const comp of tier.components) {
+        const entry = typeof comp === 'string' ? { name: comp } : comp;
+        browserComponents.set(entry.name, entry);
+      }
+    }
+  }
+
+  // Merge: for each browser component, check if code found it too
+  for (const [bName, bComp] of browserComponents) {
+    if (componentsByName.has(bName)) {
+      const codeComp = componentsByName.get(bName);
+      codeComp.source = 'both';
+      codeComp.routes = bComp.routes || [];
+      codeComp.selector = bComp.selector || null;
+      codeComp.instances = bComp.instances || 0;
+      codeComp.figmaNodeId = bComp.figmaNodeId || null;
+    } else {
+      componentsByName.set(bName, {
+        name: bName,
+        source: 'browser',
+        sourcePath: null,
+        codeDependencies: [],
+        routes: bComp.routes || [],
+        selector: bComp.selector || null,
+        instances: bComp.instances || 0,
+        figmaNodeId: bComp.figmaNodeId || null,
+      });
+    }
+  }
+
+  // 6b. Augment dependencies with runtime tree containment so composites
+  // discovered only via the browser (App, route pages) — whose codeDependencies
+  // are empty because their children render through the router — are tiered
+  // AFTER their children instead of being treated as leaves.
+  const treeChildren = extractTreeRelations(browserMap && browserMap.tree ? browserMap.tree : []);
+  for (const [name, kids] of treeChildren) {
+    const comp = componentsByName.get(name);
+    if (!comp) continue;
+    const deps = new Set(comp.codeDependencies || []);
+    for (const k of kids) {
+      if (k !== name && componentsByName.has(k)) deps.add(k);
+    }
+    comp.codeDependencies = [...deps].sort();
+  }
+
+  // 6c. Propagate routes down the render tree: a component rendered inside a
+  // routed ancestor shares that route, so pre-capture knows where to find it.
+  // Then, for in-tree components that still lack a selector, derive one from a
+  // reliable semantic anchor in source (role / data-testid). This widens
+  // pre-capture coverage without fabricating brittle class-name selectors.
+  function propagateRoutes(node, inheritedRoutes) {
+    if (Array.isArray(node)) {
+      for (const n of node) propagateRoutes(n, inheritedRoutes);
+      return;
+    }
+    if (!node || typeof node !== 'object') return;
+    let routes = inheritedRoutes;
+    const comp = componentsByName.get(node.name);
+    if (comp) {
+      if (comp.routes && comp.routes.length) {
+        routes = comp.routes;
+      } else if (routes && routes.length) {
+        comp.routes = [routes[0]];
+      }
+      if (!comp.selector && comp.sourcePath) {
+        const hint = extractSelectorHint(comp.sourcePath);
+        if (hint) comp.selector = hint;
+      }
+    }
+    for (const k of node.children || []) propagateRoutes(k, routes);
+  }
+  propagateRoutes(browserMap && browserMap.tree ? browserMap.tree : [], []);
+
+  // Also try to match browser components via source-map if present
+  if (browserMap && browserMap.sourceMap) {
+    for (const [bName, srcPath] of Object.entries(browserMap.sourceMap)) {
+      if (componentsByName.has(bName) && srcPath && srcPath !== 'None') {
+        const comp = componentsByName.get(bName);
+        if (!comp.sourcePath) comp.sourcePath = srcPath;
+      }
+    }
+  }
+
+  // Ensure code-only components have default browser fields
+  for (const comp of componentsByName.values()) {
+    if (!comp.routes) comp.routes = [];
+    if (!comp.selector) comp.selector = null;
+    if (comp.instances === undefined) comp.instances = 0;
+    if (!comp.figmaNodeId) comp.figmaNodeId = null;
+  }
+
+  // Make sourcePaths relative
+  const cwd = process.cwd();
+  for (const comp of componentsByName.values()) {
+    if (comp.sourcePath && path.isAbsolute(comp.sourcePath)) {
+      comp.sourcePath = path.relative(cwd, comp.sourcePath);
+    }
+  }
+
+  // 6d. Tier the app root (router shell) AFTER all routed pages. The runtime tree
+  // captured in step 6b reflects only the route active during the crawl, so it
+  // misses the root's edges to the other page components — leaving the root a
+  // false leaf in Tier 1, where it is rejected for missing children every run
+  // (the long-standing "App mis-tiered into Tier 1" bug). Force every routed page
+  // component (routes set by the browser map, or name ending in Page/Screen/Layout)
+  // to be a dependency of the root so the topological sort places it last.
+  const rootName = componentsByName.has('App')
+    ? 'App'
+    : (() => {
+        const treeRoot = browserMap && browserMap.tree
+          ? (Array.isArray(browserMap.tree) ? browserMap.tree[0] : browserMap.tree)
+          : null;
+        return treeRoot && treeRoot.name && componentsByName.has(treeRoot.name)
+          ? treeRoot.name
+          : null;
+      })();
+  if (rootName) {
+    const root = componentsByName.get(rootName);
+    const pageNames = [...componentsByName.keys()].filter((n) => {
+      if (n === rootName) return false;
+      const c = componentsByName.get(n);
+      return (c.routes || []).length > 0 || /(?:Page|Screen|Layout)$/.test(n);
+    });
+    const deps = new Set(root.codeDependencies || []);
+    for (const p of pageNames) {
+      // Never add a back-edge: if the page already depends on the root, skip it
+      // so computeTiers does not see a cycle.
+      const pageDeps = componentsByName.get(p).codeDependencies || [];
+      if (!pageDeps.includes(rootName)) deps.add(p);
+    }
+    root.codeDependencies = [...deps].sort();
+  }
+
+  // 7. Compute tiers from code dependencies
+  const allComponents = [...componentsByName.values()];
+  const tierNames = computeTiers(allComponents);
+
+  // 8. Build output
+  const tiers = tierNames.map((names, i) => ({
+    tier: i + 1,
+    label: i === 0 ? 'Leaf components (no dependencies)' : `Depends on tier ${i} and below`,
+    components: names.map((n) => componentsByName.get(n)),
+  }));
+
+  const sourceBreakdown = { browser: 0, code: 0, both: 0 };
+  for (const comp of allComponents) {
+    sourceBreakdown[comp.source] = (sourceBreakdown[comp.source] || 0) + 1;
+  }
+
+  const output = {
+    ...(browserMap || {}),
+    scannedAt: new Date().toISOString(),
+    componentCount: allComponents.length,
+    sourceBreakdown,
+    tiers,
+    tree: browserMap?.tree || [],
+  };
+
+  if (outputPath) {
+    const outDir = path.dirname(outputPath);
+    fs.mkdirSync(outDir, { recursive: true });
+    fs.writeFileSync(outputPath, JSON.stringify(output, null, 2));
+    console.log(`Wrote ${allComponents.length} components (${sourceBreakdown.both} both, ${sourceBreakdown.code} code-only, ${sourceBreakdown.browser} browser-only) to ${outputPath}`);
+  } else {
+    console.log(JSON.stringify(output, null, 2));
+  }
+}
+
+// ── Main ──
+
+if (flag('--discover')) {
+  runDiscover();
+} else if (flag('--scan')) {
+  runScan();
+} else {
+  console.error(`Usage:
+  discover-code-components.js --discover [--root <dir>]
+  discover-code-components.js --scan <dir1> [dir2...] [--browser-map <path>] [--output <path>] [--exclude <name1,name2>]`);
+  process.exit(2);
+}

--- a/plugins/figma-from-code/skills/figma-from-code/1-discovery-components/normalize-component-map.js
+++ b/plugins/figma-from-code/skills/figma-from-code/1-discovery-components/normalize-component-map.js
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+
+/**
+ * Normalizes component-map.json names to match Figma naming conventions.
+ *
+ * Resolves two classes of mismatch between the DOM scanner and Figma:
+ *   1. Lucide icons: scanner reads React fiber displayName (canonical),
+ *      but Figma uses the codebase import name (may be a legacy alias).
+ *   2. SVG asset wrappers: scanner sees the wrapper component name,
+ *      but Figma uses Asset/{assetName}.
+ *
+ * Usage:
+ *   node normalize-component-map.js <component-map.json> <icons.json> [--write]
+ *
+ * Without --write, prints a dry-run report. With --write, updates in place.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const componentMapPath = process.argv[2];
+const iconsJsonPath = process.argv[3];
+const writeMode = process.argv.includes("--write");
+
+if (!componentMapPath || !iconsJsonPath) {
+  console.error(
+    "Usage: node normalize-component-map.js <component-map.json> <icons.json> [--write]"
+  );
+  process.exit(1);
+}
+
+const componentMap = JSON.parse(fs.readFileSync(componentMapPath, "utf-8"));
+const iconsData = JSON.parse(fs.readFileSync(iconsJsonPath, "utf-8"));
+
+const iconImportNames = new Set(iconsData.icons.map((i) => i.name));
+const assetImportNames = new Set(iconsData.assets.map((a) => a.name));
+
+function buildLucideAliasMap() {
+  const aliasToCanonical = {};
+  const canonicalToAlias = {};
+
+  try {
+    const lucidePath = path.join(
+      process.cwd(),
+      "node_modules/lucide-react/dist/esm/lucide-react.js"
+    );
+    const content = fs.readFileSync(lucidePath, "utf-8");
+
+    for (const line of content.split("\n")) {
+      if (!line.startsWith("export")) continue;
+      const match = line.match(/export \{ (.+) \} from/);
+      if (!match) continue;
+
+      const names = match[1]
+        .split(",")
+        .map((s) => s.trim().replace("default as ", ""))
+        .filter((n) => !n.includes("Icon") && !n.includes("Lucide"));
+
+      if (names.length >= 2) {
+        const canonical = names[0];
+        for (let i = 1; i < names.length; i++) {
+          aliasToCanonical[names[i]] = canonical;
+          if (!canonicalToAlias[canonical]) canonicalToAlias[canonical] = [];
+          canonicalToAlias[canonical].push(names[i]);
+        }
+      }
+    }
+  } catch {
+    console.warn("Warning: could not read lucide-react exports, skipping alias resolution");
+  }
+
+  return { aliasToCanonical, canonicalToAlias };
+}
+
+const { aliasToCanonical, canonicalToAlias } = buildLucideAliasMap();
+
+function resolveIconName(scannerName) {
+  if (iconImportNames.has(scannerName)) return scannerName;
+
+  const aliases = canonicalToAlias[scannerName] || [];
+  for (const alias of aliases) {
+    if (iconImportNames.has(alias)) return alias;
+  }
+
+  return null;
+}
+
+function resolveAssetName(scannerName) {
+  if (assetImportNames.has(scannerName)) return scannerName;
+
+  for (const assetName of assetImportNames) {
+    if (assetName.startsWith(scannerName)) return assetName;
+  }
+
+  return null;
+}
+
+const renames = [];
+
+function normalizeComponent(comp) {
+  const original = comp.name;
+  const isLeaf = !comp.children || comp.children.length === 0;
+
+  if (!isLeaf) return;
+
+  const iconMatch = resolveIconName(original);
+  if (iconMatch) {
+    comp.name = `Icon/${iconMatch}`;
+    renames.push({ from: original, to: comp.name, reason: "icon" });
+    return;
+  }
+
+  const assetMatch = resolveAssetName(original);
+  if (assetMatch) {
+    comp.name = `Asset/${assetMatch}`;
+    renames.push({ from: original, to: comp.name, reason: "asset" });
+    return;
+  }
+}
+
+for (const tier of componentMap.tiers) {
+  for (const comp of tier.components) {
+    normalizeComponent(comp);
+  }
+}
+
+function renameInTree(node) {
+  const rename = renames.find((r) => r.from === node.name);
+  if (rename) node.name = rename.to;
+  if (node.children) node.children.forEach(renameInTree);
+}
+
+if (componentMap.tree) {
+  componentMap.tree.forEach(renameInTree);
+}
+
+for (const tier of componentMap.tiers) {
+  for (const comp of tier.components) {
+    if (comp.children) {
+      comp.children = comp.children.map((childName) => {
+        const rename = renames.find((r) => r.from === childName);
+        return rename ? rename.to : childName;
+      });
+    }
+  }
+}
+
+if (renames.length === 0) {
+  console.log("No renames needed — all names already match Figma conventions.");
+} else {
+  console.log(`Normalized ${renames.length} component name(s):\n`);
+  for (const r of renames) {
+    console.log(`  ${r.from} → ${r.to} (${r.reason})`);
+  }
+}
+
+if (writeMode) {
+  fs.writeFileSync(componentMapPath, JSON.stringify(componentMap, null, 2) + "\n");
+  console.log(`\nWrote updated ${componentMapPath}`);
+} else {
+  console.log("\nDry run — pass --write to update the file.");
+}

--- a/plugins/figma-from-code/skills/figma-from-code/10-validator/SKILL.md
+++ b/plugins/figma-from-code/skills/figma-from-code/10-validator/SKILL.md
@@ -1,0 +1,570 @@
+# Skill: Figma Rebuild Validator
+
+Validates the output of `figma-from-code` by navigating the live app, screenshotting each component in its natural context, and comparing against the **matching Figma variant** — not the entire component set. Produces a structured report with side-by-side screenshots.
+
+This skill can be used two ways:
+
+- **Standalone:** Run directly to validate a completed rebuild (all phases below)
+- **As a reference for Phase 5:** The orchestrator's Phase 5 agent reads this skill for the Component App Map, variant resolution logic, and structural QA scripts
+
+## When to Use
+
+- After running `figma-from-code` to verify the output (standalone)
+- When auditing whether Figma components match their React implementations
+- When the orchestrator's Phase 5 agent needs the Component App Map or comparison scripts
+
+## Prerequisites
+
+- Figma MCP must be connected and authenticated
+- Dev server must be running (e.g., `localhost:5173` — use the URL from `state.json` or the `devServerUrl` parameter)
+- `.temp/figma-from-code/state.json` must exist (produced by `figma-from-code`)
+- `compare.js` (bundled at `${CLAUDE_SKILL_DIR}/10-validator/compare.js`) provides the pixel diff
+
+## Workflow
+
+```
+Phase 1: Inventory        → list all Figma components + classify app visibility
+Phase 1e: Variant Resolve → for each component set, find the specific variant used in the app
+Phase 2: Screenshots      → process each tier sequentially to capture app + Figma screenshots and run pixel diffs
+Phase 3: Structural       → check variables, pages, screen sizes
+Phase 4: Report           → merge tier results, write .temp/figma-validation/report.md
+```
+
+---
+
+## Phase 1: Build Component Inventory
+
+### Step 1a — Read state file
+
+```bash
+cat .temp/figma-from-code/state.json
+```
+
+Extract `fileKey`.
+
+### Step 1b — Query Figma for all components
+
+```javascript
+// use_figma
+await figma.setCurrentPageAsync(figma.root.children.find((p) => p.name === '📦 Components'));
+const sets = figma.currentPage.findAll((n) => n.type === 'COMPONENT_SET');
+const singles = figma.currentPage.children.filter((n) => n.type === 'COMPONENT');
+const all = [
+  ...sets.map((s) => ({ name: s.name, id: s.id, type: 'set' })),
+  ...singles.map((s) => ({ name: s.name, id: s.id, type: 'single' })),
+];
+return JSON.stringify(all);
+```
+
+### Step 1c — Classify each component
+
+Use the **Component App Map** below to assign each component a `url`, `selector`, optional `click` action, and `figmaVariant` (the variant properties that match what's rendered in the app).
+
+### Step 1d — Check dev server
+
+```bash
+curl -s --max-time 3 {devServerUrl} > /dev/null && echo "running" || echo "not_running"
+```
+
+If `not_running`: halt and tell the user to run `the dev server`.
+
+Print the classification to the conversation:
+
+```
+📱 App visible (44): Button, Input, ...
+⚠️  Requires interaction (4): Dialog, Sheet, ...
+🚫  Not visible in app (1): Skeleton (loading state only)
+```
+
+---
+
+## Phase 1e: Variant Node Resolution
+
+**This is the key step that ensures Figma screenshots match the app variant.**
+
+For every component whose `type === 'set'` and that has a `figmaVariant` specified in the Component App Map, resolve the specific child variant node ID before taking screenshots.
+
+### What this solves
+
+Without this step, `get_screenshot(fileKey, setNodeId)` returns an image of **all variants tiled** in the component set — not the single variant that the app is rendering. Resolving to the child node gives an apples-to-apples comparison.
+
+### Resolution script (run once per component set)
+
+```javascript
+// use_figma
+const setNodeId = '{nodeId from Phase 1b}';
+const targetProps = { Variant: 'primary', State: 'Default' }; // from Component App Map figmaVariant column
+
+const componentSet = figma.getNodeById(setNodeId);
+if (!componentSet || componentSet.type !== 'COMPONENT_SET') {
+  return JSON.stringify({
+    resolvedId: setNodeId,
+    resolvedName: componentSet?.name ?? 'unknown',
+    fallback: true,
+  });
+}
+
+// Log available variant property names and their values to aid debugging
+const available = componentSet.children.map((c) => ({
+  id: c.id,
+  name: c.name,
+  props: c.variantProperties,
+}));
+
+// Try exact match first (case-insensitive values)
+let match = componentSet.children.find((child) =>
+  Object.entries(targetProps).every(
+    ([k, v]) => child.variantProperties?.[k]?.toLowerCase() === v.toLowerCase()
+  )
+);
+
+// Partial match fallback: match only props that exist on the set's property keys
+if (!match) {
+  const availableKeys = Object.keys(componentSet.children[0]?.variantProperties ?? {});
+  const filteredTarget = Object.fromEntries(
+    Object.entries(targetProps).filter(([k]) => availableKeys.includes(k))
+  );
+  match = componentSet.children.find((child) =>
+    Object.entries(filteredTarget).every(
+      ([k, v]) => child.variantProperties?.[k]?.toLowerCase() === v.toLowerCase()
+    )
+  );
+}
+
+// Last resort: first child
+match = match ?? componentSet.children[0];
+return JSON.stringify({
+  resolvedId: match.id,
+  resolvedName: match.name,
+  props: match.variantProperties,
+  available,
+});
+```
+
+**Store the resolved `variantNodeId` for each component.** Use this in Phase 2 when calling `get_screenshot`.
+
+### Handling multiple app variants for one component
+
+Some components appear in multiple variants in the app (e.g., Button appears as `primary` on form submit and `ghost` in menus). For these, create **two entries** in the comparison table:
+
+| Entry                | App Variant                                              | Figma Variant Props                     |
+| -------------------- | -------------------------------------------------------- | --------------------------------------- |
+| Button (submit)      | `button[type="submit"]` on the create form page          | `{Variant: "primary", Size: "regular"}` |
+| Button (menu action) | `[data-radix-dropdown-menu-content] button` on list page | `{Variant: "ghost", Size: "small"}`     |
+
+---
+
+## Component App Map
+
+The Component App Map assigns each Figma component a URL, Playwright CSS selector, optional click/hover action, and Figma variant properties for comparison targeting.
+
+**This map is built dynamically during Phase 1c** from the `component-map.json` output (Phase 0a). It is NOT hardcoded.
+
+The screenshot script is: `${CLAUDE_SKILL_DIR}/10-validator/screenshot.js`
+
+Usage:
+
+```bash
+# Element screenshot (preferred)
+node screenshot.js <url> <output> --selector "css" [--click "click-css"] [--hover "hover-css"] [--variant "label"] [width] [height]
+
+# Full-page fallback
+node screenshot.js <url> <output> [width] [height]
+```
+
+Flags:
+
+- `--selector` — CSS selector for the element to screenshot
+- `--click` — click this element before screenshotting (opens overlays, enters edit mode)
+- `--hover` — hover over this element before screenshotting (reveals tooltips, hover cards)
+- `--variant` — label printed in output for logging (no effect on screenshot)
+- `--nth N` — use the Nth matching element (0-indexed)
+
+### Building the Map
+
+For each component discovered in `component-map.json`:
+
+1. **URL**: Use the route(s) where the component appears (from `component-map.json -> routes`)
+2. **Selector**: Use the best CSS selector (from `component-map.json -> selector`). Prefer `[data-component="Name"]`, `[aria-label="..."]`, or class-based selectors
+3. **Click action**: If the component requires interaction to become visible (overlays, dropdowns, edit modes), specify a click selector
+4. **Hover action**: If the component requires hover to reveal (tooltips, hover cards), specify a hover selector
+5. **Figma variant**: The variant properties that match the app's default rendering (e.g., `{Variant: "primary", State: "Default"}`)
+
+### Selector Strategy by Component Type
+
+| Component Type                        | Selector Strategy                 | Example                                                     |
+| ------------------------------------- | --------------------------------- | ----------------------------------------------------------- |
+| Always visible (nav, header, sidebar) | `aria-label` or semantic HTML     | `header[aria-label="Main navigation"]`                      |
+| List panels                           | Class-based width selectors       | `[class*="w-[200px]"]`                                      |
+| Detail panels                         | Flex layout selectors             | `[class*="flex-1"][class*="flex-col"]`                      |
+| Form inputs                           | Input type + placeholder          | `input[placeholder="..."]`, `textarea`                      |
+| Buttons                               | Type or role selectors            | `button[type="submit"]`, `a[href="..."]`                    |
+| Inline editing                        | Click to enter edit mode          | `--click "h1"` then screenshot the input                    |
+| Overlays/dialogs                      | Click trigger, screenshot overlay | `--click "button[aria-label='...']"` then `[role="dialog"]` |
+| Embedded components                   | Parent context selectors          | `[class*="ComponentName"]`                                  |
+
+### Components Not Directly Visible in App
+
+Some components are not rendered by default and require special handling:
+
+| Type                                  | Reason                            | Capture Strategy                                     |
+| ------------------------------------- | --------------------------------- | ---------------------------------------------------- |
+| Loading states (e.g., Skeleton)       | Only visible during data fetch    | Capture during initial page load before data arrives |
+| Error states (e.g., Alert)            | Only visible on errors            | Simulate a network error                             |
+| Hover components (Tooltip, HoverCard) | Requires hover                    | Use `--hover "trigger-selector"`                     |
+| Click-to-reveal (Calendar, Popover)   | Requires interaction              | Use `--click "trigger-selector"`                     |
+| Embedded primitives (Badge, Checkbox) | Only inside parent components     | Screenshot parent, or open container first           |
+| Not used in UI                        | Component exists but not rendered | Skip — note as `not_visible` in report               |
+
+For hover-only components, use Playwright's `.hover()` API in a custom script rather than the `--click` flag.
+
+---
+
+## Phase 2: Screenshot Pairs (Sequential by Tier)
+
+Process all tiers sequentially inline. For each tier, handle every component: check for pre-built screenshots, capture app + Figma screenshots, run the pixel diff. Components within a tier share URLs, so reuse a single Playwright page load per URL where possible.
+
+### Per-Tier Process
+
+For each tier in `state.json -> buildOrder.tiers`, process all components using Steps 2a–2e below. After completing a tier, write results to `.temp/figma-validation/tier-{N}-results.json`:
+
+```json
+[{ "name": "...", "matchPct": 94.2, "borderMatchPct": 91.0, "verdict": "match", "issues": [] }, ...]
+```
+
+### Collecting Results
+
+After all tiers are processed, read each `tier-{N}-results.json` and merge into a single component list for Phase 3/4. Components with `verdict: "mismatch"` or `verdict: "minor_diff"` are candidates for Phase 5 fixes.
+
+---
+
+### Per-Component Steps
+
+Run these steps for every component in each tier.
+
+#### Step 2a — Check for pre-build app screenshot and text
+
+Before capturing a new screenshot, check if the orchestrator already captured one:
+
+```bash
+ls .temp/figma-from-code/screenshots/{ComponentName}/app.png 2>/dev/null && echo "exists" || echo "missing"
+```
+
+- If **exists**: copy it to `.temp/figma-validation/screenshots/{ComponentName}/app.png` — skip the Playwright capture for this component.
+- If **missing**: capture a fresh screenshot using Steps 2b/2c below.
+
+Also check for pre-extracted text:
+
+```bash
+ls .temp/figma-from-code/screenshots/{ComponentName}/text.json 2>/dev/null && echo "exists" || echo "missing"
+```
+
+- If **text.json exists**: the Figma component was already built with real text — skip Step 2b-text.
+- If **missing**: run `extract-text.js` (Step 2b-text) and use it to update the Figma component's text nodes before screenshotting (Step 2c-text).
+
+#### Step 2b — Capture app screenshot (if not pre-built)
+
+Run the screenshot script with `--selector`:
+
+```bash
+node ${CLAUDE_SKILL_DIR}/10-validator/screenshot.js \
+  "<dev-server-url>{url}" \
+  ".temp/figma-validation/screenshots/{ComponentName}/app.png" \
+  --selector "{selector}" \
+  1440 900
+```
+
+If the component requires a click first, use `--click`:
+
+```bash
+node ${CLAUDE_SKILL_DIR}/10-validator/screenshot.js \
+  "<dev-server-url>{url}" \
+  ".temp/figma-validation/screenshots/{ComponentName}/app.png" \
+  --selector "{screenshot-selector}" \
+  --click "{click-selector}" \
+  1440 900
+```
+
+#### Step 2b-text — Extract and inject real text (if text.json missing)
+
+If `text.json` was not produced during the rebuild, run the extractor now and update the Figma component's text nodes to match the app before screenshotting:
+
+**Extract:**
+
+```bash
+node ${CLAUDE_SKILL_DIR}/10-validator/extract-text.js \
+  "<dev-server-url>{url}" \
+  --selector "{selector}" \
+  [--click "{click-selector}"] \
+  [--nth N] \
+  > ".temp/figma-validation/screenshots/{ComponentName}/text.json"
+```
+
+**Inject into Figma** (run once per component, before step 2d):
+
+```javascript
+// use_figma — update Figma text nodes to match app text
+async function injectText(nodeId, textJson) {
+  const node = figma.getNodeById(nodeId);
+  const { lines, headings, inputs, buttons, labels } = textJson;
+
+  // Collect all visible text strings in app order
+  const appStrings = [...headings, ...labels, ...inputs, ...buttons, ...lines]
+    .filter((s, i, arr) => s && arr.indexOf(s) === i) // dedupe, preserve order
+    .slice(0, 20);
+
+  let strIdx = 0;
+  async function updateTextNodes(n) {
+    if (n.type === 'TEXT' && strIdx < appStrings.length) {
+      const s = appStrings[strIdx++];
+      if (s) {
+        const fn = n.fontName === figma.mixed ? { family: 'Inter', style: 'Regular' } : n.fontName;
+        await figma.loadFontAsync(fn);
+        n.characters = s;
+      }
+    }
+    if ('children' in n) {
+      for (const c of n.children) await updateTextNodes(c);
+    }
+  }
+  await updateTextNodes(node);
+}
+const textJson = JSON.parse('{contents of text.json}');
+await injectText('{variantNodeId}', textJson);
+return 'done';
+```
+
+Skip this step for components that have no app selector (not visible in app).
+
+#### Step 2c — Structural QA: inspect the Figma node before screenshotting
+
+Before taking the Figma screenshot, run a structural check on the resolved variant node. This catches defects that are invisible in a screenshot but cause visual discrepancies in the app.
+
+```javascript
+// use_figma
+function auditNode(node) {
+  const issues = [];
+  // INSIDE stroke alignment creates a double-border visual that doesn't match CSS
+  if ('strokeAlign' in node && node.strokeAlign === 'INSIDE' && node.strokes?.length > 0) {
+    issues.push({ type: 'inside_stroke', node: node.id, name: node.name });
+  }
+  // Multiple overlapping fills can cause unexpected color blending
+  if ('fills' in node && node.fills.filter((f) => f.visible !== false).length > 1) {
+    issues.push({ type: 'multiple_fills', node: node.id, count: node.fills.length });
+  }
+  if ('children' in node) node.children.forEach((c) => issues.push(...auditNode(c)));
+  return issues;
+}
+const node = figma.getNodeById('{variantNodeId}');
+const issues = auditNode(node);
+return JSON.stringify(issues);
+```
+
+If any issues are returned, fix them before screenshotting (e.g., change `strokeAlign` from `INSIDE` to `OUTSIDE`). Note the fix in the report.
+
+#### Step 2d — Capture Figma screenshot of the resolved variant
+
+**Always use the `variantNodeId` resolved in Phase 1e, NOT the component set node ID.**
+
+**Always request `scale: 1`** to produce a 1x export that matches the app screenshots (captured at `deviceScaleFactor: 1` by `screenshot.js`). Without explicit scale, Figma may return higher-resolution images that cause dimension mismatches during comparison.
+
+```
+get_screenshot(fileKey, variantNodeId, { scale: 1 })
+curl -sL "{image_url}" -o ".temp/figma-validation/screenshots/{ComponentName}/figma.png"
+```
+
+- For components marked `{}` (single) or `type === 'single'`, use the node ID as-is.
+- For components listed as "not visible in app", note them in the report without a screenshot pair.
+- When a component has multiple app variants (e.g., Button primary and Button ghost), create sub-folders: `Button-primary/` and `Button-ghost/`.
+
+**Why this matters:** Screenshotting the component set shows all variants stacked side-by-side in Figma. Screenshotting the resolved variant node shows only the single variant that matches what the app renders — making the visual comparison meaningful.
+
+#### Step 2e — Pixel diff comparison
+
+After both screenshots are saved, run the comparison script:
+
+```bash
+node ${CLAUDE_SKILL_DIR}/10-validator/compare.js \
+  ".temp/figma-validation/screenshots/{ComponentName}/app.png" \
+  ".temp/figma-validation/screenshots/{ComponentName}/figma.png" \
+  ".temp/figma-validation/screenshots/{ComponentName}/"
+```
+
+The script outputs:
+
+- `diff.png` — red pixels mark differences, dimmed original provides context
+- `comparison.json` — `{ matchPct, borderMatchPct, verdict, borderVerdict }`
+- Exit code: `0` = match, `1` = minor_diff (⚠️ flag for review), `2` = mismatch (❌ auto-defect)
+
+**Thresholds:**
+
+- Overall ≥ 90% → match; 75–90% → minor_diff; < 75% → mismatch
+- Border ring ≥ 85% → border_ok; < 85% → border_diff (flags as minor_diff even if overall passes)
+
+The border-region check catches subtle styling defects (extra strokes, wrong border color, box-shadow presence/absence) that are masked by text-content differences in the overall score. Always include the `diff.png` in the report table regardless of verdict — it lets you visually verify what the score detected.
+
+**Note on text-content diffs:** When Figma components were built with real app text (via `extract-text.js` in Phase 3), scores should be high (> 90%) for matching components. A score of 75–90% on a text-seeded component is meaningful — inspect the diff image for structural differences (layout, spacing, color). If components were built with placeholder text (older rebuild), scores of 60–85% are expected for text-heavy components and are not defects; in that case rely on the border score and diff image to find real issues.
+
+---
+
+## Phase 3: Structural Checks
+
+```javascript
+// use_figma
+const results = {};
+const colls = figma.variables.getLocalVariableCollections();
+results.collections = colls.map((c) => ({
+  name: c.name,
+  mode: c.modes[0].name,
+  count: c.variableIds.length,
+}));
+results.pages = figma.root.children.map((p) => p.name);
+await figma.setCurrentPageAsync(figma.root.children.find((p) => p.name === '📄 Screens'));
+results.screens = figma.currentPage.children.map((f) => ({
+  name: f.name,
+  w: Math.round(f.width),
+  h: Math.round(f.height),
+}));
+await figma.setCurrentPageAsync(figma.root.children.find((p) => p.name === '🎨 Foundations'));
+results.foundationFrames = figma.currentPage.children.map((f) => f.name);
+return JSON.stringify(results);
+```
+
+Validate variable counts against the actual counts from Phase 1 (stored in `state.json`). Verify the expected number of pages, foundation frames, and screens match the project's configuration.
+
+---
+
+## Phase 4: Write Report
+
+Output: `.temp/figma-validation/report.md`
+
+```markdown
+# Figma Rebuild Validation Report
+
+File: {fileKey} | Generated: {timestamp}
+
+## Summary
+
+|                        | Count         |
+| ---------------------- | ------------- |
+| Components in Figma    | {total}       |
+| Screenshotted from app | {captured}    |
+| Not visible in app     | {skipped}     |
+| Screenshot failures    | {failed}      |
+| Structural QA fixes    | {structFixes} |
+| Fixed after validation | {fixed}       |
+
+## Structural Checks
+
+...
+
+## Components Not Visible in App
+
+| Component | Reason |
+| --------- | ------ |
+
+...
+
+## Screenshot Comparisons
+
+### {ComponentName}
+
+Figma variant: `{variantProperties}` (node: `{variantNodeId}`)
+Pixel score: **{matchPct}%** overall | **{borderMatchPct}%** border — verdict: `{verdict}`
+
+| App (`{url}`)                               | Figma (`{variantNodeId}`)                       | Diff                                          |
+| ------------------------------------------- | ----------------------------------------------- | --------------------------------------------- |
+| ![app](screenshots/{ComponentName}/app.png) | ![figma](screenshots/{ComponentName}/figma.png) | ![diff](screenshots/{ComponentName}/diff.png) |
+```
+
+After writing the report, assess whether any components have visual defects or mismatches:
+
+- If **defects found**: proceed directly to Phase 5 (Fix Loop), starting at iteration 1.
+- If **no defects**: print a completion message and stop.
+
+---
+
+## Phase 5: Fix Loop
+
+Runs up to **3 iterations**. Each iteration attempts to fix all remaining defects, re-screenshots, and re-evaluates.
+
+### Per-iteration steps
+
+**Step 5a — Identify defects**
+
+Review the report for all components marked as mismatched or defective. On iteration 1 this is the initial report; on subsequent iterations, only components still marked ⚠️ Still Defective.
+
+**Step 5b — Fix each defective component in Figma**
+
+For each defective component:
+
+1. Identify the specific visual difference (color, spacing, layout, missing variant, wrong text, etc.)
+2. Fix it in Figma using `use_figma`
+3. Re-take the Figma screenshot: `get_screenshot(fileKey, variantNodeId, { scale: 1 })` — use the **same resolved variant node ID**, not the set
+4. Overwrite `.temp/figma-validation/screenshots/{ComponentName}/figma.png`
+5. Compare the new `figma.png` against the existing `app.png`
+6. Mark as **✅ Fixed** or **⚠️ Still Defective**
+
+Never re-attempt a component already marked ✅ Fixed in a prior iteration.
+
+**Step 5c — Update the report**
+
+Append an iteration section to `report.md`:
+
+```markdown
+## Fix Loop — Iteration {N}
+
+| Component | Status             | Notes                                   |
+| --------- | ------------------ | --------------------------------------- |
+| Button    | ✅ Fixed           | Corrected border-radius from 4px to 6px |
+| Input     | ⚠️ Still Defective | Focus ring color still wrong            |
+```
+
+Update the summary counter: `Fixed after validation: {total fixed so far}`.
+
+**Step 5d — Exit conditions**
+
+- If all defects are resolved → print a success summary and stop.
+- If the iteration count reaches 3 and defects remain → append a final section listing all unresolved components, note they require manual review, and stop.
+
+```markdown
+## Unresolved After 3 Fix Iterations
+
+| Component | Remaining Issue                     |
+| --------- | ----------------------------------- |
+| Input     | Focus ring color does not match app |
+```
+
+---
+
+## Output File Structure
+
+```
+.temp/figma-validation/
+├── report.md
+└── screenshots/
+    ├── Button-primary/
+    │   ├── app.png      ← Playwright element screenshot from live app
+    │   └── figma.png    ← Figma MCP get_screenshot of resolved variant node
+    ├── Button-ghost/
+    │   ├── app.png
+    │   └── figma.png
+    └── Input/
+        ├── app.png
+        └── figma.png
+```
+
+---
+
+## Error Handling
+
+| Error                                  | Action                                                                      |
+| -------------------------------------- | --------------------------------------------------------------------------- |
+| Dev server not running                 | Halt, tell user to run `the dev server`                                     |
+| Component set has no matching variant  | Log resolved variant + all available props; use first child; note in report |
+| Selector not found on page             | Log as `selector_not_found`, skip; note in report                           |
+| Element exists but empty/zero-size     | Log as `element_empty`, try broader selector                                |
+| Requires interaction not yet supported | Note as `requires_interaction`, include fallback full-page screenshot       |
+| Component not visible in app           | Note as `not_visible`, include Figma variant screenshot only                |
+
+Never stop the full run for a single component failure.

--- a/plugins/figma-from-code/skills/figma-from-code/10-validator/browser-connect.js
+++ b/plugins/figma-from-code/skills/figma-from-code/10-validator/browser-connect.js
@@ -1,0 +1,20 @@
+const { chromium } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+
+const ENDPOINT_FILE = path.resolve('.temp/figma-from-code/pw-endpoint.txt');
+
+async function getBrowser() {
+  try {
+    const wsEndpoint = fs.readFileSync(ENDPOINT_FILE, 'utf-8').trim();
+    return await chromium.connect(wsEndpoint);
+  } catch (err) {
+    const reason = fs.existsSync(ENDPOINT_FILE)
+      ? `endpoint unreachable (${err.message.split('\n')[0]})`
+      : 'no endpoint file';
+    console.error(`[browser-connect] Shared server not available: ${reason}. Launching standalone browser.`);
+    return await chromium.launch();
+  }
+}
+
+module.exports = { getBrowser };

--- a/plugins/figma-from-code/skills/figma-from-code/10-validator/browser-server.js
+++ b/plugins/figma-from-code/skills/figma-from-code/10-validator/browser-server.js
@@ -1,0 +1,25 @@
+const { chromium } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+
+const ENDPOINT_FILE = path.resolve('.temp/figma-from-code/pw-endpoint.txt');
+const PID_FILE = path.resolve('.temp/figma-from-code/pw-server.pid');
+
+(async () => {
+  fs.mkdirSync(path.dirname(ENDPOINT_FILE), { recursive: true });
+  const server = await chromium.launchServer();
+  const wsEndpoint = server.wsEndpoint();
+  fs.writeFileSync(ENDPOINT_FILE, wsEndpoint);
+  fs.writeFileSync(PID_FILE, String(process.pid));
+  console.log(`Playwright server started (pid ${process.pid}): ${wsEndpoint}`);
+
+  function cleanup() {
+    try { fs.unlinkSync(ENDPOINT_FILE); } catch {}
+    try { fs.unlinkSync(PID_FILE); } catch {}
+    server.close();
+    process.exit(0);
+  }
+
+  process.on('SIGINT', cleanup);
+  process.on('SIGTERM', cleanup);
+})();

--- a/plugins/figma-from-code/skills/figma-from-code/10-validator/compare.js
+++ b/plugins/figma-from-code/skills/figma-from-code/10-validator/compare.js
@@ -1,0 +1,195 @@
+/**
+ * Pixel-level visual comparison of two screenshot images.
+ *
+ * Loads both images into a headless browser canvas, walks every pixel to
+ * compute an overall match percentage and a separate border-ring match
+ * percentage, then writes a red-highlighted diff image and a JSON report
+ * to the output directory. Exit code signals the verdict:
+ *   0 = match, 1 = minor_diff, 2 = mismatch, 3 = error.
+ */
+
+const { getBrowser } = require('./browser-connect');
+const path = require('path');
+const fs   = require('fs');
+
+/**
+ * Parse CLI arguments into positional args and `--flag value` pairs.
+ * Numeric flag values are coerced to floats.
+ * @param {string[]} argv - Raw argument list (typically `process.argv.slice(2)`).
+ * @returns {{ positional: string[], flags: Record<string, number> }}
+ */
+function parseArgs(argv) {
+  const positional = [];
+  const flags = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i].startsWith('--') && i + 1 < argv.length) {
+      flags[argv[i].slice(2)] = parseFloat(argv[i + 1]);
+      i++;
+    } else {
+      positional.push(argv[i]);
+    }
+  }
+  return { positional, flags };
+}
+
+const { positional, flags } = parseArgs(process.argv.slice(2));
+const [imageA, imageB, outputDir] = positional;
+
+if (!imageA || !imageB || !outputDir) {
+  console.error('Usage: node compare.js <imageA> <imageB> <outputDir> [--match-threshold N] [--defect-threshold N] [--border-ring N] [--border-threshold N] [--tolerance N]');
+  process.exit(1);
+}
+
+const MATCH_THRESHOLD  = flags['match-threshold']  ?? 90;
+const DEFECT_THRESHOLD = flags['defect-threshold'] ?? 75;
+const BORDER_RING      = flags['border-ring']      ?? 4;
+const BORDER_THRESHOLD = flags['border-threshold'] ?? 85;
+const TOLERANCE        = flags['tolerance']        ?? 28;
+
+const absA = path.resolve(imageA);
+const absB = path.resolve(imageB);
+fs.mkdirSync(outputDir, { recursive: true });
+
+/**
+ * Read an image file from disk and return it as a base64-encoded data URL.
+ * @param {string} filePath - Absolute or relative path to a PNG image.
+ * @returns {string} A `data:image/png;base64,...` data URL.
+ */
+function toDataUrl(filePath) {
+  const bytes = fs.readFileSync(filePath);
+  return 'data:image/png;base64,' + bytes.toString('base64');
+}
+
+(async () => {
+  const browser = await getBrowser();
+  const page    = await browser.newPage();
+  await page.goto('about:blank');
+
+  const result = await page.evaluate(async ({
+    urlA, urlB,
+    matchThreshold, defectThreshold, borderRing, borderThreshold, tolerance,
+  }) => {
+    /**
+     * Load an image from a data URL into an HTMLImageElement.
+     * @param {string} src - Image source (data URL or remote URL).
+     * @returns {Promise<HTMLImageElement>} Resolves when the image is decoded.
+     */
+    function loadImage(src) {
+      return new Promise((resolve, reject) => {
+        const img = new Image();
+        img.onload  = () => resolve(img);
+        img.onerror = () => reject(new Error('Failed to load image'));
+        img.src = src;
+      });
+    }
+
+    const [imgA, imgB] = await Promise.all([loadImage(urlA), loadImage(urlB)]);
+
+    const w = imgB.naturalWidth;
+    const h = imgB.naturalHeight;
+
+    const cvA = document.createElement('canvas'); cvA.width = w; cvA.height = h;
+    const cvB = document.createElement('canvas'); cvB.width = w; cvB.height = h;
+    const cvD = document.createElement('canvas'); cvD.width = w; cvD.height = h;
+
+    cvA.getContext('2d').drawImage(imgA, 0, 0, w, h);
+    cvB.getContext('2d').drawImage(imgB, 0, 0, w, h);
+
+    const dataA   = cvA.getContext('2d').getImageData(0, 0, w, h);
+    const dataB   = cvB.getContext('2d').getImageData(0, 0, w, h);
+    const diffImg = cvD.getContext('2d').createImageData(w, h);
+
+    let diffPixels   = 0;
+    let borderDiff   = 0;
+    let borderTotal  = 0;
+
+    for (let y = 0; y < h; y++) {
+      for (let x = 0; x < w; x++) {
+        const i = (y * w + x) * 4;
+        const rD = Math.abs(dataA.data[i]     - dataB.data[i]);
+        const gD = Math.abs(dataA.data[i + 1] - dataB.data[i + 1]);
+        const bD = Math.abs(dataA.data[i + 2] - dataB.data[i + 2]);
+        const maxDiff = Math.max(rD, gD, bD);
+        const isDiff  = maxDiff > tolerance;
+
+        const inBorder = x < borderRing || x >= w - borderRing
+                      || y < borderRing || y >= h - borderRing;
+
+        if (isDiff) diffPixels++;
+        if (inBorder) {
+          borderTotal++;
+          if (isDiff) borderDiff++;
+        }
+
+        if (isDiff) {
+          diffImg.data[i] = 255; diffImg.data[i+1] = 0; diffImg.data[i+2] = 0; diffImg.data[i+3] = 220;
+        } else {
+          diffImg.data[i]   = dataA.data[i]   >> 1;
+          diffImg.data[i+1] = dataA.data[i+1] >> 1;
+          diffImg.data[i+2] = dataA.data[i+2] >> 1;
+          diffImg.data[i+3] = 255;
+        }
+      }
+    }
+
+    cvD.getContext('2d').putImageData(diffImg, 0, 0);
+
+    const total          = w * h;
+    const matchPct       = Math.round(((total - diffPixels) / total) * 10000) / 100;
+    const borderMatchPct = borderTotal > 0
+      ? Math.round(((borderTotal - borderDiff) / borderTotal) * 10000) / 100
+      : 100;
+
+    const verdict       = matchPct >= matchThreshold ? 'match'
+                        : matchPct >= defectThreshold ? 'minor_diff'
+                        : 'mismatch';
+    const borderVerdict = borderMatchPct >= borderThreshold ? 'border_ok' : 'border_diff';
+
+    return {
+      matchPct, borderMatchPct,
+      diffPixels, totalPixels: total,
+      borderDiff, borderTotal,
+      verdict, borderVerdict,
+      w, h,
+      diffDataUrl: cvD.toDataURL('image/png'),
+    };
+  }, { urlA: toDataUrl(absA), urlB: toDataUrl(absB),
+       matchThreshold: MATCH_THRESHOLD, defectThreshold: DEFECT_THRESHOLD,
+       borderRing: BORDER_RING, borderThreshold: BORDER_THRESHOLD, tolerance: TOLERANCE });
+
+  const b64 = result.diffDataUrl.replace(/^data:image\/png;base64,/, '');
+  fs.writeFileSync(path.join(outputDir, 'diff.png'), Buffer.from(b64, 'base64'));
+
+  const json = {
+    matchPct:       result.matchPct,
+    borderMatchPct: result.borderMatchPct,
+    diffPixels:     result.diffPixels,
+    totalPixels:    result.totalPixels,
+    borderDiff:     result.borderDiff,
+    borderTotal:    result.borderTotal,
+    normalizedW:    result.w,
+    normalizedH:    result.h,
+    verdict:        result.verdict,
+    borderVerdict:  result.borderVerdict,
+    thresholds: {
+      match: MATCH_THRESHOLD, defect: DEFECT_THRESHOLD,
+      borderRing: BORDER_RING, border: BORDER_THRESHOLD,
+      tolerance: TOLERANCE,
+    },
+  };
+  fs.writeFileSync(path.join(outputDir, 'comparison.json'), JSON.stringify(json, null, 2));
+
+  await browser.close();
+
+  const effectiveVerdict = result.borderVerdict === 'border_diff' && result.verdict === 'match'
+    ? 'minor_diff' : result.verdict;
+
+  const icon = effectiveVerdict === 'match' ? '✅' : effectiveVerdict === 'minor_diff' ? '⚠️' : '❌';
+  console.log(`${icon} ${effectiveVerdict.toUpperCase()} — overall ${result.matchPct}% | border ${result.borderMatchPct}% (${result.borderDiff}/${result.borderTotal} border px differ)`);
+  console.log(`   diff → ${path.join(outputDir, 'diff.png')}`);
+
+  process.exit(effectiveVerdict === 'mismatch' ? 2 : effectiveVerdict === 'minor_diff' ? 1 : 0);
+})().catch(err => {
+  console.error('compare.js error:', err.message);
+  process.exit(3);
+});

--- a/plugins/figma-from-code/skills/figma-from-code/10-validator/detect-components.js
+++ b/plugins/figma-from-code/skills/figma-from-code/10-validator/detect-components.js
@@ -1,0 +1,468 @@
+/**
+ * Shared component detection logic for discover-components.js and map-components.js.
+ *
+ * Runs inside page.evaluate() — all code here executes in the browser context.
+ * Detects React 18+, React <18, Vue 3, Vue 2, Angular, and Svelte (dev mode).
+ */
+
+async function discoverOnPage(page, { minSize = 4 } = {}) {
+  return await page.evaluate(({ minSize }) => {
+
+    // ── Framework detection ──────────────────────────────────────────
+
+    function detectFramework() {
+      const sample = document.querySelectorAll('*');
+      let react18 = false, reactOld = false, vue3 = false, vue2 = false;
+      let angular = false, svelte = false;
+
+      const limit = Math.min(sample.length, 200);
+      for (let i = 0; i < limit; i++) {
+        const el = sample[i];
+        const keys = Object.keys(el);
+        if (!react18 && keys.some(k => k.startsWith('__reactFiber$'))) react18 = true;
+        if (!reactOld && keys.some(k => k.startsWith('__reactInternalInstance$'))) reactOld = true;
+        if (!vue3 && el.__vueParentComponent) vue3 = true;
+        if (!vue2 && el.__vue__) vue2 = true;
+        if (!angular && el.__ngContext__) angular = true;
+        if (!svelte && el.__svelte_meta) svelte = true;
+      }
+
+      if (!angular && document.querySelector('[ng-version]')) angular = true;
+      if (!angular && typeof window.ng?.getComponent === 'function') angular = true;
+      if (!vue3 && document.querySelector('[data-v-app]')) vue3 = true;
+
+      const version = getFrameworkVersion({ react18, reactOld, vue3, vue2, angular, svelte });
+
+      if (react18) return { name: 'react', generation: '18+', ...version };
+      if (reactOld) return { name: 'react', generation: '<18', ...version };
+      if (vue3) return { name: 'vue', generation: '3', ...version };
+      if (vue2) return { name: 'vue', generation: '2', ...version };
+      if (angular) return { name: 'angular', generation: 'ivy', ...version };
+      if (svelte) return { name: 'svelte', generation: 'dev', ...version };
+      return { name: 'unknown', generation: null, version: null, mode: null };
+    }
+
+    function getFrameworkVersion(flags) {
+      let version = null;
+      let mode = null;
+
+      if (flags.react18 || flags.reactOld) {
+        const rootEl = document.getElementById('root') || document.getElementById('app');
+        if (rootEl?._reactRootContainer) {
+          mode = 'legacy';
+        } else if (rootEl && Object.keys(rootEl).some(k => k.startsWith('__reactContainer$'))) {
+          mode = 'concurrent';
+        }
+        try {
+          const v = window.__REACT_DEVTOOLS_GLOBAL_HOOK__?.renderers?.values()?.next()?.value?.version;
+          if (v) version = v;
+        } catch {}
+      }
+
+      if (flags.vue3 || flags.vue2) {
+        try {
+          if (window.Vue?.version) version = window.Vue.version;
+          if (flags.vue3) {
+            const appEl = document.querySelector('[data-v-app]') || document.getElementById('app');
+            if (appEl?.__vue_app__?.version) version = appEl.__vue_app__.version;
+          }
+        } catch {}
+        mode = flags.vue3 ? 'composition' : 'options';
+      }
+
+      if (flags.angular) {
+        const ngEl = document.querySelector('[ng-version]');
+        if (ngEl) version = ngEl.getAttribute('ng-version');
+        mode = 'ivy';
+      }
+
+      return { version, mode };
+    }
+
+    // ── Visual prop extraction ───────────────────────────────────────
+
+    function extractVisualProps(memoizedProps) {
+      if (!memoizedProps) return {};
+      const SKIP = new Set([
+        'children', 'className', 'style', 'ref', 'key', 'id', 'asChild', 'forceMount', 'tabIndex',
+        'value', 'defaultValue', 'label', 'displayValue', 'placeholder', 'name',
+        'title', 'description', 'content', 'alt', 'src', 'href', 'to',
+      ]);
+      const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+      const result = {};
+      for (const k of Object.keys(memoizedProps)) {
+        if (SKIP.has(k)) continue;
+        if (k.endsWith('Id') || k.endsWith('Uuid') || k.endsWith('Key')) continue;
+        if (k.startsWith('on') || k.startsWith('data-') || k.startsWith('aria-')) continue;
+        const v = memoizedProps[k];
+        if (v === null || v === undefined) continue;
+        if (typeof v === 'function') continue;
+        if (typeof v === 'object') continue;
+        if (typeof v === 'string') {
+          if (!v || v.length > 50 || v.includes(' ') || v.startsWith('/') || v.startsWith('http')) continue;
+          if (UUID_RE.test(v)) continue;
+        }
+        result[k] = v;
+      }
+      return result;
+    }
+
+    // ── Component extraction per framework ───────────────────────────
+
+    function getReact18Components(root) {
+      const components = [];
+      const seenEls = new WeakSet();
+      const seenFibers = new WeakSet();
+
+      function walk(el) {
+        if (seenEls.has(el)) return;
+        seenEls.add(el);
+
+        const fiberKey = Object.keys(el).find(k => k.startsWith('__reactFiber$'));
+        if (fiberKey) {
+          const fiber = el[fiberKey];
+          let node = fiber;
+          while (node) {
+            if (typeof node.type === 'function' || (typeof node.type === 'object' && node.type !== null)) {
+              if (seenFibers.has(node)) break;
+              const name = node.type?.displayName || node.type?.name || node.type?.render?.displayName || node.type?.render?.name;
+              if (name && name.length > 1) {
+                seenFibers.add(node);
+                const props = extractVisualProps(node.memoizedProps);
+                let parentFiber = node.return;
+                let fiberParent = null;
+                while (parentFiber) {
+                  if (typeof parentFiber.type === 'function' || (typeof parentFiber.type === 'object' && parentFiber.type !== null)) {
+                    const parentName = parentFiber.type?.displayName || parentFiber.type?.name || parentFiber.type?.render?.displayName || parentFiber.type?.render?.name;
+                    if (parentName && parentName.length > 1 && parentName !== name) {
+                      fiberParent = parentName;
+                      break;
+                    }
+                  }
+                  parentFiber = parentFiber.return;
+                }
+                components.push({ name, el, props, fiberParent });
+                break;
+              }
+            }
+            node = node.return;
+          }
+        }
+        for (const child of el.children) walk(child);
+      }
+
+      walk(root);
+      return components;
+    }
+
+    function getReactOldComponents(root) {
+      const components = [];
+      const seenEls = new WeakSet();
+      const seenInst = new WeakSet();
+
+      function walk(el) {
+        if (seenEls.has(el)) return;
+        seenEls.add(el);
+
+        const key = Object.keys(el).find(k => k.startsWith('__reactInternalInstance$'));
+        if (key) {
+          let inst = el[key];
+          while (inst) {
+            if (seenInst.has(inst)) break;
+            const name = inst._currentElement?.type?.displayName
+              || inst._currentElement?.type?.name
+              || inst.type?.displayName
+              || inst.type?.name;
+            if (name && name.length > 1 && /^[A-Z]/.test(name)) {
+              seenInst.add(inst);
+              components.push({ name, el });
+              break;
+            }
+            inst = inst._hostParent || inst.return;
+          }
+        }
+        for (const child of el.children) walk(child);
+      }
+
+      walk(root);
+      return components;
+    }
+
+    function getVue3Components(root) {
+      const components = [];
+      const seen = new WeakSet();
+
+      function walk(el) {
+        if (seen.has(el)) return;
+        seen.add(el);
+
+        const comp = el.__vueParentComponent;
+        if (comp) {
+          const name = comp.type?.name || comp.type?.__name || comp.type?.displayName;
+          if (name) components.push({ name, el });
+        }
+        for (const child of el.children) walk(child);
+      }
+
+      walk(root);
+      return components;
+    }
+
+    function getVue2Components(root) {
+      const components = [];
+      const seen = new WeakSet();
+
+      function walk(el) {
+        if (seen.has(el)) return;
+        seen.add(el);
+
+        if (el.__vue__) {
+          const vm = el.__vue__;
+          const name = vm.$options.name || vm.$options._componentTag;
+          if (name) components.push({ name, el });
+        }
+        for (const child of el.children) walk(child);
+      }
+
+      walk(root);
+      return components;
+    }
+
+    function getAngularComponents(root) {
+      const components = [];
+      const seen = new WeakSet();
+      const hasNgApi = typeof window.ng?.getComponent === 'function';
+
+      function walk(el) {
+        if (seen.has(el)) return;
+        seen.add(el);
+
+        if (hasNgApi) {
+          try {
+            const comp = window.ng.getComponent(el);
+            if (comp) {
+              const name = comp.constructor?.name;
+              if (name && name !== 'Object' && name.length > 1) {
+                components.push({ name, el });
+              }
+            }
+          } catch {}
+        }
+
+        if (el.__ngContext__) {
+          const tag = el.tagName?.toLowerCase();
+          if (tag && tag.includes('-')) {
+            const name = tag.split('-').map(s => s.charAt(0).toUpperCase() + s.slice(1)).join('');
+            components.push({ name, el, fromTag: true });
+          }
+        }
+
+        for (const child of el.children) walk(child);
+      }
+
+      walk(root);
+      return components;
+    }
+
+    function getSvelteComponents(root) {
+      const components = [];
+      const seen = new WeakSet();
+
+      function walk(el) {
+        if (seen.has(el)) return;
+        seen.add(el);
+
+        if (el.__svelte_meta) {
+          const ctx = el.__svelte_meta;
+          const name = ctx.loc?.file?.split('/')?.pop()?.replace('.svelte', '') || null;
+          if (name) components.push({ name, el });
+        }
+        for (const child of el.children) walk(child);
+      }
+
+      walk(root);
+      return components;
+    }
+
+    // ── Selector generation ──────────────────────────────────────────
+
+    function generateSelector(el) {
+      if (el.dataset?.testid) return `[data-testid="${el.dataset.testid}"]`;
+
+      if (el.id && /^[a-zA-Z]/.test(el.id) && document.querySelectorAll(`#${CSS.escape(el.id)}`).length === 1) {
+        return `#${CSS.escape(el.id)}`;
+      }
+
+      const ariaLabel = el.getAttribute('aria-label');
+      if (ariaLabel) {
+        const sel = `${el.tagName.toLowerCase()}[aria-label="${ariaLabel}"]`;
+        if (document.querySelectorAll(sel).length === 1) return sel;
+      }
+
+      const role = el.getAttribute('role');
+      if (role && ariaLabel) {
+        const sel = `[role="${role}"][aria-label="${ariaLabel}"]`;
+        if (document.querySelectorAll(sel).length === 1) return sel;
+      }
+
+      const stableClasses = [...el.classList]
+        .filter(c => !c.match(/^_|^css-|^sc-|^svelte-|^ng-|^v-|^__/))
+        .filter(c => !c.match(/^\d|^jsx-/))
+        .slice(0, 4);
+
+      if (stableClasses.length > 0) {
+        const sel = `${el.tagName.toLowerCase()}.${stableClasses.map(c => CSS.escape(c)).join('.')}`;
+        if (document.querySelectorAll(sel).length === 1) return sel;
+      }
+
+      const segments = [];
+      let current = el;
+      while (current && current !== document.body && segments.length < 5) {
+        const tag = current.tagName.toLowerCase();
+        if (current.id && /^[a-zA-Z]/.test(current.id)) {
+          segments.unshift(`#${CSS.escape(current.id)}`);
+          break;
+        }
+        const parent = current.parentElement;
+        if (parent) {
+          const sameTag = [...parent.children].filter(c => c.tagName === current.tagName);
+          if (sameTag.length === 1) {
+            segments.unshift(tag);
+          } else {
+            segments.unshift(`${tag}:nth-of-type(${sameTag.indexOf(current) + 1})`);
+          }
+        } else {
+          segments.unshift(tag);
+        }
+        current = parent;
+      }
+      return segments.join(' > ');
+    }
+
+    // ── Tree reconstruction ─────────────────────────────────────────
+
+    function buildTree(rawComponents) {
+      const entries = rawComponents.map(c => ({
+        name: c.name,
+        el: c.el,
+        props: c.props || {},
+        fiberParent: c.fiberParent || null,
+        depth: getDepth(c.el),
+      }));
+
+      entries.sort((a, b) => a.depth - b.depth);
+
+      const tree = [];
+      const nodeMap = new Map();
+
+      for (const entry of entries) {
+        const node = { name: entry.name, props: entry.props, fiberParent: entry.fiberParent, children: [], el: entry.el };
+        let parentEl = entry.el.parentElement;
+        let parentNode = null;
+        while (parentEl) {
+          if (nodeMap.has(parentEl)) {
+            parentNode = nodeMap.get(parentEl);
+            break;
+          }
+          parentEl = parentEl.parentElement;
+        }
+        if (parentNode) {
+          parentNode.children.push(node);
+        } else {
+          tree.push(node);
+        }
+        nodeMap.set(entry.el, node);
+      }
+
+      const nameToNode = new Map();
+      function indexNodes(nodes) {
+        for (const node of nodes) {
+          if (!nameToNode.has(node.name)) nameToNode.set(node.name, node);
+          indexNodes(node.children);
+        }
+      }
+      indexNodes(tree);
+
+      const reparented = [];
+      for (let i = tree.length - 1; i >= 0; i--) {
+        const node = tree[i];
+        if (node.fiberParent && nameToNode.has(node.fiberParent)) {
+          const parent = nameToNode.get(node.fiberParent);
+          parent.children.push(node);
+          reparented.push(i);
+        }
+      }
+      for (const idx of reparented) tree.splice(idx, 1);
+
+      return tree;
+    }
+
+    function getDepth(el) {
+      let d = 0;
+      let n = el;
+      while (n.parentElement) { d++; n = n.parentElement; }
+      return d;
+    }
+
+    function serializeTree(nodes) {
+      return nodes.map(n => ({
+        name: n.name,
+        props: n.props || {},
+        children: serializeTree(n.children),
+      }));
+    }
+
+    // ── Run ─────────────────────────────────────────────────────────
+
+    const framework = detectFramework();
+
+    let rawComponents = [];
+    const root = document.body;
+
+    switch (framework.name) {
+      case 'react':
+        rawComponents = framework.generation === '18+'
+          ? getReact18Components(root)
+          : getReactOldComponents(root);
+        break;
+      case 'vue':
+        rawComponents = framework.generation === '3'
+          ? getVue3Components(root)
+          : getVue2Components(root);
+        break;
+      case 'angular':
+        rawComponents = getAngularComponents(root);
+        break;
+      case 'svelte':
+        rawComponents = getSvelteComponents(root);
+        break;
+    }
+
+    const deduped = new Map();
+    for (const { name, el } of rawComponents) {
+      const box = el.getBoundingClientRect();
+      if (box.width < minSize && box.height < minSize) continue;
+
+      if (!deduped.has(name)) deduped.set(name, []);
+      deduped.get(name).push({
+        selector: generateSelector(el),
+        box: { x: Math.round(box.x), y: Math.round(box.y), width: Math.round(box.width), height: Math.round(box.height) },
+        visible: box.width > 0 && box.height > 0 && el.offsetParent !== null,
+        tag: el.tagName.toLowerCase(),
+      });
+    }
+
+    const components = [...deduped.entries()]
+      .map(([name, elements]) => ({ name, instances: elements.length, elements }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+    const tree = buildTree(rawComponents.filter(c => {
+      const box = c.el.getBoundingClientRect();
+      return box.width >= minSize || box.height >= minSize;
+    }));
+
+    return { framework, components, tree: serializeTree(tree) };
+  }, { minSize });
+}
+
+module.exports = { discoverOnPage };

--- a/plugins/figma-from-code/skills/figma-from-code/10-validator/discover-components.js
+++ b/plugins/figma-from-code/skills/figma-from-code/10-validator/discover-components.js
@@ -1,0 +1,136 @@
+/**
+ * Framework-agnostic component discovery for any web application.
+ *
+ * Detects the UI framework (React 18+, React <18, Vue 3, Vue 2, Angular,
+ * Svelte dev-mode) and walks the DOM to map component names to elements.
+ *
+ * Usage:
+ *   node discover-components.js <url> [options]
+ *
+ * Options:
+ *   --list                  Print unique component names only
+ *   --name <name>           Filter to instances of a specific component
+ *   --tree                  Print the component hierarchy as a tree
+ *   --output <file.json>    Write full results to a file
+ *   --click <selector>      Click an element before discovery (opens dialogs, etc.)
+ *   --wait <ms>             Extra wait after page load (default: 0)
+ *   --min-size <px>         Skip elements smaller than this (default: 4)
+ *   --include-lib           Include library/internal components (filtered by default)
+ *   --screenshot <name>     Screenshot a component's first visible instance
+ *   --screenshot-dir <dir>  Directory for screenshots (default: ./component-screenshots)
+ */
+
+const { getBrowser } = require('./browser-connect');
+const { discoverOnPage } = require('./detect-components');
+const { isLibraryComponent } = require('./library-filter');
+const path = require('path');
+const fs = require('fs');
+
+const args = process.argv.slice(2);
+if (args.length < 1 || args[0].startsWith('--')) {
+  console.error('Usage: node discover-components.js <url> [--list] [--name Name] [--tree] [--output file.json] [--click sel] [--wait ms] [--screenshot Name]');
+  process.exit(1);
+}
+
+const url = args[0];
+const opts = {
+  list: false, name: null, tree: false, output: null,
+  click: null, wait: 0, minSize: 4, includeLib: false,
+  screenshot: null, screenshotDir: './component-screenshots',
+};
+
+for (let i = 1; i < args.length; i++) {
+  switch (args[i]) {
+    case '--list': opts.list = true; break;
+    case '--name': opts.name = args[++i]; break;
+    case '--tree': opts.tree = true; break;
+    case '--output': opts.output = args[++i]; break;
+    case '--click': opts.click = args[++i]; break;
+    case '--wait': opts.wait = Number(args[++i]); break;
+    case '--min-size': opts.minSize = Number(args[++i]); break;
+    case '--include-lib': opts.includeLib = true; break;
+    case '--screenshot': opts.screenshot = args[++i]; break;
+    case '--screenshot-dir': opts.screenshotDir = args[++i]; break;
+  }
+}
+
+(async () => {
+  const browser = await getBrowser();
+  const page = await browser.newPage();
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto(url, { waitUntil: 'networkidle', timeout: 15000 });
+
+  if (opts.click) {
+    const trigger = page.locator(opts.click).first();
+    await trigger.waitFor({ state: 'visible', timeout: 8000 });
+    await trigger.click();
+    await page.waitForTimeout(400);
+  }
+
+  if (opts.wait > 0) await page.waitForTimeout(opts.wait);
+
+  const result = await discoverOnPage(page, { minSize: opts.minSize });
+
+  if (!opts.includeLib) {
+    result.components = result.components.filter(c => !isLibraryComponent(c.name));
+  }
+
+  if (opts.name) {
+    const pattern = opts.name.toLowerCase();
+    result.components = result.components.filter(c => c.name.toLowerCase().includes(pattern));
+  }
+
+  result.url = url;
+
+  if (opts.screenshot) {
+    const comp = result.components.find(c => c.name.toLowerCase() === opts.screenshot.toLowerCase());
+    if (comp) {
+      const el = comp.elements.find(e => e.visible) || comp.elements[0];
+      if (el) {
+        fs.mkdirSync(opts.screenshotDir, { recursive: true });
+        const outPath = path.join(opts.screenshotDir, `${comp.name}.png`);
+        await page.locator(el.selector).first().screenshot({ path: outPath });
+        console.log(`Screenshot saved: ${outPath}`);
+      }
+    } else {
+      console.error(`Component "${opts.screenshot}" not found`);
+    }
+  }
+
+  if (opts.list) {
+    console.log(`Framework: ${result.framework.name} ${result.framework.generation || ''}${result.framework.version ? ' v' + result.framework.version : ''}`);
+    console.log(`Components found: ${result.components.length}\n`);
+    for (const c of result.components) {
+      const vis = c.elements.filter(e => e.visible).length;
+      console.log(`  ${c.name} (${c.instances} instance${c.instances > 1 ? 's' : ''}${vis < c.instances ? `, ${vis} visible` : ''})`);
+    }
+  } else if (opts.tree) {
+    console.log(`Framework: ${result.framework.name} ${result.framework.generation || ''}${result.framework.version ? ' v' + result.framework.version : ''}\n`);
+    function printTree(nodes, indent) {
+      for (const node of nodes) {
+        if (!opts.includeLib && isLibraryComponent(node.name)) continue;
+        if (opts.name && !node.name.toLowerCase().includes(opts.name.toLowerCase())) {
+          printTree(node.children, indent);
+          continue;
+        }
+        console.log(`${indent}${node.name}`);
+        printTree(node.children, indent + '  ');
+      }
+    }
+    printTree(result.tree, '');
+  } else {
+    process.stdout.write(JSON.stringify(result, null, 2));
+  }
+
+  if (opts.output) {
+    fs.mkdirSync(path.dirname(opts.output), { recursive: true });
+    fs.writeFileSync(opts.output, JSON.stringify(result, null, 2));
+    if (!opts.list && !opts.tree) console.log('');
+    console.log(`Written to: ${opts.output}`);
+  }
+
+  await browser.close();
+})().catch(err => {
+  console.error('discover-components.js error:', err.message);
+  process.exit(1);
+});

--- a/plugins/figma-from-code/skills/figma-from-code/10-validator/extract-icons.js
+++ b/plugins/figma-from-code/skills/figma-from-code/10-validator/extract-icons.js
@@ -1,0 +1,261 @@
+/**
+ * Icon and asset extractor for figma-from-code
+ *
+ * Statically analyzes the codebase to discover Lucide icon usage and SVG assets,
+ * then extracts SVG data from the Lucide source for Figma vector creation.
+ *
+ * Usage:
+ *   node extract-icons.js --scan <srcDir> --output <output.json>
+ *
+ * Output: JSON with icons (name, svgString, usedBy), assets, and iconsByComponent map
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+function findTsxFiles(dir) {
+  const results = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory() && entry.name !== 'node_modules') {
+      results.push(...findTsxFiles(fullPath));
+    } else if (
+      entry.isFile() &&
+      /\.tsx?$/.test(entry.name) &&
+      !/\.(test|stories|spec)\./.test(entry.name)
+    ) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+function extractLucideImports(filePath) {
+  const content = fs.readFileSync(filePath, 'utf8');
+  const icons = [];
+  const importRe = /import\s+\{([^}]+)\}\s+from\s+['"]lucide-react['"]/g;
+  let match;
+  while ((match = importRe.exec(content)) !== null) {
+    const names = match[1]
+      .split(',')
+      .map((s) => {
+        const trimmed = s.trim();
+        const asMatch = trimmed.match(/^(\w+)\s+as\s+\w+$/);
+        return asMatch ? asMatch[1] : trimmed;
+      })
+      .filter(Boolean);
+    icons.push(...names);
+  }
+  return icons;
+}
+
+function extractSvgAssetImports(filePath) {
+  const content = fs.readFileSync(filePath, 'utf8');
+  const assets = [];
+  const svgImportRe = /import\s+(\w+)\s+from\s+['"]([^'"]+\.svg)['"]/g;
+  let match;
+  while ((match = svgImportRe.exec(content)) !== null) {
+    assets.push({ importName: match[1], importPath: match[2] });
+  }
+  return assets;
+}
+
+function pascalToKebab(name) {
+  return name
+    .replace(/([a-z])(\d)/g, '$1-$2')
+    .replace(/(\d)([A-Z])/g, '$1-$2')
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/([A-Z])([A-Z][a-z])/g, '$1-$2')
+    .toLowerCase();
+}
+
+function componentNameFromPath(filePath) {
+  const basename = path.basename(filePath, path.extname(filePath));
+  if (/^(index|types)$/.test(basename)) {
+    return path.basename(path.dirname(filePath));
+  }
+  return basename;
+}
+
+function resolveIconSource(iconName, iconsDir, visited = new Set()) {
+  const kebab = pascalToKebab(iconName);
+  const filePath = path.join(iconsDir, `${kebab}.js`);
+
+  if (!fs.existsSync(filePath)) return null;
+  if (visited.has(filePath)) return null;
+  visited.add(filePath);
+
+  const content = fs.readFileSync(filePath, 'utf8');
+
+  const reExportMatch = content.match(/export\s+\{\s*default\s*\}\s+from\s+['"]\.\/([^'"]+)['"]/);
+  if (reExportMatch) {
+    const targetName = reExportMatch[1].replace(/\.js$/, '');
+    const targetPath = path.join(iconsDir, `${targetName}.js`);
+    if (!fs.existsSync(targetPath)) return null;
+    return resolveIconSource(
+      targetName
+        .split('-')
+        .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+        .join(''),
+      iconsDir,
+      visited
+    );
+  }
+
+  return { content, filePath };
+}
+
+function parseCreateLucideIcon(content) {
+  const match = content.match(/createLucideIcon\(\s*"[^"]+"\s*,\s*(\[[\s\S]*?\])\s*\)/);
+  if (!match) return null;
+
+  let elementsStr = match[1];
+  elementsStr = elementsStr.replace(/,\s*key:\s*"[^"]*"/g, '');
+
+  try {
+    const parsed = JSON.parse(elementsStr);
+    return parsed;
+  } catch {
+    try {
+      const sanitized = elementsStr.replace(/(\w+):/g, '"$1":').replace(/'/g, '"');
+      return JSON.parse(sanitized);
+    } catch {
+      return null;
+    }
+  }
+}
+
+function elementsToSvgString(elements) {
+  const children = elements
+    .map(([tag, attrs]) => {
+      const attrStr = Object.entries(attrs)
+        .filter(([k]) => k !== 'key')
+        .map(([k, v]) => `${k}="${v}"`)
+        .join(' ');
+      return `<${tag} ${attrStr}/>`;
+    })
+    .join('');
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">${children}</svg>`;
+}
+
+function resolveSvgAssetPath(importPath, srcDir) {
+  const cleaned = importPath.replace(/^@\//, '');
+  return path.join(srcDir, cleaned);
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const scanIdx = args.indexOf('--scan');
+  const outputIdx = args.indexOf('--output');
+
+  if (scanIdx === -1 || !args[scanIdx + 1]) {
+    process.stderr.write('Usage: node extract-icons.js --scan <srcDir> --output <output.json>\n');
+    process.exit(1);
+  }
+
+  const srcDir = path.resolve(args[scanIdx + 1]);
+  const outputPath =
+    outputIdx !== -1 && args[outputIdx + 1] ? path.resolve(args[outputIdx + 1]) : null;
+
+  const projectRoot = path.resolve(srcDir, '../../..');
+  const iconsDir = path.join(projectRoot, 'node_modules/lucide-react/dist/esm/icons');
+
+  if (!fs.existsSync(iconsDir)) {
+    process.stderr.write(`Lucide icons directory not found: ${iconsDir}\n`);
+    process.exit(1);
+  }
+
+  const tsxFiles = findTsxFiles(srcDir);
+
+  const iconUsageMap = {};
+  const assetUsageMap = {};
+  const iconsByComponent = {};
+
+  for (const filePath of tsxFiles) {
+    const componentName = componentNameFromPath(filePath);
+    const icons = extractLucideImports(filePath);
+    if (icons.length > 0) {
+      iconsByComponent[componentName] = icons;
+      for (const icon of icons) {
+        if (!iconUsageMap[icon]) iconUsageMap[icon] = new Set();
+        iconUsageMap[icon].add(componentName);
+      }
+    }
+
+    const assets = extractSvgAssetImports(filePath);
+    for (const asset of assets) {
+      if (!assetUsageMap[asset.importName]) {
+        assetUsageMap[asset.importName] = {
+          importPath: asset.importPath,
+          usedBy: new Set(),
+        };
+      }
+      assetUsageMap[asset.importName].usedBy.add(componentName);
+    }
+  }
+
+  const iconResults = [];
+  for (const [iconName, usedBySet] of Object.entries(iconUsageMap)) {
+    const source = resolveIconSource(iconName, iconsDir);
+    if (!source) {
+      process.stderr.write(`Warning: could not resolve icon "${iconName}"\n`);
+      continue;
+    }
+
+    const elements = parseCreateLucideIcon(source.content);
+    if (!elements) {
+      process.stderr.write(`Warning: could not parse icon "${iconName}" from ${source.filePath}\n`);
+      continue;
+    }
+
+    iconResults.push({
+      name: iconName,
+      elements,
+      svgString: elementsToSvgString(elements),
+      usedBy: [...usedBySet].sort(),
+    });
+  }
+  iconResults.sort((a, b) => a.name.localeCompare(b.name));
+
+  const assetResults = [];
+  for (const [name, info] of Object.entries(assetUsageMap)) {
+    const resolvedPath = resolveSvgAssetPath(info.importPath, srcDir);
+    const entry = {
+      name,
+      importPath: info.importPath,
+      sourcePath: path.relative(projectRoot, resolvedPath),
+      usedBy: [...info.usedBy].sort(),
+      type: 'svg-file',
+    };
+    if (fs.existsSync(resolvedPath)) {
+      entry.svgString = fs.readFileSync(resolvedPath, 'utf8').trim();
+    }
+    assetResults.push(entry);
+  }
+
+  const result = {
+    icons: iconResults,
+    assets: assetResults,
+    iconsByComponent,
+    summary: {
+      totalIcons: iconResults.length,
+      totalAssets: assetResults.length,
+      componentsWithIcons: Object.keys(iconsByComponent).length,
+    },
+  };
+
+  const json = JSON.stringify(result, null, 2);
+
+  if (outputPath) {
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, json);
+    process.stderr.write(
+      `Wrote ${result.summary.totalIcons} icons and ${result.summary.totalAssets} assets to ${outputPath}\n`
+    );
+  } else {
+    process.stdout.write(json + '\n');
+  }
+}
+
+main();

--- a/plugins/figma-from-code/skills/figma-from-code/10-validator/extract-text.js
+++ b/plugins/figma-from-code/skills/figma-from-code/10-validator/extract-text.js
@@ -1,0 +1,159 @@
+/**
+ * Text content extractor for figma-from-code
+ *
+ * Usage — single extraction:
+ *   node extract-text.js <url> --selector "css" [--click "css"] [--nth N]
+ *
+ * Usage — batch mode (one browser, many extractions):
+ *   node extract-text.js --batch manifest.json
+ *
+ *   manifest.json format:
+ *   [
+ *     {"url": "http://...", "output": "path/text.json", "selector": "css", "click": "css", "nth": 0},
+ *     ...
+ *   ]
+ *
+ * Output (single mode → stdout JSON, batch mode → individual files):
+ *   { "full", "lines", "inputs", "buttons", "headings", "labels" }
+ */
+
+const { getBrowser } = require('./browser-connect');
+const fs = require('fs');
+const path = require('path');
+
+async function extractOne(page, { url, selector, click, nth = 0 }) {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto(url, { waitUntil: 'networkidle', timeout: 15000 });
+
+  if (click) {
+    const trigger = page.locator(click).first();
+    await trigger.waitFor({ state: 'visible', timeout: 8000 });
+    await trigger.click();
+    await page.waitForTimeout(400);
+  }
+
+  const root = selector ? page.locator(selector).nth(nth) : page.locator('body');
+
+  await root.waitFor({ state: 'visible', timeout: 8000 });
+
+  return await root.evaluate((el) => {
+    const lines = (el.innerText ?? '')
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0);
+
+    const inputs = [...el.querySelectorAll('input, textarea')]
+      .map((i) => i.placeholder || i.value || '')
+      .filter(Boolean);
+
+    const buttons = [...el.querySelectorAll('button')]
+      .map((b) => b.innerText?.trim())
+      .filter((t) => t && t.length > 0 && t.length < 60);
+
+    const headings = [...el.querySelectorAll('h1,h2,h3,h4,h5,h6')]
+      .map((h) => h.innerText?.trim())
+      .filter(Boolean);
+
+    const labels = [...el.querySelectorAll('label')]
+      .map((l) => l.innerText?.trim())
+      .filter(Boolean);
+
+    const icons = [...el.querySelectorAll('svg')]
+      .map((svg) => {
+        const classes = svg.getAttribute('class') || '';
+        const lucideClass = classes.split(' ').find((c) => c.startsWith('lucide-'));
+        if (!lucideClass) return null;
+        const kebab = lucideClass.replace('lucide-', '');
+        const name = kebab
+          .split('-')
+          .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+          .join('');
+        const sizeMatch = classes.match(/\b[hw]-(\d+(?:\.\d+)?)\b/);
+        const size = sizeMatch ? parseFloat(sizeMatch[1]) * 4 : 24;
+        return { name, size };
+      })
+      .filter(Boolean);
+
+    return {
+      full: el.innerText?.trim().slice(0, 500) ?? '',
+      lines,
+      inputs,
+      buttons,
+      headings,
+      labels,
+      icons,
+    };
+  });
+}
+
+const args = process.argv.slice(2);
+
+const batchIdx = args.indexOf('--batch');
+if (batchIdx !== -1) {
+  const manifestPath = args[batchIdx + 1];
+  if (!manifestPath) {
+    process.stderr.write('Usage: node extract-text.js --batch manifest.json\n');
+    process.exit(1);
+  }
+
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+
+  (async () => {
+    const browser = await getBrowser();
+    const page = await browser.newPage();
+    let captured = 0,
+      failed = 0;
+
+    for (const entry of manifest) {
+      try {
+        const result = await extractOne(page, entry);
+        if (entry.output) {
+          fs.mkdirSync(path.dirname(entry.output), { recursive: true });
+          fs.writeFileSync(entry.output, JSON.stringify(result, null, 2));
+          console.log(`Extracted: ${entry.output}`);
+        }
+        captured++;
+      } catch (err) {
+        process.stderr.write(
+          `Failed ${entry.output || entry.url}: ${err.message.split('\n')[0]}\n`
+        );
+        failed++;
+      }
+    }
+
+    await browser.close();
+    console.log(`\nBatch complete: ${captured} extracted, ${failed} failed`);
+  })().catch((err) => {
+    process.stderr.write('extract-text.js error: ' + err.message + '\n');
+    process.exit(1);
+  });
+} else {
+  if (args.length < 1) {
+    process.stderr.write(
+      'Usage: node extract-text.js <url> --selector "css" [--click "css"] [--nth N]\n'
+    );
+    process.exit(1);
+  }
+
+  const url = args[0];
+  let selector = null,
+    clickSel = null,
+    nthIndex = 0;
+
+  for (let i = 1; i < args.length; i++) {
+    if (args[i] === '--selector') selector = args[++i];
+    else if (args[i] === '--click') clickSel = args[++i];
+    else if (args[i] === '--nth') nthIndex = Number(args[++i]);
+  }
+
+  (async () => {
+    const browser = await getBrowser();
+    const page = await browser.newPage();
+    const result = await extractOne(page, { url, selector, click: clickSel, nth: nthIndex });
+    await browser.close();
+    process.stdout.write(JSON.stringify(result, null, 2));
+  })().catch((err) => {
+    process.stderr.write('extract-text.js error: ' + err.message + '\n');
+    process.exit(1);
+  });
+}

--- a/plugins/figma-from-code/skills/figma-from-code/10-validator/inspect-styles.js
+++ b/plugins/figma-from-code/skills/figma-from-code/10-validator/inspect-styles.js
@@ -1,0 +1,384 @@
+/**
+ * Live component inspector for figma-from-code-build-component
+ *
+ * Connects to the running dev server via Playwright, locates a component,
+ * extracts computed styles, and captures screenshots for interactive states
+ * (hover, focus, disabled) when they have distinct visual treatments.
+ *
+ * Usage — single component:
+ *   node inspect-styles.js <url> --selector "css" [--nth N] --output dir/
+ *
+ * Usage — batch mode:
+ *   node inspect-styles.js --batch manifest.json
+ *
+ *   manifest.json format:
+ *   [
+ *     {"url": "http://...", "selector": "css", "nth": 0, "output": "dir/", "states": ["hover","focus","disabled"]},
+ *     ...
+ *   ]
+ *
+ * Output per component (written to output dir):
+ *   computed-styles.json  — key CSS properties from getComputedStyle, plus
+ *                           layoutContext { element, parent, viewport, derived }
+ *                           used by build-component step 1a to detect intended
+ *                           consumer width (parent ≫ element ⇒ fill:<parentWidth>)
+ *   state-hover.png       — screenshot with :hover emulated (only if visually different)
+ *   state-focus.png       — screenshot with :focus-visible emulated (only if visually different)
+ *   state-disabled.png    — screenshot with [disabled] set (only if visually different)
+ *   states.json           — which states were captured and which were skipped
+ */
+
+const { getBrowser } = require('./browser-connect');
+const fs = require('fs');
+const path = require('path');
+
+const SCRIPT_TIMEOUT = 90000;
+const _scriptTimer = setTimeout(() => {
+  console.error('inspect-styles.js: script timeout after 90s — exiting');
+  process.exit(124);
+}, SCRIPT_TIMEOUT);
+_scriptTimer.unref();
+
+const STYLE_PROPERTIES = [
+  'color',
+  'backgroundColor',
+  'borderColor',
+  'borderWidth',
+  'borderStyle',
+  'borderRadius',
+  'fontSize',
+  'fontWeight',
+  'fontFamily',
+  'lineHeight',
+  'letterSpacing',
+  'padding',
+  'paddingTop',
+  'paddingRight',
+  'paddingBottom',
+  'paddingLeft',
+  'margin',
+  'marginTop',
+  'marginRight',
+  'marginBottom',
+  'marginLeft',
+  'gap',
+  'rowGap',
+  'columnGap',
+  'display',
+  'flexDirection',
+  'alignItems',
+  'justifyContent',
+  'width',
+  'height',
+  'minWidth',
+  'minHeight',
+  'maxWidth',
+  'maxHeight',
+  'boxShadow',
+  'opacity',
+  'textDecoration',
+  'textTransform',
+  'overflow',
+  'position',
+  'cursor',
+  'outline',
+  'outlineOffset',
+  'transition',
+];
+
+const DEFAULT_STATES = ['hover', 'focus', 'disabled'];
+
+async function getComputedStyles(element) {
+  return await element.evaluate((el, props) => {
+    const cs = window.getComputedStyle(el);
+    const styles = {};
+    for (const prop of props) {
+      styles[prop] = cs.getPropertyValue(
+        prop.replace(/[A-Z]/g, (m) => '-' + m.toLowerCase())
+      );
+    }
+
+    const cssVars = {};
+    const rootStyles = window.getComputedStyle(document.documentElement);
+    const inlineStyle = el.getAttribute('style') || '';
+    const classAttr = el.getAttribute('class') || '';
+    cssVars._classes = classAttr;
+    cssVars._inlineStyle = inlineStyle;
+
+    return { styles, cssVars };
+  }, STYLE_PROPERTIES);
+}
+
+async function getLayoutContext(element) {
+  return await element.evaluate((el) => {
+    const rect = el.getBoundingClientRect();
+    const elementInfo = {
+      offsetWidth: el.offsetWidth,
+      offsetHeight: el.offsetHeight,
+      clientWidth: el.clientWidth,
+      clientHeight: el.clientHeight,
+      boundingRect: {
+        width: Math.round(rect.width),
+        height: Math.round(rect.height),
+        top: Math.round(rect.top),
+        left: Math.round(rect.left),
+      },
+    };
+
+    const parent = el.parentElement;
+    let parentInfo = null;
+    if (parent) {
+      const pcs = window.getComputedStyle(parent);
+      const prect = parent.getBoundingClientRect();
+      parentInfo = {
+        tag: parent.tagName.toLowerCase(),
+        id: parent.id || null,
+        classes: parent.getAttribute('class') || '',
+        offsetWidth: parent.offsetWidth,
+        offsetHeight: parent.offsetHeight,
+        clientWidth: parent.clientWidth,
+        boundingRect: {
+          width: Math.round(prect.width),
+          height: Math.round(prect.height),
+        },
+        display: pcs.display,
+        flexDirection: pcs.flexDirection,
+        paddingLeft: pcs.paddingLeft,
+        paddingRight: pcs.paddingRight,
+        paddingTop: pcs.paddingTop,
+        paddingBottom: pcs.paddingBottom,
+        gap: pcs.gap,
+      };
+    }
+
+    const viewport = {
+      width: window.innerWidth,
+      height: window.innerHeight,
+    };
+
+    const elementFillsParent =
+      parent && parent.clientWidth > 0
+        ? Math.abs(el.offsetWidth - (parent.clientWidth -
+            (parseFloat(window.getComputedStyle(parent).paddingLeft) || 0) -
+            (parseFloat(window.getComputedStyle(parent).paddingRight) || 0))) <= 2
+        : false;
+
+    const hugRatio =
+      parent && parent.clientWidth > 0 ? el.offsetWidth / parent.clientWidth : null;
+
+    return {
+      element: elementInfo,
+      parent: parentInfo,
+      viewport,
+      derived: {
+        elementFillsParent,
+        elementToParentRatio: hugRatio,
+      },
+    };
+  });
+}
+
+async function captureBaseScreenshot(element, outputPath) {
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  await element.screenshot({ path: outputPath });
+  return outputPath;
+}
+
+async function getStyleFingerprint(element) {
+  return await element.evaluate((el) => {
+    const cs = window.getComputedStyle(el);
+    return [
+      cs.backgroundColor,
+      cs.color,
+      cs.borderColor,
+      cs.boxShadow,
+      cs.outline,
+      cs.opacity,
+      cs.textDecoration,
+      cs.transform,
+    ].join('|');
+  });
+}
+
+async function inspectOne(page, { url, selector, nth = 0, output, states }) {
+  const statesToCheck = states || DEFAULT_STATES;
+  fs.mkdirSync(output, { recursive: true });
+
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto(url, { waitUntil: 'networkidle', timeout: 15000 });
+
+  const element = page.locator(selector).nth(nth);
+  await element.waitFor({ state: 'visible', timeout: 8000 });
+
+  // Capture a baseline app screenshot of the located element so the compare
+  // stage has a real visual reference. Many components are skipped by
+  // pre-capture (no selector in component-map) but ARE resolved here during
+  // live inspection — without this they would build blind (no_app_reference)
+  // and never enter the fix loop. Don't overwrite a pre-capture app.png (its
+  // full-page-context shot is preferred when present).
+  const appShotPath = path.join(output, 'app.png');
+  if (!fs.existsSync(appShotPath)) {
+    try {
+      await captureBaseScreenshot(element, appShotPath);
+    } catch (err) {
+      console.error(`Base screenshot failed for ${output}: ${err.message.split('\n')[0]}`);
+    }
+  }
+
+  const { styles, cssVars } = await getComputedStyles(element);
+  const layoutContext = await getLayoutContext(element);
+  const stylesPath = path.join(output, 'computed-styles.json');
+  fs.writeFileSync(
+    stylesPath,
+    JSON.stringify({ styles, cssVars, layoutContext }, null, 2)
+  );
+
+  const baseFp = await getStyleFingerprint(element);
+
+  const stateResults = {};
+
+  for (const state of statesToCheck) {
+    try {
+      let captured = false;
+      const statePath = path.join(output, `state-${state}.png`);
+
+      if (state === 'hover') {
+        await element.hover();
+        await page.waitForTimeout(300);
+        const fp = await getStyleFingerprint(element);
+        if (fp !== baseFp) {
+          await element.screenshot({ path: statePath });
+          const hoverStyles = await getComputedStyles(element);
+          stateResults.hover = { captured: true, path: statePath, styles: hoverStyles.styles };
+          captured = true;
+        }
+        await page.mouse.move(0, 0);
+        await page.waitForTimeout(200);
+      } else if (state === 'focus') {
+        await element.focus();
+        await page.waitForTimeout(300);
+        const fp = await getStyleFingerprint(element);
+        if (fp !== baseFp) {
+          await element.screenshot({ path: statePath });
+          const focusStyles = await getComputedStyles(element);
+          stateResults.focus = { captured: true, path: statePath, styles: focusStyles.styles };
+          captured = true;
+        }
+        await page.evaluate(() => {
+          if (document.activeElement) document.activeElement.blur();
+        });
+        await page.waitForTimeout(200);
+      } else if (state === 'disabled') {
+        const tagName = await element.evaluate((el) => el.tagName.toLowerCase());
+        const supportsDisabled = ['button', 'input', 'select', 'textarea', 'fieldset'].includes(
+          tagName
+        );
+        if (supportsDisabled) {
+          await element.evaluate((el) => el.setAttribute('disabled', ''));
+          await page.waitForTimeout(300);
+          const fp = await getStyleFingerprint(element);
+          if (fp !== baseFp) {
+            await element.screenshot({ path: statePath });
+            const disabledStyles = await getComputedStyles(element);
+            stateResults.disabled = {
+              captured: true,
+              path: statePath,
+              styles: disabledStyles.styles,
+            };
+            captured = true;
+          }
+          await element.evaluate((el) => el.removeAttribute('disabled'));
+          await page.waitForTimeout(200);
+        }
+      }
+
+      if (!captured && !stateResults[state]) {
+        stateResults[state] = { captured: false, reason: 'no visual difference from default' };
+      }
+    } catch (err) {
+      stateResults[state] = { captured: false, reason: err.message.split('\n')[0] };
+    }
+  }
+
+  const statesPath = path.join(output, 'states.json');
+  fs.writeFileSync(statesPath, JSON.stringify(stateResults, null, 2));
+
+  const capturedCount = Object.values(stateResults).filter((s) => s.captured).length;
+  console.log(
+    `Inspected: ${output} — ${Object.keys(styles).length} properties, ${capturedCount} state screenshots`
+  );
+
+  return { stylesPath, stateResults, capturedCount };
+}
+
+const args = process.argv.slice(2);
+
+const batchIdx = args.indexOf('--batch');
+if (batchIdx !== -1) {
+  const manifestPath = args[batchIdx + 1];
+  if (!manifestPath) {
+    console.error('Usage: node inspect-styles.js --batch manifest.json');
+    process.exit(1);
+  }
+
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+
+  (async () => {
+    const browser = await getBrowser();
+    const page = await browser.newPage();
+    const results = { inspected: [], failed: [] };
+
+    for (const entry of manifest) {
+      try {
+        const result = await inspectOne(page, entry);
+        results.inspected.push({ output: entry.output, ...result });
+      } catch (err) {
+        console.error(`Failed ${entry.output}: ${err.message.split('\n')[0]}`);
+        results.failed.push({ output: entry.output, error: err.message.split('\n')[0] });
+      }
+    }
+
+    await browser.close();
+    console.log(
+      `\nBatch complete: ${results.inspected.length} inspected, ${results.failed.length} failed`
+    );
+  })().catch((err) => {
+    console.error(err.message.split('\n')[0]);
+    process.exit(1);
+  });
+} else {
+  if (args.length < 2) {
+    console.error(
+      'Usage: node inspect-styles.js <url> --selector "css" [--nth N] --output dir/ [--states hover,focus,disabled]'
+    );
+    process.exit(1);
+  }
+
+  const url = args[0];
+  let selector = null,
+    nthIndex = 0,
+    outputDir = null,
+    states = null;
+
+  for (let i = 1; i < args.length; i++) {
+    if (args[i] === '--selector') selector = args[++i];
+    else if (args[i] === '--nth') nthIndex = Number(args[++i]);
+    else if (args[i] === '--output') outputDir = args[++i];
+    else if (args[i] === '--states') states = args[++i].split(',');
+  }
+
+  if (!selector || !outputDir) {
+    console.error('--selector and --output are required');
+    process.exit(1);
+  }
+
+  (async () => {
+    const browser = await getBrowser();
+    const page = await browser.newPage();
+    await inspectOne(page, { url, selector, nth: nthIndex, output: outputDir, states });
+    await browser.close();
+  })().catch((err) => {
+    console.error(err.message.split('\n')[0]);
+    process.exit(1);
+  });
+}

--- a/plugins/figma-from-code/skills/figma-from-code/10-validator/library-filter.js
+++ b/plugins/figma-from-code/skills/figma-from-code/10-validator/library-filter.js
@@ -1,0 +1,39 @@
+const LIBRARY_PATTERNS = [
+  /^_/,
+  /^Suspense$/,
+  /^Fragment$/,
+  /^Provider$/,
+  /^Consumer$/,
+  /^Context$/,
+  /^Outlet$/,
+  /^Route$/,
+  /^Router$/,
+  /^Routes$/,
+  /^BrowserRouter$/,
+  /^MemoryRouter$/,
+  /^QueryClientProvider$/,
+  /^Hydrate$/,
+  /^ThemeProvider$/,
+  /^StrictMode$/,
+  /^Profiler$/,
+  /^ForwardRef$/,
+  /^Memo$/,
+  /^Lazy$/,
+  /^ErrorBoundary$/,
+  /^HelmetProvider$/,
+  /^\$/,
+  /^[a-z]/,
+  /^(Presence|AnimatePresence|MotionComponent)$/,
+  /^Primitive\./,
+  /^(Slot|SlotClone|Primitive)$/,
+  /^(Portal|Dismissable|FocusScope|DismissableLayer)$/,
+  /^(Collection|ItemSlots)/,
+  /^ReactQueryDevtools/,
+  /^(Toaster|Sonner)$/,
+];
+
+function isLibraryComponent(name) {
+  return LIBRARY_PATTERNS.some(p => p.test(name));
+}
+
+module.exports = { isLibraryComponent, LIBRARY_PATTERNS };

--- a/plugins/figma-from-code/skills/figma-from-code/10-validator/map-components.js
+++ b/plugins/figma-from-code/skills/figma-from-code/10-validator/map-components.js
@@ -1,0 +1,569 @@
+/**
+ * Multi-route component mapper with build order computation.
+ *
+ * Visits multiple routes in a single browser session, discovers components
+ * on each page, merges into a unified dependency tree, and computes a
+ * bottom-up build order (leaves first) for Figma component construction.
+ *
+ * Usage:
+ *   node map-components.js <base-url> --routes /,/about,/dashboard [options]
+ *
+ * Options:
+ *   --routes <paths>       Comma-separated route paths (default: /)
+ *   --crawl                Auto-discover routes by following internal links
+ *   --max-crawl <n>        Max pages to crawl (default: 20)
+ *   --output <file.json>   Write JSON results to file
+ *   --markdown <file.md>   Write human-readable tree + build order
+ *   --include-lib          Include library/internal components
+ *   --click <selector>     Click an element on every page before discovery
+ *   --wait <ms>            Extra wait after each page load (default: 0)
+ */
+
+const { getBrowser } = require('./browser-connect');
+const { discoverOnPage } = require('./detect-components');
+const { isLibraryComponent } = require('./library-filter');
+const fs = require('fs');
+const path = require('path');
+
+const DYNAMIC_SEGMENT = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$|^[0-9a-f]{24}$|^\d+$/i;
+
+function normalizeRoute(route) {
+  return '/' + route.split('/').filter(Boolean).map(seg => DYNAMIC_SEGMENT.test(seg) ? ':id' : seg).join('/');
+}
+
+function normalizeRoutes(routes) {
+  return [...new Set(routes.map(normalizeRoute))].sort();
+}
+
+const args = process.argv.slice(2);
+if (args.length < 1 || args[0].startsWith('--')) {
+  console.error('Usage: node map-components.js <base-url> --routes /,/about [--crawl] [--output file.json] [--markdown file.md]');
+  process.exit(1);
+}
+
+const baseUrl = args[0].replace(/\/$/, '');
+const opts = {
+  routes: ['/'],
+  crawl: false,
+  maxCrawl: 20,
+  output: null,
+  markdown: null,
+  includeLib: false,
+  click: null,
+  wait: 0,
+};
+
+for (let i = 1; i < args.length; i++) {
+  switch (args[i]) {
+    case '--routes': opts.routes = args[++i].split(',').map(r => r.trim()); break;
+    case '--crawl': opts.crawl = true; break;
+    case '--max-crawl': opts.maxCrawl = Number(args[++i]); break;
+    case '--output': opts.output = args[++i]; break;
+    case '--markdown': opts.markdown = args[++i]; break;
+    case '--include-lib': opts.includeLib = true; break;
+    case '--click': opts.click = args[++i]; break;
+    case '--wait': opts.wait = Number(args[++i]); break;
+  }
+}
+
+(async () => {
+  const browser = await getBrowser();
+  const page = await browser.newPage();
+  await page.setViewportSize({ width: 1440, height: 900 });
+
+  let routes = [...opts.routes];
+
+  if (opts.crawl) {
+    console.error('Crawling for routes...');
+    await page.goto(baseUrl + routes[0], { waitUntil: 'networkidle', timeout: 15000 });
+    const discovered = await page.evaluate((base) => {
+      const origin = new URL(base).origin;
+      return [...new Set(
+        [...document.querySelectorAll('a[href]')]
+          .map(a => {
+            try { return new URL(a.href, origin); } catch { return null; }
+          })
+          .filter(u => u && u.origin === origin)
+          .map(u => u.pathname)
+      )];
+    }, baseUrl);
+    routes = [...new Set([...routes, ...discovered])].slice(0, opts.maxCrawl);
+    console.error(`Found ${routes.length} routes: ${routes.join(', ')}`);
+  }
+
+  // ── Discover components on each route ──────────────────────────
+
+  const perRoute = [];
+  let framework = null;
+
+  for (const route of routes) {
+    const fullUrl = baseUrl + route;
+    console.error(`Scanning ${route}...`);
+
+    try {
+      await page.goto(fullUrl, { waitUntil: 'networkidle', timeout: 15000 });
+
+      if (opts.click) {
+        try {
+          const trigger = page.locator(opts.click).first();
+          await trigger.waitFor({ state: 'visible', timeout: 3000 });
+          await trigger.click();
+          await page.waitForTimeout(400);
+        } catch {}
+      }
+
+      if (opts.wait > 0) await page.waitForTimeout(opts.wait);
+
+      const result = await discoverOnPage(page);
+      if (!framework) framework = result.framework;
+      perRoute.push({ route, ...result });
+    } catch (err) {
+      console.error(`  Failed: ${err.message.split('\n')[0]}`);
+    }
+  }
+
+  // ── Merge: unified dependency graph ────────────────────────────
+
+  const edges = new Map();
+  const allComponents = new Map();
+
+  function extractEdges(nodes, parent) {
+    for (const node of nodes) {
+      const name = node.name;
+      if (!edges.has(name)) edges.set(name, new Set());
+      if (parent) {
+        if (!edges.has(parent)) edges.set(parent, new Set());
+        edges.get(parent).add(name);
+      }
+      extractEdges(node.children, name);
+    }
+  }
+
+  for (const { route, components, tree } of perRoute) {
+    extractEdges(tree, null);
+
+    for (const comp of components) {
+      if (!allComponents.has(comp.name)) {
+        allComponents.set(comp.name, { name: comp.name, routes: [], selectors: [], instances: 0 });
+      }
+      const entry = allComponents.get(comp.name);
+      if (!entry.routes.includes(route)) entry.routes.push(route);
+      entry.instances += comp.instances;
+      for (const el of comp.elements) {
+        if (el.visible && !entry.selectors.some(s => s.selector === el.selector)) {
+          entry.selectors.push({ selector: el.selector, route, box: el.box });
+        }
+      }
+    }
+  }
+
+  // ── Filter library components ──────────────────────────────────
+
+  if (!opts.includeLib) {
+    for (const name of [...edges.keys()]) {
+      if (isLibraryComponent(name)) {
+        edges.delete(name);
+        allComponents.delete(name);
+      }
+    }
+    for (const [, children] of edges) {
+      for (const child of [...children]) {
+        if (isLibraryComponent(child)) children.delete(child);
+      }
+    }
+  }
+
+  // ── Disambiguate component name collisions ─────────────────────
+  // A name collision occurs when the same React display name (e.g. "Header")
+  // is used for both a root-level component AND a nested sub-component inside
+  // a different parent. In allComponents both map to the same key, so the
+  // second one overwrites the first's node ID in the built-components map.
+  //
+  // Detection: build a reverse-parent map from edges. If a name appears as
+  // a child of some parent, AND that same name also appears as a top-level
+  // component (nothing points to it), there is a collision. The nested one
+  // gets renamed to "ParentName/ChildName" in edges and allComponents.
+  //
+  // Genuine reuse (Button, Icon appearing under many parents) is NOT a
+  // collision — those components are NOT also top-level roots.
+
+  {
+    // Build: parentOf[child] = Set of parent names that have this child
+    const parentOf = new Map();
+    for (const [parent, children] of edges) {
+      for (const child of children) {
+        if (!parentOf.has(child)) parentOf.set(child, new Set());
+        parentOf.get(child).add(parent);
+      }
+    }
+
+    // Top-level names: present in allComponents but NOT referenced as a child
+    // by any other component in edges.
+    const topLevel = new Set();
+    for (const name of allComponents.keys()) {
+      if (!parentOf.has(name) || parentOf.get(name).size === 0) {
+        topLevel.add(name);
+      }
+    }
+
+    // Find names that are BOTH a top-level component AND a child of something.
+    // Those are genuine collisions: the same display name used for two distinct
+    // visual components at different tree depths.
+    //
+    // We also handle the case where a name appears as a child of multiple
+    // parents AND appears in allComponents, but is NOT top-level — this is
+    // genuine reuse (skip it).
+    //
+    // For each collision: the top-level entry keeps its name; every nested
+    // occurrence (parent → name edge) gets renamed to "Parent/name".
+    const renames = new Map(); // oldName -> Map<parentName, qualifiedName>
+
+    for (const name of allComponents.keys()) {
+      const parents = parentOf.get(name);
+      if (!parents || parents.size === 0) continue; // pure top-level, no collision
+      if (!topLevel.has(name)) continue; // not also a top-level root, genuine reuse
+
+      // This name is BOTH a top-level root AND a nested child — collision!
+      // Skip very common components that would appear everywhere (>3 parents
+      // and NOT a root = genuine reuse, already excluded above; but guard anyway).
+      if (parents.size > 3) continue;
+
+      const parentRenames = new Map();
+      for (const parentName of parents) {
+        const qualifiedName = `${parentName}/${name}`;
+        parentRenames.set(parentName, qualifiedName);
+      }
+      renames.set(name, parentRenames);
+    }
+
+    for (const [oldName, parentRenames] of renames) {
+      for (const [parentName, qualifiedName] of parentRenames) {
+        // 1. Rewrite the parent's child list in edges
+        const parentChildren = edges.get(parentName);
+        if (parentChildren && parentChildren.has(oldName)) {
+          parentChildren.delete(oldName);
+          parentChildren.add(qualifiedName);
+        }
+
+        // 2. Add an edges entry for the qualified name (copy children from old)
+        if (!edges.has(qualifiedName)) {
+          const oldChildren = edges.get(oldName);
+          edges.set(qualifiedName, oldChildren ? new Set(oldChildren) : new Set());
+        }
+
+        // 3. Add an allComponents entry for the qualified name
+        if (!allComponents.has(qualifiedName)) {
+          const oldEntry = allComponents.get(oldName);
+          if (oldEntry) {
+            allComponents.set(qualifiedName, { ...oldEntry, name: qualifiedName });
+          }
+        }
+
+        console.error(`  [disambiguate] "${oldName}" under "${parentName}" → "${qualifiedName}"`);
+      }
+
+      // The original top-level entry in allComponents and edges keeps its name.
+      // The nested qualified entries now live separately.
+    }
+  }
+
+  // ── Compute build tiers (topological sort, leaves first) ───────
+
+  const childrenOf = new Map();
+  for (const [parent, kids] of edges) {
+    childrenOf.set(parent, new Set(kids));
+  }
+  for (const name of allComponents.keys()) {
+    if (!childrenOf.has(name)) childrenOf.set(name, new Set());
+  }
+
+  const tiers = [];
+  const assigned = new Set();
+
+  while (assigned.size < childrenOf.size) {
+    const tier = [];
+    for (const [name, children] of childrenOf) {
+      if (assigned.has(name)) continue;
+      const unassignedChildren = [...children].filter(c => !assigned.has(c) && childrenOf.has(c));
+      if (unassignedChildren.length === 0) {
+        tier.push(name);
+      }
+    }
+    if (tier.length === 0) {
+      const remaining = [...childrenOf.keys()].filter(n => !assigned.has(n));
+      tier.push(...remaining);
+    }
+    tier.sort();
+    tiers.push(tier);
+    for (const name of tier) assigned.add(name);
+  }
+
+  // ── Build merged tree (deduplicated) ───────────────────────────
+
+  function mergeTreesFromRoutes(perRouteData) {
+    const merged = new Map();
+
+    function addNodes(nodes, parent) {
+      for (const node of nodes) {
+        const key = parent ? `${parent}→${node.name}` : node.name;
+        if (!merged.has(key)) {
+          merged.set(key, { name: node.name, parent, childKeys: new Set() });
+        }
+        for (const child of node.children) {
+          merged.get(key).childKeys.add(parent ? `${node.name}→${child.name}` : `${node.name}→${child.name}`);
+          addNodes([child], node.name);
+        }
+      }
+    }
+
+    for (const { tree } of perRouteData) {
+      addNodes(tree, null);
+    }
+
+    function buildMergedTree(parentName, ancestors = new Set()) {
+      const result = [];
+      for (const [key, entry] of merged) {
+        if (entry.parent === parentName) {
+          if (!opts.includeLib && isLibraryComponent(entry.name)) continue;
+          if (ancestors.has(entry.name)) continue;
+          const nextAncestors = new Set(ancestors);
+          nextAncestors.add(entry.name);
+          result.push({
+            name: entry.name,
+            children: buildMergedTree(entry.name, nextAncestors),
+          });
+        }
+      }
+      const seen = new Set();
+      return result.filter(n => {
+        if (seen.has(n.name)) return false;
+        seen.add(n.name);
+        return true;
+      });
+    }
+
+    return buildMergedTree(null);
+  }
+
+  const mergedTree = mergeTreesFromRoutes(perRoute);
+
+  // ── Assemble output ────────────────────────────────────────────
+
+  const output = {
+    baseUrl,
+    routes,
+    framework,
+    scannedAt: new Date().toISOString(),
+    componentCount: allComponents.size,
+    tiers: tiers.map((names, i) => ({
+      tier: i + 1,
+      label: i === 0 ? 'Leaf components (no children)'
+        : i === tiers.length - 1 ? 'Top-level layouts'
+        : `Depends on tier ${i} and below`,
+      components: names.map(n => {
+        const comp = allComponents.get(n);
+        const children = [...(childrenOf.get(n) || [])];
+        return {
+          name: n,
+          children: children.length > 0 ? children : undefined,
+          routes: comp?.routes,
+          selector: comp?.selectors?.[0]?.selector,
+          instances: comp?.instances || 0,
+        };
+      }),
+    })),
+    tree: mergedTree,
+  };
+
+  // ── Console output ─────────────────────────────────────────────
+
+  console.log(`\nFramework: ${framework?.name || 'unknown'} ${framework?.generation || ''}${framework?.version ? ' v' + framework.version : ''}`);
+  console.log(`Routes scanned: ${routes.length}`);
+  console.log(`Components found: ${allComponents.size}`);
+  console.log(`Build tiers: ${tiers.length}\n`);
+
+  for (let i = 0; i < tiers.length; i++) {
+    const label = i === 0 ? 'Leaf components' : i === tiers.length - 1 ? 'Top-level layouts' : `Tier ${i + 1}`;
+    console.log(`  ${label}: ${tiers[i].join(', ')}`);
+  }
+
+  // ── Write JSON ─────────────────────────────────────────────────
+
+  if (opts.output) {
+    fs.mkdirSync(path.dirname(path.resolve(opts.output)), { recursive: true });
+    fs.writeFileSync(opts.output, JSON.stringify(output, null, 2));
+    console.log(`\nJSON: ${opts.output}`);
+  }
+
+  // ── Write Markdown ─────────────────────────────────────────────
+
+  if (opts.markdown) {
+    const lines = [];
+    lines.push(`# Component Map — ${baseUrl}`);
+    lines.push('');
+    const displayRoutes = normalizeRoutes(routes);
+    lines.push(`**Framework:** ${framework?.name || 'unknown'} ${framework?.generation || ''}${framework?.version ? ' v' + framework.version : ''}`);
+    lines.push(`**Routes scanned:** ${displayRoutes.join(', ')}  _(${routes.length} pages visited)_`);
+    lines.push(`**Components:** ${allComponents.size}`);
+    lines.push(`**Generated:** ${new Date().toISOString()}`);
+    lines.push('');
+
+    lines.push('## Component Hierarchy');
+    lines.push('');
+    lines.push('```mermaid');
+    lines.push('graph TD');
+    const mermaidEdges = new Set();
+    const mermaidNodes = new Set();
+    function sanitizeId(name) { return name.replace(/[^a-zA-Z0-9]/g, '_'); }
+    function collectMermaidEdges(nodes, parent) {
+      for (const node of nodes) {
+        const id = sanitizeId(node.name);
+        mermaidNodes.add(id);
+        if (parent) {
+          const parentId = sanitizeId(parent);
+          const edgeKey = `${parentId} --> ${id}`;
+          if (!mermaidEdges.has(edgeKey)) {
+            mermaidEdges.add(edgeKey);
+          }
+        }
+        collectMermaidEdges(node.children, node.name);
+      }
+    }
+    collectMermaidEdges(mergedTree, null);
+    const tierLookup = new Map();
+    for (let i = 0; i < tiers.length; i++) {
+      for (const name of tiers[i]) tierLookup.set(name, i + 1);
+    }
+    const tierStyles = [
+      'fill:#e8f5e9,stroke:#43a047',
+      'fill:#e3f2fd,stroke:#1e88e5',
+      'fill:#fff3e0,stroke:#fb8c00',
+      'fill:#fce4ec,stroke:#e53935',
+      'fill:#f3e5f5,stroke:#8e24aa',
+      'fill:#e0f7fa,stroke:#00897b',
+      'fill:#fff9c4,stroke:#f9a825',
+      'fill:#efebe9,stroke:#6d4c41',
+    ];
+    for (const id of mermaidNodes) {
+      const origName = [...allComponents.keys()].find(n => sanitizeId(n) === id) || id;
+      lines.push(`    ${id}["${origName}"]`);
+    }
+    for (const edge of mermaidEdges) {
+      lines.push(`    ${edge}`);
+    }
+    for (const [name] of allComponents) {
+      const tier = tierLookup.get(name);
+      if (tier) {
+        const style = tierStyles[(tier - 1) % tierStyles.length];
+        lines.push(`    style ${sanitizeId(name)} ${style}`);
+      }
+    }
+    lines.push('```');
+    lines.push('');
+    lines.push('> Colors indicate build tier: ');
+    const tierCount = tiers.length;
+    const legendParts = [];
+    for (let i = 0; i < tierCount; i++) {
+      const label = i === 0 ? 'Leaf' : i === tierCount - 1 ? 'Layout' : `Tier ${i + 1}`;
+      const color = tierStyles[i % tierStyles.length].match(/fill:([^,]+)/)?.[1] || '';
+      legendParts.push(`**${label}** (Tier ${i + 1})`);
+    }
+    lines.push(`> ${legendParts.join(' → ')}`);
+    lines.push('');
+
+    lines.push('## Component Details');
+    lines.push('');
+    lines.push('| Component | Tier | Routes | Instances |');
+    lines.push('|-----------|------|--------|-----------|');
+    for (let i = 0; i < tiers.length; i++) {
+      for (const name of tiers[i]) {
+        const comp = allComponents.get(name);
+        const compRoutes = normalizeRoutes(comp?.routes || []).join(', ');
+        lines.push(`| ${name} | ${i + 1} | ${compRoutes} | ${comp?.instances || 0} |`);
+      }
+    }
+
+    lines.push('');
+    lines.push('## Component Instances by Page');
+    lines.push('');
+
+    const routeGroups = new Map();
+    for (const entry of perRoute) {
+      const normalized = normalizeRoute(entry.route);
+      if (!routeGroups.has(normalized)) routeGroups.set(normalized, entry);
+    }
+
+    function formatNodeLabel(node) {
+      const propEntries = Object.entries(node.props || {});
+      if (propEntries.length === 0) return node.name;
+      const propsStr = propEntries.map(([k, v]) =>
+        typeof v === 'boolean' ? (v ? k : `${k}={false}`) : `${k}="${v}"`
+      ).join(' ');
+      return `\`<${node.name} ${propsStr}>\``;
+    }
+
+    function printPageTree(nodes, depth) {
+      const indent = '    '.repeat(depth);
+      for (const node of nodes) {
+        if (!opts.includeLib && isLibraryComponent(node.name)) {
+          printPageTree(node.children || [], depth);
+          continue;
+        }
+        lines.push(`${indent}- [ ] ${formatNodeLabel(node)}`);
+        printPageTree(node.children || [], depth + 1);
+      }
+    }
+
+    for (const [normalized, entry] of routeGroups) {
+      lines.push(`### ${normalized}`);
+      lines.push('');
+      printPageTree(entry.tree || [], 0);
+      lines.push('');
+    }
+
+    lines.push('## Component Variations');
+    lines.push('');
+
+    const variations = new Map();
+    function collectVariations(nodes) {
+      for (const node of nodes) {
+        if (!opts.includeLib && isLibraryComponent(node.name)) {
+          collectVariations(node.children || []);
+          continue;
+        }
+        const propEntries = Object.entries(node.props || {});
+        if (propEntries.length > 0) {
+          if (!variations.has(node.name)) variations.set(node.name, new Set());
+          const key = propEntries.map(([k, v]) => `${k}=${v}`).join(', ');
+          variations.get(node.name).add(key);
+        }
+        collectVariations(node.children || []);
+      }
+    }
+    for (const { tree } of perRoute) collectVariations(tree || []);
+
+    if (variations.size > 0) {
+      lines.push('| Component | Visual Props Seen |');
+      lines.push('|-----------|-------------------|');
+      for (const [name, props] of [...variations.entries()].sort()) {
+        const propList = [...props].map(p => `\`${p}\``).join(', ');
+        lines.push(`| ${name} | ${propList} |`);
+      }
+    } else {
+      lines.push('_No visual props detected across scanned pages._');
+    }
+
+    fs.mkdirSync(path.dirname(path.resolve(opts.markdown)), { recursive: true });
+    fs.writeFileSync(opts.markdown, lines.join('\n'));
+    console.log(`Markdown: ${opts.markdown}`);
+  }
+
+  if (!opts.output && !opts.markdown) {
+    process.stdout.write('\n' + JSON.stringify(output, null, 2));
+  }
+
+  await browser.close();
+})().catch(err => {
+  console.error('map-components.js error:', err.message);
+  process.exit(1);
+});

--- a/plugins/figma-from-code/skills/figma-from-code/10-validator/resolve-colors.js
+++ b/plugins/figma-from-code/skills/figma-from-code/10-validator/resolve-colors.js
@@ -1,0 +1,450 @@
+/**
+ * resolve-colors.js
+ *
+ * Pre-computes all CSS custom property colors as sRGB values so that
+ * Phase 3 subagents can look up { r, g, b } directly — no LLM arithmetic.
+ *
+ * Usage:
+ *   node resolve-colors.js <css-file> [--tailwind <tailwind.config.js>] --output <out.json>
+ *
+ * Supports:
+ *   - Hex:               #rgb / #rrggbb / #rrggbbaa
+ *   - HSL (bare):        "240 5.9% 10%"          (shadcn format, no wrapper)
+ *   - HSL (wrapped):     "hsl(240 5.9% 10%)"     or "hsl(240, 5.9%, 10%)"
+ *   - OKLCH (wrapped):   "oklch(0.141 0.005 285.823)"
+ *   - RGB (wrapped):     "rgb(255, 255, 255)"     or "rgb(255 255 255)"
+ *
+ * Output JSON schema:
+ * {
+ *   cssVariables: {
+ *     "--primary": { raw: "...", format: "hex|hsl|oklch|rgb", rgb: { r, g, b } },
+ *     ...
+ *   },
+ *   tailwindMap: {
+ *     "bg-primary": "--primary",
+ *     ...
+ *   }
+ * }
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// ---------------------------------------------------------------------------
+// Color conversion helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Gamma-expand a single sRGB channel value (0-1) to linear light.
+ * @param {number} v
+ * @returns {number}
+ */
+function linearize(v) {
+  return v <= 0.04045 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+}
+
+/**
+ * Apply sRGB gamma compression to a linear-light channel (0-1).
+ * @param {number} v
+ * @returns {number}
+ */
+function gammaCompress(v) {
+  return v <= 0.0031308 ? 12.92 * v : 1.055 * Math.pow(v, 1 / 2.4) - 0.055;
+}
+
+/** Clamp a value to [0, 1]. */
+function clamp01(v) {
+  return Math.max(0, Math.min(1, v));
+}
+
+/**
+ * OKLCH → sRGB
+ * Path: OKLCH → OKLab → LMS (linear) → linear sRGB → sRGB
+ *
+ * @param {number} L   Lightness [0, 1]
+ * @param {number} C   Chroma    [0, ∞)
+ * @param {number} h   Hue       [0, 360) degrees
+ * @returns {{ r: number, g: number, b: number }}  All channels in [0, 1]
+ */
+function oklchToRgb(L, C, h) {
+  const hRad = (h * Math.PI) / 180;
+
+  const a = C * Math.cos(hRad);
+  const b = C * Math.sin(hRad);
+
+  const l_ = L + 0.3963377774 * a + 0.2158037573 * b;
+  const m_ = L - 0.1055613458 * a - 0.0638541728 * b;
+  const s_ = L - 0.0894841775 * a - 1.2914855480 * b;
+
+  const l = l_ * l_ * l_;
+  const m = m_ * m_ * m_;
+  const s = s_ * s_ * s_;
+
+  const rLin =  4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s;
+  const gLin = -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s;
+  const bLin = -0.0041960863 * l - 0.7034186147 * m + 1.7076147010 * s;
+
+  return {
+    r: clamp01(gammaCompress(rLin)),
+    g: clamp01(gammaCompress(gLin)),
+    b: clamp01(gammaCompress(bLin)),
+  };
+}
+
+/**
+ * HSL → sRGB
+ * @param {number} h   Hue       [0, 360)
+ * @param {number} s   Saturation [0, 100]
+ * @param {number} l   Lightness  [0, 100]
+ * @returns {{ r: number, g: number, b: number }}  All channels in [0, 1]
+ */
+function hslToRgb(h, s, l) {
+  const sn = s / 100;
+  const ln = l / 100;
+
+  const c = (1 - Math.abs(2 * ln - 1)) * sn;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = ln - c / 2;
+
+  let r = 0, g = 0, b = 0;
+  if (h < 60)       { r = c; g = x; b = 0; }
+  else if (h < 120) { r = x; g = c; b = 0; }
+  else if (h < 180) { r = 0; g = c; b = x; }
+  else if (h < 240) { r = 0; g = x; b = c; }
+  else if (h < 300) { r = x; g = 0; b = c; }
+  else              { r = c; g = 0; b = x; }
+
+  return {
+    r: clamp01(r + m),
+    g: clamp01(g + m),
+    b: clamp01(b + m),
+  };
+}
+
+/**
+ * Hex → sRGB
+ * Handles #rgb, #rrggbb, #rrggbbaa (alpha channel is discarded).
+ * @param {string} hex
+ * @returns {{ r: number, g: number, b: number } | null}
+ */
+function hexToRgb(hex) {
+  const h = hex.replace('#', '');
+  if (h.length === 3 || h.length === 4) {
+    const r = parseInt(h[0] + h[0], 16);
+    const g = parseInt(h[1] + h[1], 16);
+    const b = parseInt(h[2] + h[2], 16);
+    return { r: r / 255, g: g / 255, b: b / 255 };
+  }
+  if (h.length === 6 || h.length === 8) {
+    const r = parseInt(h.slice(0, 2), 16);
+    const g = parseInt(h.slice(2, 4), 16);
+    const b = parseInt(h.slice(4, 6), 16);
+    return { r: r / 255, g: g / 255, b: b / 255 };
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// CSS parsing helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Remove CSS comments from source text.
+ * @param {string} src
+ * @returns {string}
+ */
+function stripComments(src) {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+/**
+ * Parse all CSS custom properties from :root / [data-theme] / .dark blocks.
+ * Returns a Map of varName → raw value string.
+ * @param {string} css
+ * @returns {Map<string, string>}
+ */
+function parseCssVariables(css) {
+  const result = new Map();
+  const cleaned = stripComments(css);
+
+  const PROP_RE = /--([\w-]+)\s*:\s*([^;]+);/g;
+
+  const rootBlockRE = /(?::root|\[data-theme[^\]]*\]|\.dark|\.light|@layer\s+base\s*\{[^}]*\{)\s*\{([^}]*)\}/gs;
+  let blockMatch;
+  while ((blockMatch = rootBlockRE.exec(cleaned)) !== null) {
+    const block = blockMatch[blockMatch.length - 1];
+    let propMatch;
+    while ((propMatch = PROP_RE.exec(block)) !== null) {
+      const name = '--' + propMatch[1].trim();
+      const value = propMatch[2].trim();
+      result.set(name, value);
+    }
+  }
+
+  if (result.size === 0) {
+    let propMatch;
+    while ((propMatch = PROP_RE.exec(cleaned)) !== null) {
+      const name = '--' + propMatch[1].trim();
+      const value = propMatch[2].trim();
+      result.set(name, value);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Determine the color format and parse raw value string to { r, g, b }.
+ * Returns null if the value is not a recognised color (e.g. a length token).
+ * @param {string} raw
+ * @returns {{ format: string, rgb: { r, g, b } } | null}
+ */
+function parseColor(raw) {
+  const v = raw.trim();
+
+  if (v.startsWith('#')) {
+    const rgb = hexToRgb(v);
+    return rgb ? { format: 'hex', rgb } : null;
+  }
+
+  const oklchMatch = v.match(/^oklch\(\s*([\d.]+%?)\s+([\d.]+)\s+([\d.]+)\s*(?:\/\s*[\d.%]+)?\s*\)$/i);
+  if (oklchMatch) {
+    let L = parseFloat(oklchMatch[1]);
+    if (oklchMatch[1].endsWith('%')) L /= 100;
+    const C = parseFloat(oklchMatch[2]);
+    const h = parseFloat(oklchMatch[3]);
+    return { format: 'oklch', rgb: oklchToRgb(L, C, h) };
+  }
+
+  const hslWrappedMatch = v.match(/^hsl\(\s*([\d.]+)\s*[,\s]\s*([\d.]+)%\s*[,\s]\s*([\d.]+)%\s*(?:\/\s*[\d.%]+)?\s*\)$/i);
+  if (hslWrappedMatch) {
+    const h = parseFloat(hslWrappedMatch[1]);
+    const s = parseFloat(hslWrappedMatch[2]);
+    const l = parseFloat(hslWrappedMatch[3]);
+    return { format: 'hsl', rgb: hslToRgb(h, s, l) };
+  }
+
+  const rgbMatch = v.match(/^rgba?\(\s*([\d.]+)\s*[,\s]\s*([\d.]+)\s*[,\s]\s*([\d.]+)\s*(?:[,/]\s*[\d.%]+)?\s*\)$/i);
+  if (rgbMatch) {
+    return {
+      format: 'rgb',
+      rgb: {
+        r: clamp01(parseFloat(rgbMatch[1]) / 255),
+        g: clamp01(parseFloat(rgbMatch[2]) / 255),
+        b: clamp01(parseFloat(rgbMatch[3]) / 255),
+      },
+    };
+  }
+
+  const bareHslMatch = v.match(/^([\d.]+)\s+([\d.]+)%\s+([\d.]+)%$/);
+  if (bareHslMatch) {
+    const h = parseFloat(bareHslMatch[1]);
+    const s = parseFloat(bareHslMatch[2]);
+    const l = parseFloat(bareHslMatch[3]);
+    return { format: 'hsl', rgb: hslToRgb(h, s, l) };
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Tailwind config parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Attempt to extract a Tailwind theme color → CSS-variable mapping from a
+ * tailwind.config.js source file using a bracket-depth-aware token walk.
+ * No `require()` — stays dependency-free even on configs that import plugins.
+ *
+ * Handles flat keys:
+ *   background: 'var(--background)',
+ * Nested object keys (DEFAULT and named sub-keys):
+ *   primary: { DEFAULT: 'var(--primary)', foreground: 'var(--primary-foreground)' }
+ *   sidebar:  { DEFAULT: 'var(--sidebar)', primary: 'var(--sidebar-primary)' }
+ *
+ * Returns a Map of Tailwind class suffix → cssVarName.
+ * e.g.  "primary"             → "--primary"
+ *       "primary-foreground"  → "--primary-foreground"
+ *       "sidebar"             → "--sidebar"
+ *       "sidebar-primary"     → "--sidebar-primary"
+ *
+ * @param {string} src
+ * @returns {Map<string, string>}
+ */
+function parseTailwindConfig(src) {
+  const result = new Map();
+
+  const colorsBlockMatch = src.match(/colors\s*:\s*\{([\s\S]*)\},?\s*\}/);
+  if (!colorsBlockMatch) {
+    const re = /["']?([\w-]+)["']?\s*:\s*["'][^"']*var\(--([\w-]+)\)[^"']*["']/g;
+    let m;
+    while ((m = re.exec(src)) !== null) {
+      result.set(m[1], '--' + m[2]);
+    }
+    return result;
+  }
+
+  const colorsText = extractBalancedBraces(src, src.indexOf('colors'));
+  if (!colorsText) {
+    return result;
+  }
+
+  parseColorObject(colorsText, '', result);
+  return result;
+}
+
+/**
+ * Extract the text of the balanced { } block starting at or after `startIndex`.
+ * @param {string} src
+ * @param {number} startIndex
+ * @returns {string | null}
+ */
+function extractBalancedBraces(src, startIndex) {
+  const open = src.indexOf('{', startIndex);
+  if (open === -1) return null;
+  let depth = 0;
+  for (let i = open; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') {
+      depth--;
+      if (depth === 0) return src.slice(open + 1, i);
+    }
+  }
+  return null;
+}
+
+/**
+ * Walk the tokens of a colors object body and populate `result`.
+ * `prefix` is the accumulated Tailwind key prefix (e.g. "sidebar").
+ * @param {string} body         Raw text between the outer { }
+ * @param {string} prefix       Accumulated key prefix (dash-joined)
+ * @param {Map<string,string>} result
+ */
+function parseColorObject(body, prefix, result) {
+  const KEY_VALUE_RE = /["']?([\w-]+)["']?\s*:\s*(?:(\{)|["']([^"']*)["'])/g;
+  let m;
+  while ((m = KEY_VALUE_RE.exec(body)) !== null) {
+    const rawKey = m[1];
+    const isObject = !!m[2];
+    const strValue = m[3];
+
+    if (isObject) {
+      const objectStart = m.index + m[0].length - 1;
+      const innerText = extractBalancedBraces(body, objectStart);
+      if (innerText !== null) {
+        const childPrefix = prefix ? `${prefix}-${rawKey}` : rawKey;
+        parseColorObject(innerText, childPrefix, result);
+        const afterBlock = objectStart + innerText.length + 2;
+        KEY_VALUE_RE.lastIndex = afterBlock;
+      }
+    } else if (strValue !== undefined) {
+      const varMatch = strValue.match(/var\(--([\w-]+)\)/);
+      if (varMatch) {
+        let tailwindKey;
+        if (rawKey === 'DEFAULT') {
+          tailwindKey = prefix || rawKey;
+        } else {
+          tailwindKey = prefix ? `${prefix}-${rawKey}` : rawKey;
+        }
+        if (tailwindKey && tailwindKey !== 'DEFAULT') {
+          result.set(tailwindKey, '--' + varMatch[1]);
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Expand a Tailwind color key to the canonical set of utility classes.
+ * e.g. "primary" → ["bg-primary", "text-primary", "border-primary", ...]
+ * @param {string} key
+ * @returns {string[]}
+ */
+function tailwindPrefixes(key) {
+  return ['bg-', 'text-', 'border-', 'ring-', 'fill-', 'stroke-', 'decoration-'].map(p => p + key);
+}
+
+// ---------------------------------------------------------------------------
+// CLI entrypoint
+// ---------------------------------------------------------------------------
+
+function main() {
+  const args = process.argv.slice(2);
+  if (args.length === 0 || args[0] === '--help') {
+    process.stderr.write(
+      'Usage: node resolve-colors.js <css-file> [--tailwind <tailwind.config.js>] --output <out.json>\n'
+    );
+    process.exit(1);
+  }
+
+  const cssPath = args[0];
+  let tailwindPath = null;
+  let outputPath = null;
+
+  for (let i = 1; i < args.length; i++) {
+    if (args[i] === '--tailwind' && args[i + 1]) {
+      tailwindPath = args[++i];
+    } else if (args[i] === '--output' && args[i + 1]) {
+      outputPath = args[++i];
+    }
+  }
+
+  if (!outputPath) {
+    process.stderr.write('Error: --output <path> is required\n');
+    process.exit(1);
+  }
+
+  if (!fs.existsSync(cssPath)) {
+    process.stderr.write(`Error: CSS file not found: ${cssPath}\n`);
+    process.exit(1);
+  }
+
+  const cssSource = fs.readFileSync(cssPath, 'utf8');
+  const rawVars = parseCssVariables(cssSource);
+
+  const cssVariables = {};
+  for (const [name, raw] of rawVars) {
+    const parsed = parseColor(raw);
+    if (parsed) {
+      cssVariables[name] = {
+        raw,
+        format: parsed.format,
+        rgb: {
+          r: Math.round(parsed.rgb.r * 1000) / 1000,
+          g: Math.round(parsed.rgb.g * 1000) / 1000,
+          b: Math.round(parsed.rgb.b * 1000) / 1000,
+        },
+      };
+    }
+  }
+
+  const tailwindMap = {};
+  if (tailwindPath && fs.existsSync(tailwindPath)) {
+    const twSource = fs.readFileSync(tailwindPath, 'utf8');
+    const twMap = parseTailwindConfig(twSource);
+    for (const [key, cssVar] of twMap) {
+      for (const cls of tailwindPrefixes(key)) {
+        tailwindMap[cls] = cssVar;
+      }
+    }
+  }
+
+  const output = { cssVariables, tailwindMap };
+
+  const outDir = path.dirname(outputPath);
+  if (!fs.existsSync(outDir)) {
+    fs.mkdirSync(outDir, { recursive: true });
+  }
+
+  fs.writeFileSync(outputPath, JSON.stringify(output, null, 2));
+
+  const varCount = Object.keys(cssVariables).length;
+  const mapCount = Object.keys(tailwindMap).length;
+  process.stdout.write(
+    `resolve-colors: wrote ${varCount} CSS variables and ${mapCount} Tailwind class mappings to ${outputPath}\n`
+  );
+}
+
+main();

--- a/plugins/figma-from-code/skills/figma-from-code/10-validator/screenshot.js
+++ b/plugins/figma-from-code/skills/figma-from-code/10-validator/screenshot.js
@@ -1,0 +1,167 @@
+/**
+ * Component screenshot helper for figma-from-code-validator
+ *
+ * Usage — single screenshot (element):
+ *   node screenshot.js <url> <output> --selector "css" [--click "css"] [--hover "css"] [width] [height]
+ *
+ * Usage — single screenshot (full page):
+ *   node screenshot.js <url> <output> [width] [height]
+ *
+ * Usage — batch mode (one browser, many screenshots):
+ *   node screenshot.js --batch manifest.json
+ *
+ *   manifest.json format:
+ *   [
+ *     {"url": "http://...", "output": "path.png", "selector": "css", "click": "css", "hover": "css", "nth": 0, "variant": "label"},
+ *     ...
+ *   ]
+ *
+ * Flags:
+ *   --selector "css"   Target a specific DOM element
+ *   --click "css"      Click this element before screenshotting
+ *   --hover "css"      Hover over this element before screenshotting
+ *   --nth N            Use the Nth matching element (0-indexed, default: 0)
+ *   --variant "name"   Label printed in output message (no effect on screenshot)
+ *   --batch file.json  Process multiple screenshots in a single browser session
+ */
+const { getBrowser } = require('./browser-connect');
+const path = require('path');
+const fs = require('fs');
+
+const DEVICE_SCALE_FACTOR = 1;
+const SCRIPT_TIMEOUT = 60000;
+const _scriptTimer = setTimeout(() => {
+  console.error('screenshot.js: script timeout after 60s — exiting');
+  process.exit(124);
+}, SCRIPT_TIMEOUT);
+_scriptTimer.unref();
+
+async function captureOne(
+  page,
+  { url, output, selector, click, hover, nth = 0, variant, width = 1440, height = 900 }
+) {
+  fs.mkdirSync(path.dirname(output), { recursive: true });
+  await page.setViewportSize({ width, height });
+  await page.goto(url, { waitUntil: 'networkidle', timeout: 15000 });
+
+  if (click) {
+    const trigger = page.locator(click).first();
+    await trigger.waitFor({ state: 'visible', timeout: 8000 });
+    await trigger.click();
+    await page.waitForTimeout(400);
+  }
+
+  if (hover) {
+    const hoverTarget = page.locator(hover).first();
+    await hoverTarget.waitFor({ state: 'visible', timeout: 8000 });
+    await hoverTarget.hover();
+    await page.waitForTimeout(600);
+  }
+
+  if (selector) {
+    const el = page.locator(selector).nth(nth);
+    await el.waitFor({ state: 'visible', timeout: 8000 });
+    await el.screenshot({ path: output });
+  } else {
+    await page.screenshot({ path: output });
+  }
+
+  const label = variant ? ` [${variant}]` : '';
+  console.log(`Saved${label}: ${output}`);
+}
+
+const args = process.argv.slice(2);
+
+const batchIdx = args.indexOf('--batch');
+if (batchIdx !== -1) {
+  const manifestPath = args[batchIdx + 1];
+  if (!manifestPath) {
+    console.error('Usage: node screenshot.js --batch manifest.json');
+    process.exit(1);
+  }
+
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+
+  (async () => {
+    const browser = await getBrowser();
+    const context = await browser.newContext({ deviceScaleFactor: DEVICE_SCALE_FACTOR });
+    const page = await context.newPage();
+    const results = { captured: [], failed: [] };
+
+    for (const entry of manifest) {
+      try {
+        await captureOne(page, entry);
+        results.captured.push(entry.output);
+      } catch (err) {
+        console.error(`Failed ${entry.output}: ${err.message.split('\n')[0]}`);
+        results.failed.push({ output: entry.output, error: err.message.split('\n')[0] });
+      }
+    }
+
+    await browser.close();
+    console.log(
+      `\nBatch complete: ${results.captured.length} captured, ${results.failed.length} failed`
+    );
+  })().catch((err) => {
+    console.error(err.message.split('\n')[0]);
+    process.exit(1);
+  });
+} else {
+  if (args.length < 2) {
+    console.error(
+      'Usage: node screenshot.js <url> <output> [--selector "sel"] [--click "sel"] [--hover "sel"] [--nth N] [--variant "name"] [width] [height]'
+    );
+    process.exit(1);
+  }
+
+  const url = args[0];
+  const output = args[1];
+
+  let selector = null,
+    clickSel = null,
+    hoverSel = null,
+    nthIndex = 0,
+    variantLabel = null;
+  let width = 1440,
+    height = 900;
+
+  const numericArgs = [];
+  for (let i = 2; i < args.length; i++) {
+    if (args[i] === '--selector') {
+      selector = args[++i];
+    } else if (args[i] === '--click') {
+      clickSel = args[++i];
+    } else if (args[i] === '--hover') {
+      hoverSel = args[++i];
+    } else if (args[i] === '--nth') {
+      nthIndex = Number(args[++i]);
+    } else if (args[i] === '--variant') {
+      variantLabel = args[++i];
+    } else if (!isNaN(Number(args[i]))) {
+      numericArgs.push(Number(args[i]));
+    }
+  }
+  if (numericArgs[0] != null) width = numericArgs[0];
+  if (numericArgs[1] != null) height = numericArgs[1];
+
+  (async () => {
+    const browser = await getBrowser();
+    const context = await browser.newContext({ deviceScaleFactor: DEVICE_SCALE_FACTOR });
+    const page = await context.newPage();
+    await captureOne(page, {
+      url,
+      output,
+      selector,
+      click: clickSel,
+      hover: hoverSel,
+      nth: nthIndex,
+      variant: variantLabel,
+      width,
+      height,
+    });
+    await browser.close();
+  })().catch((err) => {
+    console.error(err.message.split('\n')[0]);
+    process.exit(1);
+  });
+}

--- a/plugins/figma-from-code/skills/figma-from-code/10-validator/screenshot_nth.js
+++ b/plugins/figma-from-code/skills/figma-from-code/10-validator/screenshot_nth.js
@@ -1,0 +1,59 @@
+/**
+ * Custom screenshot with --nth support for click
+ */
+const { getBrowser } = require('./browser-connect');
+const path = require('path');
+const fs = require('fs');
+
+const args = process.argv.slice(2);
+if (args.length < 2) {
+  console.error('Usage: node screenshot_nth.js <url> <output> [--selector "sel"] [--click-nth N]');
+  process.exit(1);
+}
+
+const url    = args[0];
+const output = args[1];
+
+let selector = null;
+let clickNth = null;
+let width = 1440;
+let height = 900;
+
+for (let i = 2; i < args.length; i++) {
+  if (args[i] === '--selector') selector = args[++i];
+  else if (args[i] === '--click-nth') clickNth = Number(args[++i]);
+  else if (!isNaN(Number(args[i]))) {
+    if (width === 1440) width = Number(args[i]);
+    else height = Number(args[i]);
+  }
+}
+
+fs.mkdirSync(path.dirname(output), { recursive: true });
+
+(async () => {
+  const browser = await getBrowser();
+  const page = await browser.newPage();
+  await page.setViewportSize({ width, height });
+  await page.goto(url, { waitUntil: 'networkidle', timeout: 15000 });
+
+  if (clickNth !== null) {
+    const trigger = page.locator('h1').nth(clickNth);
+    await trigger.waitFor({ state: 'visible', timeout: 8000 });
+    await trigger.click();
+    await page.waitForTimeout(400);
+  }
+
+  if (selector) {
+    const el = page.locator(selector).first();
+    await el.waitFor({ state: 'visible', timeout: 8000 });
+    await el.screenshot({ path: output });
+  } else {
+    await page.screenshot({ path: output });
+  }
+
+  await browser.close();
+  console.log(`Saved: ${output}`);
+})().catch(err => {
+  console.error(err.message.split('\n')[0]);
+  process.exit(1);
+});

--- a/plugins/figma-from-code/skills/figma-from-code/2-discovery-assets/SKILL.md
+++ b/plugins/figma-from-code/skills/figma-from-code/2-discovery-assets/SKILL.md
@@ -1,0 +1,143 @@
+# Skill: Icon & Asset Discovery
+
+Discovers all Lucide icons and SVG file assets imported across the codebase, extracts their SVG markup, and maps which components use which icons. This is pure static analysis — no dev server or Figma access needed.
+
+## When to Use
+
+- Before `figma-from-code` Phase 3 (icon preamble builds Figma icon components from this data)
+- Standalone audit of icon and asset usage across the codebase
+- When resuming a build and `icons.json` is missing
+
+## Prerequisites
+
+- Source directory exists (the directory containing the project's component source files)
+- `node_modules/lucide-react` installed (for resolving icon SVG data)
+
+## Required Inputs
+
+| Input       | Description                                                                 |
+| ----------- | --------------------------------------------------------------------------- |
+| `sourceDir` | Path to the source directory to scan (e.g., `src/`, `<source-dir>/`) |
+
+## Output Files
+
+Written to `.temp/figma-from-code/`:
+
+| File         | Contents                                                       |
+| ------------ | -------------------------------------------------------------- |
+| `icons.json` | Icon/asset manifest with SVG strings and per-component mapping |
+
+### `icons.json` structure
+
+```json
+{
+  "icons": [
+    {
+      "name": "Check",
+      "elements": [["path", { "d": "M20 6 9 17l-5-5" }]],
+      "svgString": "<svg ...>...</svg>",
+      "usedBy": ["Button", "Checkbox"]
+    }
+  ],
+  "assets": [
+    {
+      "name": "AppLogoSvg",
+      "importPath": "@/assets/logo.svg",
+      "sourcePath": "{sourceDir}/assets/logo.svg",
+      "svgString": "...",
+      "usedBy": ["Header"]
+    }
+  ],
+  "iconsByComponent": {
+    "Button": ["Check", "X"],
+    "Header": ["AppLogoSvg"]
+  },
+  "summary": {
+    "totalIcons": 21,
+    "totalAssets": 1,
+    "componentsWithIcons": 22
+  }
+}
+```
+
+## Workflow
+
+### 1. Ensure output directory exists
+
+```bash
+mkdir -p .temp/figma-from-code/
+```
+
+### 2. Run the icon extraction script
+
+```bash
+node ${CLAUDE_SKILL_DIR}/10-validator/extract-icons.js \
+  --scan {sourceDir} \
+  --output .temp/figma-from-code/icons.json
+```
+
+The script:
+
+- Recursively finds all `.tsx?` files (excludes `node_modules`, test files)
+- Parses static imports from `lucide-react`
+- Resolves each icon's SVG from `node_modules/lucide-react/dist/esm/icons/`
+- Finds and extracts SVG file imports (e.g., `import Logo from '@/assets/logo.svg'`)
+- Maps which components use which icons/assets
+
+### 3. Read and summarize the output
+
+Read `.temp/figma-from-code/icons.json` and extract:
+
+- `summary.totalIcons` — number of Lucide icons found
+- `summary.totalAssets` — number of SVG file assets found
+- `summary.componentsWithIcons` — how many components use icons
+- `icons[].name` — list of icon names
+- `assets[].name` — list of asset names
+
+### 4. Write icons summary for the orchestrator
+
+Extract the data the orchestrator needs into a small summary file so it never has to read the full `icons.json` (which contains SVG strings):
+
+```bash
+node -e "
+  const data = JSON.parse(require('fs').readFileSync('.temp/figma-from-code/icons.json','utf-8'));
+  const summary = {
+    iconCount: data.summary.totalIcons,
+    icons: data.icons.map(i => i.name),
+    assetCount: data.summary.totalAssets,
+    assets: data.assets.map(a => a.name)
+  };
+  require('fs').writeFileSync('.temp/figma-from-code/icons-summary.json', JSON.stringify(summary, null, 2));
+"
+```
+
+Write to `.temp/figma-from-code/icons-summary.json`. The orchestrator reads only this file (~500 bytes) instead of the full icons.json.
+
+### 5. Report
+
+```
+Icon & Asset Discovery complete:
+- {totalIcons} Lucide icons discovered
+- {totalAssets} SVG assets found
+- Icons used across {componentsWithIcons} components
+```
+
+## Scripts Reference
+
+| Script             | Location                                                       | Purpose                                                              |
+| ------------------ | -------------------------------------------------------------- | -------------------------------------------------------------------- |
+| `extract-icons.js` | `${CLAUDE_SKILL_DIR}/10-validator/extract-icons.js` | Static analysis of imports to find icons/assets and extract SVG data |
+
+Do NOT modify this script.
+
+## Skip / Resume
+
+If called with `resume: true`, check whether `.temp/figma-from-code/icons.json` exists on disk. If it does, skip and read the existing file. If it's missing, re-run.
+
+## Error Handling
+
+| Scenario                         | Action                                                                          |
+| -------------------------------- | ------------------------------------------------------------------------------- |
+| `extract-icons.js` fails         | Verify the source directory exists and `node_modules/lucide-react` is installed |
+| Icon SVG resolution fails        | Script logs warnings per-icon; other icons still extracted                      |
+| SVG file asset not found on disk | Script logs warning; asset entry created without `svgString`                    |

--- a/plugins/figma-from-code/skills/figma-from-code/3-setup-tokens/SKILL.md
+++ b/plugins/figma-from-code/skills/figma-from-code/3-setup-tokens/SKILL.md
@@ -1,0 +1,109 @@
+# Skill: Setup Tokens (Phase 1)
+
+Creates Figma variable collections, extracts the CSS-variable-to-Figma-variable-ID map, and pre-computes all CSS colors as sRGB values. Runs as a subagent dispatched by the orchestrator.
+
+## When to Use
+
+- When `figma-from-code` orchestrator reaches Phase 1
+- Standalone to recreate variable collections and color maps after token changes
+
+## Required Inputs
+
+| Input                 | Description                                          | Source                    |
+| --------------------- | ---------------------------------------------------- | ------------------------- |
+| `fileKey`             | Figma file key                                       | State ledger or caller    |
+| `existingCollections` | List of variable collection names that already exist | Phase 0a Figma inspection |
+
+## Output Files
+
+| File                                         | Contents                                       | Consumed by             |
+| -------------------------------------------- | ---------------------------------------------- | ----------------------- |
+| `.temp/figma-from-code/variables.json`       | CSS var name -> Figma variable ID map          | Phase 3 build subagents |
+| `.temp/figma-from-code/resolved-colors.json` | Pre-computed sRGB values for all CSS variables | Phase 3 build subagents |
+| `.temp/figma-from-code/tokens-summary.json`  | Small summary for the orchestrator             | Orchestrator only       |
+
+## Workflow
+
+### 1. Create variable collections
+
+Load and run the `figma-setup-variables` skill. Pass `fileKey` and `existingCollections`.
+
+Skip if all three collections (`Palette`, `Semantic`, `Spacing`) already exist.
+
+### 2. Extract variable lookup map
+
+Run this `use_figma` call to build the CSS-variable-name to Figma-variable-ID map:
+
+```javascript
+const collections = await figma.variables.getLocalVariableCollectionsAsync();
+const map = {};
+for (const col of collections) {
+  for (const varId of col.variableIds) {
+    const v = await figma.variables.getVariableByIdAsync(varId);
+    if (v.codeSyntax && v.codeSyntax.WEB) {
+      map[v.codeSyntax.WEB] = {
+        id: v.id,
+        name: v.name,
+        collectionName: col.name,
+        resolvedType: v.resolvedType,
+      };
+    }
+  }
+}
+return JSON.stringify(map);
+```
+
+Write the returned JSON to `.temp/figma-from-code/variables.json`.
+
+### 3. Resolve CSS colors
+
+Run the color resolution script to pre-compute all CSS variable colors as sRGB:
+
+```bash
+node ${CLAUDE_SKILL_DIR}/10-validator/resolve-colors.js \
+  <source-dir>/index.css \
+  --tailwind <tailwind-config> \
+  --output .temp/figma-from-code/resolved-colors.json
+```
+
+### 4. Write summary
+
+Count the entries in `variables.json` and `resolved-colors.json`, then write the summary:
+
+```bash
+node -e "
+  const vars = JSON.parse(require('fs').readFileSync('.temp/figma-from-code/variables.json','utf-8'));
+  const colors = JSON.parse(require('fs').readFileSync('.temp/figma-from-code/resolved-colors.json','utf-8'));
+  const varCount = Object.keys(vars).length;
+  const colorCount = Object.keys(colors.cssVariables || {}).length;
+  const collections = [...new Set(Object.values(vars).map(v => v.collectionName))];
+  const summary = { collections, variableCount: varCount, resolvedColorCount: colorCount, variableMapPath: '.temp/figma-from-code/variables.json', resolvedColorsPath: '.temp/figma-from-code/resolved-colors.json' };
+  require('fs').writeFileSync('.temp/figma-from-code/tokens-summary.json', JSON.stringify(summary, null, 2));
+  console.log('Tokens summary: ' + collections.length + ' collections, ' + varCount + ' variables, ' + colorCount + ' resolved colors');
+"
+```
+
+### 5. Report
+
+```
+Phase 1 complete:
+- {collections.length} variable collections: {collection names}
+- {variableCount} CSS variables mapped to Figma variable IDs
+- {resolvedColorCount} CSS colors pre-computed as sRGB
+```
+
+## Skip / Resume
+
+Skip if all three conditions are met:
+
+- `.temp/figma-from-code/variables.json` exists
+- `.temp/figma-from-code/resolved-colors.json` exists
+- `.temp/figma-from-code/tokens-summary.json` exists
+
+## Error Handling
+
+| Scenario                              | Action                                                                    |
+| ------------------------------------- | ------------------------------------------------------------------------- |
+| `figma-setup-variables` fails         | Report error; variable creation is required for downstream phases         |
+| `use_figma` variable extraction fails | Retry once; if still failing, report error                                |
+| `resolve-colors.js` fails             | Report error; Phase 3 can still build using computed-styles.json fallback |

--- a/plugins/figma-from-code/skills/figma-from-code/4-setup-structure/SKILL.md
+++ b/plugins/figma-from-code/skills/figma-from-code/4-setup-structure/SKILL.md
@@ -1,0 +1,122 @@
+# Skill: Setup File Structure (Phase 2)
+
+Creates the Figma file skeleton and all container frames needed by later phases. Runs as a subagent dispatched by the orchestrator.
+
+## When to Use
+
+- When `figma-from-code` orchestrator reaches Phase 2
+- Standalone to set up a fresh Figma file for a code-to-Figma rebuild
+
+## Required Inputs
+
+| Input           | Description                             | Source                    |
+| --------------- | --------------------------------------- | ------------------------- |
+| `fileKey`       | Figma file key                          | State ledger              |
+| `existingPages` | Pages already present in the Figma file | Phase 0a Figma inspection |
+
+## Output Files
+
+| File                                           | Contents                    | Consumed by                                           |
+| ---------------------------------------------- | --------------------------- | ----------------------------------------------------- |
+| `.temp/figma-from-code/structure-summary.json` | All page and frame node IDs | Orchestrator (merges into `state.json -> figmaNodes`) |
+
+## Workflow
+
+### 1. Create pages and foundations
+
+Load and run the `figma-setup-file-structure` skill. Pass `fileKey` and `existingPages`.
+
+After completion, screenshot the Foundations page for visual verification.
+
+### 2. Create Icons and Screens container frames
+
+Create only the Icons frame (on the Components page) and the Screens container frame (on the Screens page). Tier frames are created on-demand at the start of each tier build in Phase 3.
+
+```javascript
+await figma.setCurrentPageAsync(componentsPage);
+
+const iconsFrame = figma.createFrame();
+iconsFrame.name = 'Icons';
+iconsFrame.layoutMode = 'HORIZONTAL';
+iconsFrame.primaryAxisSizingMode = 'AUTO';
+iconsFrame.counterAxisSizingMode = 'AUTO';
+iconsFrame.layoutWrap = 'WRAP';
+iconsFrame.itemSpacing = 24;
+iconsFrame.counterAxisSpacing = 24;
+iconsFrame.paddingTop = 24;
+iconsFrame.paddingBottom = 24;
+iconsFrame.paddingLeft = 24;
+iconsFrame.paddingRight = 24;
+iconsFrame.fills = [{ type: 'SOLID', color: { r: 1, g: 1, b: 1 } }];
+iconsFrame.x = 0;
+iconsFrame.y = 0;
+componentsPage.appendChild(iconsFrame);
+
+await figma.setCurrentPageAsync(screensPage);
+const screensFrame = figma.createFrame();
+screensFrame.name = 'Screens';
+screensFrame.layoutMode = 'HORIZONTAL';
+screensFrame.primaryAxisSizingMode = 'AUTO';
+screensFrame.counterAxisSizingMode = 'AUTO';
+screensFrame.itemSpacing = 80;
+screensFrame.paddingTop = 80;
+screensFrame.paddingBottom = 80;
+screensFrame.paddingLeft = 80;
+screensFrame.paddingRight = 80;
+screensFrame.fills = [{ type: 'SOLID', color: { r: 0.973, g: 0.973, b: 0.98 } }];
+screensFrame.x = 0;
+screensFrame.y = 0;
+screensPage.appendChild(screensFrame);
+
+return { iconsFrameId: iconsFrame.id, screensFrameId: screensFrame.id };
+```
+
+### 3. Screenshot for verification
+
+Take a screenshot of the Components page to verify the Icons frame was created:
+
+```
+get_screenshot(fileKey, componentsPageId)
+```
+
+### 4. Write summary
+
+Write the page and container frame node IDs to the summary file:
+
+```json
+{
+  "foundationsPageId": "...",
+  "componentsPageId": "...",
+  "screensPageId": "...",
+  "foundationsFrameId": "...",
+  "iconsFrameId": "...",
+  "screensFrameId": "...",
+  "foundationsScreenshot": ".temp/figma-from-code/screenshots/foundations.png"
+}
+```
+
+Write to `.temp/figma-from-code/structure-summary.json`.
+
+### 5. Report
+
+```
+Phase 2 complete:
+- 3 pages created (Foundations, Components, Screens)
+- Icons frame + Screens container frame created
+- Tier frames will be created on-demand at the start of each Phase 3 tier build
+```
+
+## Skip / Resume
+
+Skip if all conditions are met:
+
+- `.temp/figma-from-code/structure-summary.json` exists
+- All page IDs, `iconsFrameId`, and `screensFrameId` in the summary are verified to exist in Figma (use `get_metadata` or `use_figma` to check)
+
+## Error Handling
+
+| Scenario                              | Action                                                         |
+| ------------------------------------- | -------------------------------------------------------------- |
+| `figma-setup-file-structure` fails    | Report error; page/foundations creation is required            |
+| `use_figma` tier frame creation fails | Retry once; if still failing, report which frames were created |
+| Pages already exist but frames don't  | Create only the missing frames (idempotent)                    |

--- a/plugins/figma-from-code/skills/figma-from-code/5-precapture/SKILL.md
+++ b/plugins/figma-from-code/skills/figma-from-code/5-precapture/SKILL.md
@@ -1,0 +1,184 @@
+# Skill: Pre-capture Reference Material
+
+Captures app screenshots and structured text content for every UI component before any Figma building begins. Decoupling capture from building means build agents never launch Chromium. A single unified batch manifest (sorted by URL) minimizes page navigations and avoids multi-subagent overhead.
+
+## When to Use
+
+- Before `figma-from-code` Phase 3 (component builds need app screenshots as reference)
+- To refresh app screenshots after UI changes without re-running the full pipeline
+- Standalone capture of component screenshots for design review
+
+## Prerequisites
+
+- Dev server running at `<dev-server-url>`
+- Playwright installed (`node_modules/playwright-core`)
+- Shared Playwright server running (started by orchestrator before dispatching):
+  ```bash
+  node ${CLAUDE_SKILL_DIR}/10-validator/browser-server.js &
+  ```
+  Endpoint is written to `.temp/figma-from-code/pw-endpoint.txt` and auto-detected by scripts. If not running, scripts fall back to launching their own browser.
+
+## Manifest Building
+
+The **subagent** builds all manifests itself before running any screenshots. Do not wait for external manifest files — build them from `component-map.json`.
+
+1. Read `.temp/figma-from-code/component-map.json` to get all components and the routes where they appear
+2. Derive selectors from each component's `selector` field in `component-map.json` (see **Selector Strategy** below)
+3. Build two unified manifests (screenshot + text) covering all screenshottable components, sorted by `url`
+4. Create a `precapture-screens` manifest for full-page screenshots of all discovered routes
+
+### Selector Strategy
+
+Use `component-map.json → selector` for each component. If the field is present, use it as-is. If absent or null, skip the component (treat as no-selector). Do not read any other skill file to obtain selectors.
+
+| Component Type                        | Preferred Selector                | Example                                |
+| ------------------------------------- | --------------------------------- | -------------------------------------- |
+| Always visible (nav, header, sidebar) | `aria-label` or semantic HTML     | `header[aria-label="Main navigation"]` |
+| Form inputs                           | Input type + placeholder          | `input[placeholder="..."]`             |
+| Overlays/dialogs                      | Click trigger + `[role="dialog"]` | `--click "button[aria-label='...']"`   |
+| Embedded / primitives                 | Parent context                    | `[class*="ComponentName"]`             |
+
+### Components with no app selector (skip entirely)
+
+Components that have no CSS selector in `component-map.json` should be skipped. These are typically loading states, error states, hover-only components, and components not directly visible in the UI.
+
+### Code-only components (skip entirely)
+
+Components with `source: "code"` in `component-map.json` were discovered by static code analysis but have no browser route or selector. They cannot be screenshotted from the running app. Skip them during pre-capture — they proceed to Phase 3 build with `appScreenshot: null` (the build skill handles the `no_app_reference` path).
+
+## Manifest Format
+
+The subagent constructs a unified manifest for all screenshottable components. The manifest is a JSON array where each entry has: `name`, `url`, `selector`, `click` (optional), `hover` (optional), `nth` (optional).
+
+Write two manifest files (sorted by `url` to cluster same-route entries):
+
+- `.temp/figma-from-code/manifests/all-screenshots.json` — all screenshot entries
+- `.temp/figma-from-code/manifests/all-text.json` — all text extraction entries
+
+### Screenshot manifest entry format
+
+```json
+{
+  "url": "<dev-server-url>{url}",
+  "output": ".temp/figma-from-code/screenshots/{name}/app.png",
+  "selector": "{selector}",
+  "click": "{click}",
+  "hover": "{hover}",
+  "nth": 0
+}
+```
+
+### Text manifest entry format
+
+```json
+{
+  "url": "<dev-server-url>{url}",
+  "output": ".temp/figma-from-code/screenshots/{name}/text.json",
+  "selector": "{selector}",
+  "click": "{click}",
+  "nth": 0
+}
+```
+
+### Screen manifest entries (no selector — full page)
+
+```json
+[
+  {
+    "url": "<dev-server-url>{route}",
+    "output": ".temp/figma-from-code/screenshots/screens/{ScreenName}/app.png"
+  }
+]
+```
+
+Build one entry per discovered route from `component-map.json`. Name screens by converting route paths to PascalCase (e.g., `/items/new` → `CreateItemPage`).
+
+## Subagent Prompt Template
+
+The orchestrator dispatches **one subagent** that handles manifest-building and all captures inline.
+
+> **Chunking:** `screenshot.js` has a 60-second timeout per run. If `all-screenshots.json` contains more than 15 entries, split it into chunk files of 15 entries each (`chunk-01.json`, `chunk-02.json`, …) and run each chunk sequentially. The default chunk size of 15 assumes ~3s per component; reduce if your app has slow navigation.
+
+```
+Capture app screenshots and text content for UI components from a running dev server.
+
+Skill file: ${CLAUDE_SKILL_DIR}/5-precapture/SKILL.md
+Read it for manifest format, selector strategy, and output format.
+
+Step 0 — Build manifests from component-map.json:
+  Read .temp/figma-from-code/component-map.json
+  For each component with a non-null selector field, create entries in:
+    .temp/figma-from-code/manifests/all-screenshots.json
+    .temp/figma-from-code/manifests/all-text.json
+  Skip components with source: "code" or no selector.
+  For routes in component-map.json, build:
+    .temp/figma-from-code/manifests/precapture-screens.json
+  Sort all manifests by url before writing.
+
+Scripts (already exist, do not modify):
+  Screenshot: node ${CLAUDE_SKILL_DIR}/10-validator/screenshot.js
+  Text:       node ${CLAUDE_SKILL_DIR}/10-validator/extract-text.js
+
+Both scripts support batch mode for faster execution (one browser, many captures):
+
+1. Capture all screenshots (chunk if > 15 entries — run each chunk sequentially):
+   node ${CLAUDE_SKILL_DIR}/10-validator/screenshot.js \
+     --batch .temp/figma-from-code/manifests/all-screenshots.json
+
+2. Extract all text content in one batch:
+   node ${CLAUDE_SKILL_DIR}/10-validator/extract-text.js \
+     --batch .temp/figma-from-code/manifests/all-text.json
+
+After both batches complete, write results to:
+.temp/figma-from-code/precapture-all.json
+
+Use this format:
+{"group": "all", "captured": [{"name": "...", "app": "...", "text": "..."}], "skipped": [...], "failed": [{"name": "...", "error": "..."}]}
+```
+
+## Output Files
+
+Written to `.temp/figma-from-code/`:
+
+| File                      | Contents                                            |
+| ------------------------- | --------------------------------------------------- |
+| `precapture-all.json`     | Results for all component screenshots (single file) |
+| `precapture-screens.json` | Results for full-page screenshots                   |
+
+### Output format
+
+```json
+{
+  "group": "all",
+  "captured": [
+    { "name": "Button", "app": ".temp/.../Button/app.png", "text": ".temp/.../Button/text.json" }
+  ],
+  "skipped": ["Skeleton"],
+  "failed": [{ "name": "Calendar", "error": "selector not found" }]
+}
+```
+
+## Scripts Reference
+
+| Script              | Location                                                        | Purpose                                                 |
+| ------------------- | --------------------------------------------------------------- | ------------------------------------------------------- |
+| `screenshot.js`     | `${CLAUDE_SKILL_DIR}/10-validator/screenshot.js`     | Playwright element/page screenshots, supports `--batch` |
+| `extract-text.js`   | `${CLAUDE_SKILL_DIR}/10-validator/extract-text.js`   | Structured text extraction by role, supports `--batch`  |
+| `browser-server.js` | `${CLAUDE_SKILL_DIR}/10-validator/browser-server.js` | Shared Playwright WebSocket server                      |
+
+Do NOT modify these scripts.
+
+All screenshots are captured at 1x scale (`deviceScaleFactor: 1` is enforced in `screenshot.js`). This prevents Retina 2x doubling and ensures consistent dimensions for downstream comparison against Figma screenshots (which must also use `scale: 1` in `get_screenshot` calls).
+
+## Skip / Resume
+
+If called with `resume: true`, check whether `.temp/figma-from-code/precapture-all.json` and `precapture-screens.json` both exist. If both are present, skip. If either is missing, re-run the missing capture.
+
+## Error Handling
+
+| Scenario                                  | Action                                                          |
+| ----------------------------------------- | --------------------------------------------------------------- |
+| Dev server not running                    | Halt, tell user to start the dev server                         |
+| Screenshot script fails for one component | Log in `failed` array, continue with remaining components       |
+| Entire batch fails                        | Report error, offer retry for the failed chunk or full manifest |
+| Missing selectors                         | Component goes in `skipped` array, non-fatal                    |

--- a/plugins/figma-from-code/skills/figma-from-code/6-build-tier/SKILL.md
+++ b/plugins/figma-from-code/skills/figma-from-code/6-build-tier/SKILL.md
@@ -1,0 +1,195 @@
+# Skill: Build Components (Phase 3)
+
+Builds all Figma components using pre-captured reference material, reusing lower-tier components as instances. Tiers run sequentially because each tier depends on components built in all lower tiers. Within a tier, components are built sequentially.
+
+## When to Use
+
+- When `figma-from-code` reaches Phase 3
+- Standalone to build or rebuild a single tier of components
+- After code changes to rebuild affected components
+
+## Prerequisites
+
+- Phases 0–2.5 complete (build order, icons, tokens, file structure, screenshots all in place)
+- `.temp/figma-from-code/state.json` populated with `buildOrder`, `figmaNodes`, `iconDiscovery`
+- `figmaNodes.componentsPageId` present in state (set by Phase 2)
+- Pre-captured screenshots in `.temp/figma-from-code/screenshots/`
+
+## Preamble: Build Icon & Asset Components
+
+**Before processing any tier**, build all icon and asset components inline. Read and follow the icon preamble skill instructions at:
+
+`${CLAUDE_SKILL_DIR}/6-build-tier/icon-preamble/SKILL.md`
+
+Execute the entire preamble workflow inline using `fileKey` and `iconsFrameId`. The skill reads `icons.json` and `builtComponents.json` from disk, creates icon/asset components via `use_figma`, and writes results to `.temp/figma-from-code/icon-preamble-results.json`.
+
+**After the preamble completes:**
+
+1. Read `icon-preamble-results.json`
+2. Merge `created` entries into `state.builtComponents`
+3. Rewrite `builtComponents.json` from updated state
+4. Report counts from `totalCreated` / `totalSkipped` fields
+
+## Handling Library Components (no source file)
+
+Many tier-1 components detected by site-component-map are Lucide icons or router primitives imported directly from npm packages. They have no `.tsx` file in the codebase.
+
+| Type             | Example                           | Figma approach                                                                                            |
+| ---------------- | --------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| Lucide icon      | `Bot`, `Star`, `EllipsisVertical` | **Already built as `Icon/{Name}` in preamble** — skip, these are in `builtComponents`                     |
+| SVG asset        | `AppLogoSvg`                      | **Already built as `Asset/{Name}` in preamble** — skip                                                    |
+| Router primitive | `Link` (react-router-dom)         | Build as a nav link component set (Default / Active variants) showing what the link looks like in context |
+
+When a tier-1 component name matches a Lucide icon discovered in Phase 0b, do not rebuild it — it already exists as `Icon/{Name}` in `builtComponents`.
+
+## Per-Tier Process
+
+For each component in the tier, execute the **entire** `${CLAUDE_SKILL_DIR}/7-build-component/7a/SKILL.md` (build) and `${CLAUDE_SKILL_DIR}/7-build-component/7b-review-fix-component/SKILL.md` (review/fix) workflow inline: analyze source → build via `use_figma` → screenshot via `get_screenshot` → compare via `compare.js` → fix loop (up to 3 iterations).
+
+Build components sequentially within a tier. Do not proceed to the next tier until all components for the current tier have been built.
+
+**Before dispatching:** ensure the results directory exists:
+
+```bash
+mkdir -p .temp/figma-from-code/build-results
+```
+
+### Create the tier frame
+
+Before building any components for a tier, create the tier's container frame on the Components page. The frame does not exist yet — tier frames are created on-demand at the start of each tier build, not during Phase 2.
+
+Compute the y-position by reading `figmaNodes` in state: place each new tier frame below the Icons frame and any already-created tier frames with 80px gaps.
+
+```javascript
+const componentsPage = figma.root.children.find((p) => p.id === componentsPageId);
+await figma.setCurrentPageAsync(componentsPage);
+
+// Compute y offset: below all existing frames on the page
+const existingFrames = componentsPage.children;
+const maxBottom = existingFrames.reduce((y, f) => Math.max(y, f.y + f.height), 0);
+const yPos = existingFrames.length > 0 ? maxBottom + 80 : 200;
+
+const tierFrame = figma.createFrame();
+tierFrame.name = `Tier ${tier} — ${tierLabel}`;
+tierFrame.layoutMode = 'HORIZONTAL';
+tierFrame.primaryAxisSizingMode = 'AUTO';
+tierFrame.counterAxisSizingMode = 'AUTO';
+tierFrame.itemSpacing = 80;
+tierFrame.paddingTop = 48;
+tierFrame.paddingBottom = 48;
+tierFrame.paddingLeft = 48;
+tierFrame.paddingRight = 48;
+tierFrame.fills = [{ type: 'SOLID', color: { r: 1, g: 1, b: 1 } }];
+tierFrame.x = 0;
+tierFrame.y = yPos;
+componentsPage.appendChild(tierFrame);
+
+const tierFrameId = tierFrame.id;
+```
+
+Record `tierFrameId` in the tier summary output so the orchestrator can persist it to `state.figmaNodes.tier{N}FrameId`.
+
+### Filter out already-built components
+
+Before building components for a tier, check each component against `builtComponents` in state.json. If a component's name already has a node ID in `builtComponents` (seeded from Phase 0a Figma inspection or from a prior tier build), **skip it**.
+
+> **Pre-Existing Components Rule (orchestrator skill):** components whose node ID is in `state.json → preExistingComponents` predate this run. They are skipped here by default. If the user (or a Phase 5 finding) requests a rebuild for one of them, the orchestrator MUST first obtain explicit user authorization before dispatching, even in auto mode. See the orchestrator skill's "Pre-Existing Components Rule" section.
+
+```
+Tier 2 components: [Button, CaseComments, Link, RelatedCasesAccordion]
+Already in builtComponents: [Button, Link]
+→ Build only: [CaseComments, RelatedCasesAccordion]
+→ Report: "Skipped 2 already-built components: Button, Link"
+```
+
+This enables partial rebuilds — pointing the pipeline at a Figma file that already has some components built will skip those and only create what's missing.
+
+### Per-Component Build (inline)
+
+For each component, execute the build and review phases sequentially as two distinct steps:
+
+**Step A — Build (Steps 1–3):** Read and follow `${CLAUDE_SKILL_DIR}/7-build-component/7a/SKILL.md`. This analyzes the source, creates the Figma node, captures the initial screenshot, and writes `.temp/figma-from-code/build-results/{ComponentName}-built.json`.
+
+**Step B — Review/Fix (Steps 4–7):** Read the `-built.json` handoff. If `status` is `built`, read and follow `${CLAUDE_SKILL_DIR}/7-build-component/7b-review-fix-component/SKILL.md`. If `status` is anything other than `built` (`needs_authorization`, `rejected`, `failed`), skip the review phase and write the final result directly by copying the handoff fields to `.temp/figma-from-code/build-results/{ComponentName}.json`.
+
+Build components sequentially within a tier — complete both steps for one component before starting the next. Do not proceed to the next tier until all components for the current tier have been built and reviewed.
+
+### After All Components Complete
+
+1. Read each `.temp/figma-from-code/build-results/{ComponentName}.json`
+2. Collect all node IDs, match scores, and failures
+3. Log any components that failed entirely (no result file)
+
+## Orchestrator Behavior Between Tiers
+
+After all components for a tier are built:
+
+1. Write `build-tier{N}.json` with completed/failed/match lists **and `tierFrameId`**
+2. Merge new node IDs into `builtComponents` in state.json
+3. Update `state.figmaNodes.tier{N}FrameId` from `build-tier{N}.json → tierFrameId`
+4. Spot-check: `get_screenshot(fileKey, tierFrameId)` — verify components have realistic, varied heights (not all thin strips)
+5. Update `tierProgress.tier{N}` and `phase3` status
+6. Report comparison results: how many matched, how many fixed, how many remain mismatched
+7. **Checkpoint with user** — ask to proceed to next tier
+8. Do not auto-proceed across tier boundaries
+
+## Output Files
+
+Written to `.temp/figma-from-code/`:
+
+| File                                 | Contents                                                        |
+| ------------------------------------ | --------------------------------------------------------------- |
+| `build-results/{ComponentName}.json` | Per-component result (written by tier agent)                    |
+| `build-tier{N}.json`                 | Tier summary (written by orchestrator after collecting results) |
+
+### Per-component result format
+
+```json
+{
+  "componentName": "Button",
+  "nodeId": "123:45",
+  "type": "COMPONENT_SET",
+  "variants": [{ "name": "Variant=primary, State=Default", "nodeId": "123:46" }],
+  "comparison": {
+    "matchPct": 94.2,
+    "borderMatchPct": 91.0,
+    "verdict": "match",
+    "iterations": 1,
+    "fixes": ["border-radius 4px -> 8px"]
+  },
+  "figmaScreenshot": ".temp/figma-from-code/screenshots/Button/figma.png"
+}
+```
+
+### Tier summary format
+
+```json
+{
+  "tier": 1,
+  "tierFrameId": "456:78",
+  "completed": [
+    { "name": "Button", "nodeId": "123:45", "figmaScreenshot": ".temp/.../Button/figma.png" }
+  ],
+  "failed": [{ "name": "Calendar", "error": "use_figma exceeded incremental limit" }]
+}
+```
+
+## Tier Definitions
+
+Tiers are dynamic — they come from the `site-component-map` output stored at `.temp/figma-from-code/component-map.json` during Phase 0a. Read `state.json → buildOrder.tiers` for the current build order.
+
+## Skip / Resume
+
+If called with `resume: true`, check `state.json → tierProgress` for completed tiers and `build-results/` for individual component results. Only build components without a result file.
+
+## Error Handling
+
+| Scenario                                | Action                                                                |
+| --------------------------------------- | --------------------------------------------------------------------- |
+| `use_figma` fails                       | Retry once; if still fails, write error to result file                |
+| `use_figma` incremental limit           | Split component builds across multiple `use_figma` calls              |
+| Components all same thin height         | `fixSizing()` was not run — run it on the tier frame, re-screenshot   |
+| Text node padding error                 | Wrap text in an auto-layout frame (see build-component skill)         |
+| Library component has no source file    | Check icon/asset preamble; build nav link variant if router primitive |
+| Component build produces no result file | Log as failed, report at checkpoint                                   |
+| `createNodeFromSvg()` fails for icon    | Create 24x24 placeholder rectangle so higher tiers can instantiate    |

--- a/plugins/figma-from-code/skills/figma-from-code/6-build-tier/icon-preamble/SKILL.md
+++ b/plugins/figma-from-code/skills/figma-from-code/6-build-tier/icon-preamble/SKILL.md
@@ -1,0 +1,86 @@
+# Skill: Icon & Asset Preamble
+
+Builds all Figma icon and asset components from SVG data before any tier processing begins. Reads `icons.json`, skips already-built entries in `builtComponents.json`, and creates `Icon/{Name}` and `Asset/{Name}` components via `use_figma`.
+
+## Required Inputs
+
+| Input          | Source                                      |
+| -------------- | ------------------------------------------- |
+| `fileKey`      | Passed by orchestrator                      |
+| `iconsFrameId` | From `state.json → figmaNodes.iconsFrameId` |
+
+## Files Read from Disk
+
+- `.temp/figma-from-code/icons.json` — icon/asset manifest with SVG strings
+- `.temp/figma-from-code/builtComponents.json` — registry of already-built components
+
+## Output File
+
+Write `.temp/figma-from-code/icon-preamble-results.json` on completion.
+
+## Workflow
+
+### 1. Read inputs
+
+Read `icons.json` and `builtComponents.json` from disk.
+
+### 2. Filter already-built
+
+For each icon in `icons[].name` and each asset in `assets[].name`, check if an entry exists in `builtComponents.json`. Skip any that already have a node ID — they were built in a prior run or seeded from Figma inspection in Phase 0a.
+
+### 3. Build icon components
+
+For each remaining Lucide icon, call `use_figma` to create a Figma component from its SVG string:
+
+- Batch ~7 icons per `use_figma` call to stay within incremental limits
+- Use `figma.createNodeFromSvg(svgString)` for each icon
+- Name each component `Icon/{iconName}` (e.g., `Icon/Check`, `Icon/Bot`)
+- Resize to 24×24 (standard Lucide size) using `node.resize(24, 24)`
+- Place inside the Icons frame (`iconsFrameId`)
+- Collect each created node's ID
+
+If `createNodeFromSvg()` fails for an icon, create a 24×24 placeholder rectangle so higher-tier components can still instantiate it. Log the failure.
+
+### 4. Build asset components
+
+For each remaining SVG asset, call `use_figma`:
+
+- Batch ~7 assets per `use_figma` call
+- Use `figma.createNodeFromSvg(svgString)` for each asset
+- Name each component `Asset/{assetName}` (e.g., `Asset/AppLogoSvg`)
+- Resize to the asset's natural dimensions if known, otherwise 100×40
+- Place inside the Icons frame alongside icon components
+- Collect each created node's ID
+
+### 5. Write output
+
+Write `.temp/figma-from-code/icon-preamble-results.json`:
+
+```json
+{
+  "created": {
+    "Icon/Check": "123:45",
+    "Icon/Bot": "123:46",
+    "Asset/AppLogoSvg": "123:47"
+  },
+  "skipped": ["Icon/Star"],
+  "failed": [],
+  "totalCreated": 3,
+  "totalSkipped": 1,
+  "totalFailed": 0
+}
+```
+
+### 6. Report back
+
+Report: `{ "success": true, "outputFile": ".temp/figma-from-code/icon-preamble-results.json" }`
+
+Include a one-line summary: `"Created 3 icons/assets, skipped 1 already-built, 0 failed."`
+
+## Error Handling
+
+| Scenario                          | Action                                                                        |
+| --------------------------------- | ----------------------------------------------------------------------------- |
+| `icons.json` missing              | Report `success: false`, message: "icons.json not found — run Phase 0b first" |
+| `createNodeFromSvg()` fails       | Create 24×24 placeholder rectangle, log to `failed[]`, continue               |
+| `use_figma` incremental limit hit | Split remaining icons into a new `use_figma` call                             |

--- a/plugins/figma-from-code/skills/figma-from-code/7-build-component/7a/SKILL.md
+++ b/plugins/figma-from-code/skills/figma-from-code/7-build-component/7a/SKILL.md
@@ -1,0 +1,160 @@
+# Skill: Build a Figma Component from Code (Steps 1–3)
+
+> **Build phase only.** Analyzes the component source, creates the Figma node, and captures the initial screenshot. Called by `figma-from-code` Phase 3 (via the tier agent) or standalone. Review/fix is handled by the sibling `7b-review-fix-component` skill.
+>
+> **Figma MCP tools available:** `use_figma`, `get_screenshot`.
+
+## Required Inputs
+
+| Input                   | Description                                                                                       | Source                                                   |
+| ----------------------- | ------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| `componentName`         | Name of the component (e.g., `Button`, `UserProfile`)                                             | Build order / caller                                     |
+| `fileKey`               | Figma file key                                                                                    | State ledger or caller                                   |
+| `parentFrameId`         | Node ID of the tier/container frame to append the component into                                  | State ledger                                             |
+| `sourceFile`            | Absolute path to the component's `.tsx` source file                                               | Project's component source directory                     |
+| `sourceDir`             | Component's modlet root directory (parent of `.figma/`)                                           | Derived from `sourceFile` path                           |
+| `devServerUrl`          | URL of the running dev server — required for Step 1g live inspection                              | State ledger or caller                                   |
+| `textContent`           | Extracted text JSON from the live app                                                             | `.temp/figma-from-code/screenshots/{name}/text.json`     |
+| `iconUsage`             | Which Lucide icons and SVG assets the component uses, with sizes                                  | Source code imports + `icons.json`                       |
+| `builtComponents`       | Map of `{componentName: nodeId}` for all previously built components available for instance reuse | State ledger `builtComponents`                           |
+| `preExistingComponents` | Immutable snapshot of components that existed in Figma BEFORE this orchestrator run started       | State ledger `preExistingComponents` (Phase 0a snapshot) |
+
+Screenshot directory is always `.temp/figma-from-code/screenshots/{componentName}/` — derived from `componentName`, not passed as an input.
+
+### Optional Inputs
+
+| Input              | Description                                                                                                                                                                                                                                                                                     |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `computedStyles`   | Resolved CSS values from `computed-styles.json` (produced by `inspect-styles.js` in step 1g). Authoritative for colors, spacing, typography. Also contains `layoutContext.parent.clientWidth` — used by Step 1a to promote hug→fill when the parent slot is meaningfully wider than the element |
+| `stateScreenshots` | Paths to state screenshots (`state-hover.png`, `state-focus.png`, `state-disabled.png`) and style diffs from `states.json`                                                                                                                                                                      |
+| `cssFile`          | Path to the component's `.css` module file if external styles exist                                                                                                                                                                                                                             |
+| `figmaVariant`     | Variant properties that match the app rendering (passed through to the `-built.json` handoff for use by `7b-review-fix-component`)                                                                                                                                                              |
+
+---
+
+## Build Handoff File Schema
+
+Written to `.temp/figma-from-code/build-results/{componentName}-built.json` after Step 3. This is the handoff consumed by `7b-review-fix-component`.
+
+```json
+{
+  "componentName": "Button",
+  "status": "built | needs_authorization | rejected | failed",
+  "nodeId": "123:45",
+  "screenshotNodeId": "123:46",
+  "type": "COMPONENT_SET | COMPONENT",
+  "variants": [{ "name": "Variant=primary, Size=regular", "nodeId": "123:46" }],
+  "figmaScreenshot": ".temp/figma-from-code/screenshots/Button/figma.png",
+  "figmaVariant": { "Variant": "primary", "State": "Default" },
+  "sourceDir": "<source-dir>/components/Button",
+  "preExistingTouched": [],
+  "missingChildren": []
+}
+```
+
+`status` values:
+
+- `built` — Steps 1–3 completed; handoff is ready for `7b-review-fix-component`
+- `needs_authorization` — `componentName` is in `preExistingComponents`; skip review phase
+- `rejected` — missing child components; `missingChildren` list is populated; skip review phase
+- `failed` — Figma API error during Steps 2–3; skip review phase
+
+## Variant Strategy
+
+Variants are computed by Step 1b — they are **not** a caller input. See [../step-1-analyze.md §1b](../step-1-analyze.md) for the full extraction algorithm (variant library definitions, CSS pseudo-states, responsive breakpoints, prop-driven structural states), the representative set algorithm, and the budget guardrail (cap: 30 combos).
+
+---
+
+## Pre-Existing Components Rule
+
+Before doing any work that resolves to a node ID in `preExistingComponents`, **stop**. That node existed in Figma before this run; modifying it requires explicit user authorization per the orchestrator skill's "Pre-Existing Components Rule".
+
+Concretely:
+
+- If `componentName` itself maps to a node in `preExistingComponents`: write `status: "needs_authorization"` and `preExistingTouched: ["<name>"]` to the `-built.json` handoff and return immediately. Do not call `use_figma`.
+- If a _child_ you would instantiate is in `preExistingComponents`: **instancing it is fine** — that's reuse, not modification. Modifying its master is not.
+
+This rule overrides Steps 2–3 of the workflow when in conflict. Full detail is in [../step-1-analyze.md §Pre-Existing Components Rule](../step-1-analyze.md).
+
+---
+
+## Execution Mode
+
+The tier agent runs this build skill for each component sequentially. All steps execute **inline** — no further agent dispatching.
+
+After this skill completes, the tier agent calls `7b-review-fix-component` with the `-built.json` handoff as its primary input. If `status` is not `built`, the tier agent skips the review phase and writes the final result directly from the handoff.
+
+---
+
+## Inline Workflow
+
+All steps run inline within a single agent. There is no subagent dispatching — the agent executes every step itself.
+
+```
+Steps 1-3 (all inline):
+  1. Analyze → read source + reference material, write .figma/code.json
+  2. Build   → create Figma component via use_figma, write .figma/figma.json
+  3. Screenshot → capture Figma result via get_screenshot
+```
+
+### Flow
+
+```
+1.  Execute Step 1 (Analyze) → produces code.json
+1a. If result shows "needs_authorization" → write -built.json with status "needs_authorization", stop
+1b. If result shows "rejected"            → write -built.json with status "rejected" + missingChildren, stop
+2.  Read code.json, execute Step 2 (Build)
+    Post-Step 2 invariant: componentNodeId must be a non-null string before proceeding
+3.  Execute Step 3 (Screenshot) → produces figma.png
+4.  Write -built.json with status "built", nodeId, screenshotNodeId, figmaScreenshot, variants
+```
+
+### Step reference files
+
+Detailed instructions for each step live in the parent directory and in `../prompts/`:
+
+- **[../prompts/analyze.md](../prompts/analyze.md)** — Step 1 inputs and instructions
+
+---
+
+## Workflow
+
+Each step has its own detailed file in the parent directory (`../`).
+
+| Step | File                                               | Phase   | What it does                                                                                  |
+| ---- | -------------------------------------------------- | ------- | --------------------------------------------------------------------------------------------- |
+| 1    | [../step-1-analyze.md](../step-1-analyze.md)       | Analyze | Read source + reference material, inspect live component, write `.figma/code.json`            |
+| 2    | [../step-2-build.md](../step-2-build.md)           | Build   | Create the component in Figma via `use_figma`, enumerate instances, write `.figma/figma.json` |
+| 3    | [../step-3-screenshot.md](../step-3-screenshot.md) | Build   | Capture the Figma result via `get_screenshot`                                                 |
+
+> Steps 4–7 (compare, fix loop, track, return) are handled by `../7b-review-fix-component/SKILL.md`.
+
+---
+
+## fixSizing() — Mandatory After Every Build
+
+The `fixSizing()` function definition, construction-time sizing rules, and anti-patterns live in [../step-2-build.md](../step-2-build.md). Call it on every component and every child component before appending to the parent frame.
+
+---
+
+## Common Pitfalls
+
+| Pitfall                                                        | Prevention                                                                              |
+| -------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| All components appear as thin strips                           | `fixSizing()` was not called — see [../step-2-build.md](../step-2-build.md)             |
+| Rendering a design-system child as plain text or a local frame | Caught by Step 4a in `7b-review-fix-component` — always instance from `builtComponents` |
+
+---
+
+## Error Handling
+
+Step-specific error cases are documented in each step file. Global rules:
+
+| Scenario                                          | Action                                                                                     |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `componentName` is in `preExistingComponents`     | Write `-built.json` with `status: "needs_authorization"`, stop immediately                 |
+| Any required child missing from `builtComponents` | Write `-built.json` with `status: "rejected"` and `missingChildren` list, stop immediately |
+| `use_figma` API error during Steps 2–3            | Write `-built.json` with `status: "failed"`, include error message, stop                   |
+| No app screenshot available                       | Proceed normally — screenshot absence is handled in `7b-review-fix-component`              |
+
+Never fail silently. Every error or skip must appear in the `-built.json` handoff.

--- a/plugins/figma-from-code/skills/figma-from-code/7-build-component/7b-review-fix-component/SKILL.md
+++ b/plugins/figma-from-code/skills/figma-from-code/7-build-component/7b-review-fix-component/SKILL.md
@@ -1,0 +1,154 @@
+# Skill: Review and Fix a Figma Component (Steps 4–7)
+
+> **Review/fix phase only.** Receives the `-built.json` handoff from `7-build-component`, runs instance/sizing/pixel comparison, executes the fix loop, finalizes tracking files, and returns the complete result. All Figma MCP tools are available (`use_figma`, `get_screenshot`).
+
+## Required Inputs
+
+| Input              | Description                                                | Source                                                           |
+| ------------------ | ---------------------------------------------------------- | ---------------------------------------------------------------- |
+| `componentName`    | Name of the component (e.g., `Button`, `UserProfile`)      | Handoff file or caller                                           |
+| `fileKey`          | Figma file key                                             | State ledger or caller                                           |
+| `builtHandoffPath` | Path to the `-built.json` handoff from `7-build-component` | `.temp/figma-from-code/build-results/{componentName}-built.json` |
+
+All other inputs (`nodeId`, `screenshotNodeId`, `figmaScreenshot`, `figmaVariant`, `sourceDir`, `variants`) are read from the handoff file — they are not passed separately.
+
+### Also reads from disk
+
+- `.temp/figma-from-code/builtComponents.json` — for instance resolution during fix loop
+- `state.json → preExistingComponents` — for the pre-existing guard
+- `.temp/figma-from-code/screenshots/{componentName}/app.png` — app reference screenshot
+- `{sourceDir}/.figma/code.json` — written by Step 1; consumed by Step 4a
+- `{sourceDir}/.figma/figma.json` — written by Step 2f; consumed by Step 4a
+
+---
+
+## Acceptance Thresholds
+
+| Metric           | Pass threshold |
+| ---------------- | -------------- |
+| `matchPct`       | ≥ 90%          |
+| `borderMatchPct` | ≥ 85%          |
+
+Both must pass for `verdict: "match"`. `matchPct` alone passing yields `"minor_diff"`. Below `matchPct` threshold is `"mismatch"`.
+
+---
+
+## Result File Schema
+
+Written to `.temp/figma-from-code/build-results/{componentName}.json` on every execution path.
+
+```json
+{
+  "componentName": "Button",
+  "status": "success | partial_match | no_app_reference | needs_authorization | rejected | failed",
+  "nodeId": "123:45",
+  "type": "COMPONENT_SET | COMPONENT",
+  "variants": [{ "name": "Variant=primary, Size=regular", "nodeId": "123:46" }],
+  "comparison": {
+    "verdict": "match | minor_diff | mismatch | no_app_reference",
+    "matchPct": 94.2,
+    "borderMatchPct": 91.0,
+    "iterations": 1,
+    "fixes": ["border-radius 4px -> 8px"]
+  },
+  "preExistingTouched": [],
+  "missingChildren": [],
+  "trackingFile": { "written": true }
+}
+```
+
+`status` values:
+
+- `success` — built and passed acceptance thresholds
+- `partial_match` — built, fix loop ran 3 iterations without reaching thresholds
+- `no_app_reference` — built, no `app.png` found; comparison skipped
+- `needs_authorization` — propagated from handoff; no comparison performed
+- `rejected` — propagated from handoff; no comparison performed
+- `failed` — propagated from handoff or Figma API error during fix loop
+
+---
+
+## Pre-Existing Components Rule
+
+The fix loop (Step 5) must **never** edit a node whose ID appears in `preExistingComponents`. If a comparison finding requires modifying such a node, surface it in the result and let the orchestrator/user decide. Full detail is in [../step-1-analyze.md §Pre-Existing Components Rule](../step-1-analyze.md).
+
+---
+
+## Early-Exit Gate
+
+After reading the handoff file, check `status`:
+
+| Handoff status        | Action                                                                                        |
+| --------------------- | --------------------------------------------------------------------------------------------- |
+| `built`               | Continue to Inline Workflow below                                                             |
+| `needs_authorization` | Write final result with `status: "needs_authorization"`, propagate `preExistingTouched`, stop |
+| `rejected`            | Write final result with `status: "rejected"`, propagate `missingChildren`, stop               |
+| `failed`              | Write final result with `status: "failed"`, propagate error message, stop                     |
+
+---
+
+## Inline Workflow
+
+All steps run inline within a single agent. There is no subagent dispatching.
+
+```
+Steps 4–7 (all inline):
+  4a. Instance check → run check-instances.js (hard gate)
+  4b. Sizing check   → verify dimensions match intent
+  4c. Pixel diff     → compare against app screenshot → verdict
+  5.  Fix loop       → if verdict is not "match", diagnose and fix (up to 3 iterations)
+  6.  Track          → verify/refresh figma-component.json tracking files
+  7.  Return         → write final result file with node ID, match score, issues
+```
+
+### Flow
+
+```
+1.  Read {componentName}-built.json
+1a. If status ≠ "built" → propagate status to final result, stop (see Early-Exit Gate)
+2.  Execute Step 4a (instance check)
+    If 4a reports missing_instances → enter Step 5 fix loop with missing_instances
+                                      (skip 4b/4c for this first pass)
+3.  If 4a passes → execute Steps 4b, 4c → get verdict
+4.  If app.png is missing → skip comparison, set verdict "no_app_reference", proceed to Step 6
+5.  If verdict is "match" → skip to Step 6
+6.  If verdict is not "match" → execute Step 5 fix loop (up to 3 iterations)
+7.  Execute Step 6 (track), Step 7 (return)
+```
+
+**Fix iteration model:** Step 5 runs up to 3 iterations inline. Each iteration: diagnose from `diff.png`/`comparison.json`, apply fix via `use_figma`, re-enumerate instances (Step 2f re-run), re-screenshot, re-compare. If all 3 iterations complete without match, return `status: "partial_match"` and proceed to Step 6. Do not retry Step 5.
+
+---
+
+## Workflow
+
+Step files live in `../7-build-component/`. Open the linked file before executing each step.
+
+| Step | File                                           | Phase    | What it does                                                                 |
+| ---- | ---------------------------------------------- | -------- | ---------------------------------------------------------------------------- |
+| 4a   | [../step-4-compare.md](../step-4-compare.md)   | Compare  | Instance-usage gate — `check-instances.js` diffs `code.json` vs `figma.json` |
+| 4b   | [../step-4-compare.md](../step-4-compare.md)   | Compare  | Sizing sanity check                                                          |
+| 4c   | [../step-4-compare.md](../step-4-compare.md)   | Compare  | Pixel diff against the app screenshot → verdict                              |
+| 5    | [../step-5-fix-loop.md](../step-5-fix-loop.md) | Fix      | Diagnose from comparison data and fix (up to 3 iterations)                   |
+| 6    | [../step-6-track.md](../step-6-track.md)       | Finalize | Verify tracking files, refresh `updatedAt`, sanity-check invariants          |
+| 7    | [../step-7-return.md](../step-7-return.md)     | Finalize | Report result with node ID, match score, and any remaining issues            |
+
+### Script references
+
+- `check-instances.js` — lives at `${CLAUDE_SKILL_DIR}/7-build-component/check-instances.js` (parent directory)
+- `compare.js` — lives at `${CLAUDE_SKILL_DIR}/10-validator/compare.js`
+- `inspect-styles.js` — used by Step 5 re-enumeration if needed
+
+---
+
+## Error Handling
+
+| Scenario                                           | Action                                                                    |
+| -------------------------------------------------- | ------------------------------------------------------------------------- |
+| Handoff status is not `built`                      | Propagate to final result, stop (see Early-Exit Gate)                     |
+| No app screenshot (`app.png` missing)              | Skip comparison, write `status: "no_app_reference"`, proceed to Step 6    |
+| Fix loop reaches 3 iterations without match        | Return `status: "partial_match"`, proceed to Step 6 — do not retry Step 5 |
+| `use_figma` API error during fix loop              | Record error in result, return current best `status`, proceed to Step 6   |
+| Fix loop would edit a `preExistingComponents` node | Stop fix loop, surface in result, let orchestrator/user decide            |
+
+Never fail silently. Every error or skip must appear in the final result file.

--- a/plugins/figma-from-code/skills/figma-from-code/7-build-component/SKILL.md
+++ b/plugins/figma-from-code/skills/figma-from-code/7-build-component/SKILL.md
@@ -1,0 +1,33 @@
+# Component Build Skills — Index
+
+This folder contains two sub-skills that together execute the full per-component build-and-review pipeline for `figma-from-code` Phase 3.
+
+| Sub-skill      | Folder                                                                 | Steps | What it does                                                                                    |
+| -------------- | ---------------------------------------------------------------------- | ----- | ----------------------------------------------------------------------------------------------- |
+| **Build**      | [`7a/SKILL.md`](7a/SKILL.md)                                           | 1–3   | Analyze source, create Figma node, capture initial screenshot, write `-built.json` handoff      |
+| **Review/Fix** | [`7b-review-fix-component/SKILL.md`](7b-review-fix-component/SKILL.md) | 4–7   | Instance check, sizing check, pixel diff, fix loop (up to 3 iterations), tracking, final result |
+
+## Step Files (shared library)
+
+All step instruction files live directly in this folder and are referenced by both sub-skills:
+
+| File                                         | Step     | Phase    |
+| -------------------------------------------- | -------- | -------- |
+| [step-1-analyze.md](step-1-analyze.md)       | 1        | Analyze  |
+| [step-2-build.md](step-2-build.md)           | 2        | Build    |
+| [step-3-screenshot.md](step-3-screenshot.md) | 3        | Build    |
+| [step-4-compare.md](step-4-compare.md)       | 4a/4b/4c | Compare  |
+| [step-5-fix-loop.md](step-5-fix-loop.md)     | 5        | Fix      |
+| [step-6-track.md](step-6-track.md)           | 6        | Finalize |
+| [step-7-return.md](step-7-return.md)         | 7        | Finalize |
+
+Scripts: [`check-instances.js`](check-instances.js), [`check-prereqs.js`](check-prereqs.js)
+Prompt templates: [`prompts/`](prompts/)
+
+## Usage
+
+The tier agent (`6-build-tier`) calls each sub-skill inline in sequence per component:
+
+1. Read and follow `7a/SKILL.md` → produces `.temp/figma-from-code/build-results/{Name}-built.json`
+2. If handoff `status` is `built`: read and follow `7b-review-fix-component/SKILL.md` → produces final `.temp/figma-from-code/build-results/{Name}.json`
+3. If handoff `status` is not `built` (`needs_authorization`, `rejected`, `failed`): propagate to final result, skip step 2

--- a/plugins/figma-from-code/skills/figma-from-code/7-build-component/check-instances.js
+++ b/plugins/figma-from-code/skills/figma-from-code/7-build-component/check-instances.js
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+/**
+ * Verify that every design-system child the source code uses appears as an
+ * INSTANCE inside the built Figma component, by comparing the two `.figma/`
+ * tracking files written during the build.
+ *
+ * Inputs:
+ *   <componentDir>/.figma/code.json   — analysis snapshot (Step 1h).
+ *                                       Field: childComponents = [Figma names]
+ *   <componentDir>/.figma/figma.json  — built-state record (Step 2f / Step 5).
+ *                                       Field: dependencies[].componentName
+ *
+ * The script diffs `code.childComponents` against `figma.dependencies[].componentName`.
+ * Mismatch is the failure that produced "I rendered EditableTitle as a text node"
+ * — visually identical at rest, but design-system-broken.
+ *
+ * Usage:
+ *   node check-instances.js <componentName> <componentDir>
+ *
+ *   componentName   PascalCase name (used in marker + rejection JSON)
+ *   componentDir    Directory containing `.figma/code.json` and `.figma/figma.json`
+ *                   (typically the modlet directory)
+ *
+ * Outputs:
+ *   On success: writes .temp/figma-from-code/instances/<componentName>.ok
+ *   On failure: prints rejection JSON to stderr and exits 1.
+ *
+ * Exit codes:
+ *   0  Every required child is instanced.
+ *   1  At least one required child is missing (rejection), or a tracking file
+ *      is missing / malformed.
+ *   2  Usage error.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const [, , componentName, componentDir] = process.argv;
+
+if (!componentName || !componentDir) {
+  console.error('Usage: check-instances.js <componentName> <componentDir>');
+  process.exit(2);
+}
+
+const cwd = process.cwd();
+const resolvedDir = path.resolve(cwd, componentDir);
+const codePath = path.join(resolvedDir, '.figma', 'code.json');
+const figmaPath = path.join(resolvedDir, '.figma', 'figma.json');
+
+function readTracking(label, p) {
+  if (!fs.existsSync(p)) {
+    console.error(
+      JSON.stringify(
+        {
+          status: 'error',
+          reason: `missing_${label}`,
+          expectedPath: p,
+          howToFix:
+            label === 'code_json'
+              ? 'Step 1h must write `.figma/code.json` from the analysis snapshot before this gate runs.'
+              : 'Step 2f must write `.figma/figma.json` (with dependencies enumerated from the built component) before this gate runs.',
+        },
+        null,
+        2
+      )
+    );
+    process.exit(1);
+  }
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf-8'));
+  } catch (err) {
+    console.error(`Invalid JSON in ${p}: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+const code = readTracking('code_json', codePath);
+const figma = readTracking('figma_json', figmaPath);
+
+const rawChildren = Array.isArray(code.childComponents) ? code.childComponents : [];
+const required = rawChildren.map((c) => (typeof c === 'string' ? c : c.figmaName));
+const builtDeps = Array.isArray(figma.dependencies) ? figma.dependencies : [];
+const actual = new Set(builtDeps.map((d) => d.componentName));
+
+const missing = required.filter((name) => !actual.has(name));
+const unexpected = [...actual].filter((name) => !required.includes(name));
+
+const result = {
+  componentName,
+  componentDir: resolvedDir,
+  codeJson: codePath,
+  figmaJson: figmaPath,
+  requiredInstances: [...required].sort(),
+  presentInstances: required.filter((n) => actual.has(n)).sort(),
+  missingInstances: [...missing].sort(),
+  unexpectedInstances: unexpected.sort(),
+};
+
+if (missing.length > 0) {
+  result.status = 'rejected';
+  result.reason = 'missing_instances';
+  result.howToFix =
+    'The build rendered the listed components as plain text or local frames instead of instancing them. Replace each local subtree with `figma.getNodeById(builtComponents[name]).createInstance()`. For instances of component sets, pick the right variant via setProperties(). To override text inside an instance, findOne(n => n.type === "TEXT"), loadFontAsync(text.fontName), then setCharacters. After fixing, re-run Step 2f to refresh `.figma/figma.json` and re-run this check.';
+  console.error(JSON.stringify(result, null, 2));
+  process.exit(1);
+}
+
+const markerDir = path.join(cwd, '.temp/figma-from-code/instances');
+fs.mkdirSync(markerDir, { recursive: true });
+const markerPath = path.join(markerDir, `${componentName}.ok`);
+fs.writeFileSync(
+  markerPath,
+  JSON.stringify(
+    {
+      status: 'ok',
+      componentName,
+      componentDir: resolvedDir,
+      requiredInstances: result.requiredInstances,
+      checkedAt: new Date().toISOString(),
+    },
+    null,
+    2
+  )
+);
+console.log(
+  `OK ${componentName}: ${result.presentInstances.length} required instance(s) verified. Marker: ${markerPath}`
+);
+process.exit(0);

--- a/plugins/figma-from-code/skills/figma-from-code/7-build-component/check-prereqs.js
+++ b/plugins/figma-from-code/skills/figma-from-code/7-build-component/check-prereqs.js
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+/**
+ * Verify that a component's child dependencies exist in the target Figma file
+ * before allowing a build to start.
+ *
+ * Usage:
+ *   node check-prereqs.js <componentName> <sourcePath> [--strict]
+ *
+ *   componentName  PascalCase name of the component to be built (e.g. "CaseDetails")
+ *   sourcePath     Path to the React source file (.tsx)
+ *   --strict       Treat any UNCLASSIFIED import (PascalCase from a relative path)
+ *                  as a required child. Default: only treat imports whose origin
+ *                  is `./components/...` or `@/components/...` as required.
+ *
+ * Inputs read:
+ *   .temp/figma-from-code/builtComponents.json  -- map of { "Name": "nodeId" }
+ *
+ * Outputs:
+ *   On success: writes .temp/figma-from-code/prereqs/<componentName>.ok with
+ *     { status: "ok", componentName, availableChildren, checkedAt }
+ *   On failure: prints rejection JSON to stderr and exits 1.
+ *
+ * Exit codes:
+ *   0  All required children present, marker written
+ *   1  Missing children (rejection) or other validation failure
+ *   2  Usage error
+ */
+const fs = require('fs');
+const path = require('path');
+
+const args = process.argv.slice(2);
+const strict = args.includes('--strict');
+const positional = args.filter((a) => !a.startsWith('--'));
+const [componentName, sourcePath] = positional;
+
+if (!componentName || !sourcePath) {
+  console.error('Usage: check-prereqs.js <componentName> <sourcePath> [--strict]');
+  process.exit(2);
+}
+
+const cwd = process.cwd();
+const stateJsonPath = path.join(cwd, '.temp/figma-from-code/state.json');
+const builtMapPath = path.join(cwd, '.temp/figma-from-code/builtComponents.json');
+
+let built;
+let resolvedSource;
+
+if (fs.existsSync(stateJsonPath)) {
+  try {
+    const state = JSON.parse(fs.readFileSync(stateJsonPath, 'utf-8'));
+    if (state.builtComponents && typeof state.builtComponents === 'object') {
+      built = state.builtComponents;
+      resolvedSource = stateJsonPath;
+    }
+  } catch (err) {
+    console.error(`Invalid JSON in ${stateJsonPath}: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+if (!built) {
+  if (fs.existsSync(builtMapPath)) {
+    try {
+      built = JSON.parse(fs.readFileSync(builtMapPath, 'utf-8'));
+      resolvedSource = builtMapPath;
+    } catch (err) {
+      console.error(`Invalid JSON in ${builtMapPath}: ${err.message}`);
+      process.exit(1);
+    }
+  }
+}
+
+if (!built) {
+  console.error(
+    JSON.stringify(
+      {
+        status: 'error',
+        reason: 'missing_built_components_cache',
+        checkedPaths: [stateJsonPath, builtMapPath],
+        howToFix:
+          'Either run the figma-from-code orchestrator (which writes state.json → builtComponents) or populate .temp/figma-from-code/builtComponents.json with a JSON map { "ComponentName": "nodeId", ... }. The figma-explore skill or get_metadata MCP tool can produce this.',
+      },
+      null,
+      2
+    )
+  );
+  process.exit(1);
+}
+
+if (!fs.existsSync(sourcePath)) {
+  console.error(`Source file not found: ${sourcePath}`);
+  process.exit(1);
+}
+
+const source = fs.readFileSync(sourcePath, 'utf-8');
+
+const namedRe = /import\s+(?:type\s+)?\{([^}]+)\}\s+from\s+['"]([^'"]+)['"]/g;
+const defaultRe = /import\s+([A-Z][A-Za-z0-9_]+)\s+(?:,\s*\{[^}]*\}\s+)?from\s+['"]([^'"]+)['"]/g;
+
+const COMPONENT_ORIGIN_RE = /^(\.\.?\/|@\/)(components|pages)\//;
+
+const candidates = new Set();
+const ignored = [];
+// Per-candidate import context: the set of origins it was imported from, and the
+// set of sibling names sharing each import statement. Used to resolve compound
+// sub-exports (e.g. SelectTrigger from a built Select) without masking genuinely
+// independent siblings.
+const candidateContext = new Map();
+
+function recordCandidate(name, origin, siblings) {
+  candidates.add(name);
+  let ctx = candidateContext.get(name);
+  if (!ctx) {
+    ctx = { origins: new Set(), siblings: new Set() };
+    candidateContext.set(name, ctx);
+  }
+  ctx.origins.add(origin);
+  for (const s of siblings) if (s !== name) ctx.siblings.add(s);
+}
+
+// Last path segment of an import origin, with a trailing "/index" collapsed and
+// any extension stripped — i.e. the component a file-module is named after.
+function originBasename(origin) {
+  const parts = origin.replace(/\/index$/, '').split('/');
+  return (parts[parts.length - 1] || '').replace(/\.[a-zA-Z]+$/, '');
+}
+
+let m;
+while ((m = namedRe.exec(source))) {
+  const origin = m[2];
+  const names = m[1]
+    .split(',')
+    .map((s) => s.trim().replace(/^type\s+/, '').split(/\s+as\s+/)[0])
+    .filter(Boolean)
+    .filter((n) => /^[A-Z][A-Za-z0-9_]+$/.test(n));
+  const accepted = strict ? origin.startsWith('.') || origin.startsWith('@/') : COMPONENT_ORIGIN_RE.test(origin);
+  for (const n of names) {
+    if (accepted) {
+      recordCandidate(n, origin, names);
+    } else {
+      ignored.push({ name: n, origin });
+    }
+  }
+}
+while ((m = defaultRe.exec(source))) {
+  const origin = m[2];
+  const name = m[1];
+  if (strict ? origin.startsWith('.') || origin.startsWith('@/') : COMPONENT_ORIGIN_RE.test(origin)) {
+    recordCandidate(name, origin, [name]);
+  } else {
+    ignored.push({ name, origin });
+  }
+}
+
+candidates.delete(componentName);
+candidateContext.delete(componentName);
+
+function isBuilt(name) {
+  return Boolean(built[name] || built[`Icon/${name}`] || built[`Asset/${name}`]);
+}
+
+// A child is satisfied as a compound sub-export when:
+//  (a) basename rule — it is imported from a module file that is itself a built
+//      component (e.g. `MenuItem` from `.../MoreOptionsMenu`, `SelectItem` from
+//      `.../Select`), or
+//  (b) prefix-sibling rule — it shares an import statement with a built component
+//      whose name is a prefix of the child's (e.g. `PopoverContent` alongside the
+//      built `Popover`, even from a barrel like `@/components/ui`).
+// Both are deliberately narrow so independent siblings imported together (e.g.
+// `CaseList` and `CaseDetails`) are NOT falsely satisfied for one another.
+function subExportParent(child) {
+  const ctx = candidateContext.get(child);
+  if (!ctx) return null;
+  for (const origin of ctx.origins) {
+    const base = originBasename(origin);
+    if (base && base !== child && isBuilt(base)) return base;
+  }
+  for (const sib of ctx.siblings) {
+    if (sib !== child && child.startsWith(sib) && isBuilt(sib)) return sib;
+  }
+  return null;
+}
+
+const missing = [];
+const available = [];
+const resolvedSubExports = [];
+for (const child of candidates) {
+  if (isBuilt(child)) {
+    available.push(child);
+    continue;
+  }
+  const parent = subExportParent(child);
+  if (parent) {
+    available.push(child);
+    resolvedSubExports.push({ child, parent });
+  } else {
+    missing.push(child);
+  }
+}
+
+const result = {
+  componentName,
+  sourceFile: sourcePath,
+  availableChildren: available.sort(),
+  missingChildren: missing.sort(),
+  resolvedSubExports,
+  ignoredImports: ignored,
+  strict,
+};
+
+if (missing.length > 0) {
+  result.status = 'rejected';
+  result.reason = 'missing_children';
+  result.howToFix =
+    'Build the missing children first (each must appear in builtComponents.json), then re-run this check.';
+  console.error(JSON.stringify(result, null, 2));
+  process.exit(1);
+}
+
+const markerDir = path.join(cwd, '.temp/figma-from-code/prereqs');
+fs.mkdirSync(markerDir, { recursive: true });
+const markerPath = path.join(markerDir, `${componentName}.ok`);
+const markerBody = {
+  status: 'ok',
+  componentName,
+  sourceFile: sourcePath,
+  availableChildren: available.sort(),
+  resolvedSubExports,
+  checkedAt: new Date().toISOString(),
+  builtComponentsCache: resolvedSource,
+};
+fs.writeFileSync(markerPath, JSON.stringify(markerBody, null, 2));
+console.log(`OK ${componentName}: ${available.length} child(ren) verified. Marker: ${markerPath}`);
+process.exit(0);

--- a/plugins/figma-from-code/skills/figma-from-code/7-build-component/prompts/analyze.md
+++ b/plugins/figma-from-code/skills/figma-from-code/7-build-component/prompts/analyze.md
@@ -1,0 +1,32 @@
+## Step 1: Analyze — Inputs and Instructions
+
+Analyze a React component's source code and produce a `code.json` analysis file.
+
+Read the step-1-analyze.md file at:
+${CLAUDE_SKILL_DIR}/7-build-component/step-1-analyze.md
+
+Follow ALL sub-steps (0 through 1g). Write code.json to:
+{sourceDir}/.figma/code.json
+
+### Required inputs
+
+- Component name: {componentName}
+- Source file: {sourceFile}
+- Source dir: {sourceDir}
+- Built components: read from `.temp/figma-from-code/builtComponents.json`
+- Pre-existing components: read from `state.json -> preExistingComponents`
+- Dev server URL: {devServerUrl}
+
+Screenshot dir convention: `.temp/figma-from-code/screenshots/{componentName}/`
+
+### Early exit conditions
+
+If {componentName} appears as a key in preExistingComponents, this component
+pre-dates the current pipeline run. Write a result file with "status": "needs_authorization"
+and "preExistingTouched": ["{componentName}"] to
+.temp/figma-from-code/build-results/{componentName}.json and stop immediately.
+Do NOT analyze, do NOT write code.json — just write the rejection and return.
+
+If any child component is missing from builtComponents, write a rejection result
+(status: "rejected", missingChildren: [...]) to
+.temp/figma-from-code/build-results/{componentName}.json and stop.

--- a/plugins/figma-from-code/skills/figma-from-code/7-build-component/prompts/build-component-full.md
+++ b/plugins/figma-from-code/skills/figma-from-code/7-build-component/prompts/build-component-full.md
@@ -1,0 +1,458 @@
+# Build One Figma Component — Full Pipeline (Steps 1–7)
+
+> **Note:** This is the single-agent reference (all 7 steps in one agent). The active workflow
+> path is the **4-stage split** under `prompts/stages/{analyze,build,compare,fix}.md`, where each
+> stage runs as its own focused agent. Keep this file in sync with those when the build logic
+> changes; it remains the authoritative end-to-end description and the basis for any single-agent
+> or 2-stage variant.
+
+You are building a single Figma component from its React source, then comparing it
+against the app screenshot and iterating until it matches. Execute all seven steps
+below in order. This document is self-contained — do not read other SKILL.md files.
+
+## Inputs (interpolated by the orchestrator)
+
+- Component name: `{componentName}`
+- Source file: `{sourceFile}` (may be empty for synthesized Icon/Asset components)
+- Source dir (modlet root whose `.figma/` holds the tracking files): `{sourceDir}`
+- Figma file key: `{fileKey}`
+- Parent frame node ID (the tier frame to append into): `{parentFrameId}`
+- Dev server URL: `{devServerUrl}`
+- Screenshot dir: `.temp/figma-from-code/screenshots/{componentName}/`
+- Built components registry: `.temp/figma-from-code/builtComponents.json`
+- Pre-existing components: `state.json → preExistingComponents`
+
+## Tool & script paths
+
+- Live inspection: `node ${CLAUDE_SKILL_DIR}/10-validator/inspect-styles.js`
+- Prereq gate: `node ${CLAUDE_SKILL_DIR}/7-build-component/check-prereqs.js <componentName> <sourceFile>`
+- Instance gate: `node ${CLAUDE_SKILL_DIR}/7-build-component/check-instances.js <componentName> <sourceDir>`
+- Pixel compare: `node ${CLAUDE_SKILL_DIR}/10-validator/compare.js <app.png> <figma.png> <outDir>/`
+
+## Early-exit gates (check BEFORE any work)
+
+1. **Pre-existing master** — if `{componentName}` is a key in `preExistingComponents`,
+   it predates this run. Write `{ "componentName": "{componentName}", "status": "needs_authorization", "preExistingTouched": ["{componentName}"] }`
+   to `.temp/figma-from-code/build-results/{componentName}.json` and **return immediately**.
+   Do not analyze, do not write `code.json`, do not call `use_figma`.
+2. **Missing children** — if any child component (sub-component or `Icon/{Name}`) the
+   source uses is absent from `builtComponents`, write `{ "componentName": "...", "status": "rejected", "reason": "missing_children", "missingChildren": [...] }`
+   to the build-results file and **return immediately**.
+
+Instancing a child that is itself in `preExistingComponents` is fine (reuse, not
+modification). The fix loop must never edit a node in `preExistingComponents`.
+
+---
+
+# Step 1 — Analyze the source → write `code.json`
+
+Produce `{sourceDir}/.figma/code.json`. Create `.figma/` (and parents) first.
+Write a skeleton immediately (crash-recovery signal), accumulate sub-step results in
+memory, then write the complete file once at the end of 1g (or 1f if 1g is skipped).
+
+`code.json` schema (fields filled across sub-steps):
+
+```json
+{
+  "componentName": "...",
+  "sourceFile": "...",
+  "analyzedAt": "<ISO 8601 UTC>",
+  "lastCommit": { "hash": "...", "date": "...", "message": "..." },
+  "liveInspection": "complete" | "skipped_no_dev_server" | "skipped_explicitly",
+  "layout": { "direction": "VERTICAL"|"HORIZONTAL", "widthIntent": "...", "heightIntent": "..." },
+  "variantAxes": [ /* see 1b */ ],
+  "variantCombos": [ /* see 1b-iii */ ],
+  "variantStrategy": "representative",
+  "totalPossibleCombinations": 0,
+  "iconUsage": [ { "name": "Star", "figmaComponent": "Icon/Star", "size": 20 } ],
+  "childComponents": [ { "figmaName": "...", "nodeId": "...", "usageCount": 1, "usages": ["..."] } ],
+  "textContent": { /* from text.json */ },
+  "computedStyles": { /* from Step 1g */ },
+  "states": { /* from Step 1g */ }
+}
+```
+
+**Step 0 — skeleton.** Get the git commit: `git log -1 --format="%H|%aI|%s" -- {sourceFile}`
+(all null if untracked). Write the skeleton with all analysis fields `null`.
+
+**1a — structure & sizing intent.** Read the source. Determine layout direction
+(`flex-col` → VERTICAL; `flex`/`flex-row` → HORIZONTAL). Classify each axis of the
+*outermost* container as:
+- `fill` — `w-full`, `flex-1`, `flex: 1`, `min-w-full`, or in a flex parent without sized siblings
+- `fixed:NNN` — explicit `w-[200px]`, `w-64`, `h-10`
+- `hug` — content-driven (none of the above)
+
+Record `layout: { direction, widthIntent, heightIntent }`. Step 4b verifies this.
+
+Sizing promotions:
+- **Parent-context (1g ran):** read `layoutContext` from `computed-styles.json`. If
+  `parent.clientWidth - paddingL - paddingR ≥ element.offsetWidth × 1.25` AND that gap
+  ≥ 200px, promote `widthIntent` from `hug` to `fill:<parentContentWidth>`. Never promote
+  over an explicit `fixed:NNN`.
+- **Role hint:** path under `pages/`/`routes/`, or name ends in `Page`/`Screen`/`Layout`
+  → page-level; default to filling the screen body (read body size from `screensFrameId`,
+  ~1380×768).
+- **Page-consumed fallback (1g skipped):** if the file is imported by anything under
+  `pages/`/`routes/`, treat as page-level for sizing.
+
+**1b — variant axes & representative combos.** Extract axes from these sources:
+
+- *1b-i variant library:* find `cva()`/`tv()`/`defineRecipe()`/`styleVariants()`. For each
+  key in `variants`, create an axis `{ property: PascalCase(key), values, defaultValue (from defaultVariants or first), source: "variant-library", classMap: <verbatim Tailwind strings per value> }`.
+  Also capture the cva base classes (first arg) for the shared layout foundation, and
+  `compoundVariants` if present.
+- *1b-ii CSS pseudo-states:* if Step 1g's `states.json` has any `captured: true` state, add
+  `{ property: "State", values: ["Default", ...captured], defaultValue: "Default", source: "css-pseudo-state", stateStyles: <resolved RGB/box-shadow/opacity diffs> }`.
+- *1b-iii responsive breakpoints:* scan JSX for paired visibility classes
+  (`lg:hidden` vs `hidden lg:flex`, etc.). When blocks differ structurally, add a `Layout`
+  axis `{ values: ["Desktop","Mobile",...], defaultValue: "Desktop", source: "responsive-breakpoint", breakpoint, visibilityMap: { <value>: { include:[...], exclude:[...] } } }`.
+  Keep the largest breakpoint as default.
+- *1b-iv prop-driven states:* scan for `useState` controlling overlays/modals/menus and
+  conditional overlay rendering. Add/merge a `State` axis with
+  `stateConfig: { <value>: { description, overlays: [{ component, trigger, content/props, position }] } }`.
+  Do NOT extract hover/focus/disabled here (those are 1b-ii) or non-visual state.
+
+Compute the **representative combo set** (vary one axis at a time from the default):
+
+```
+defaultCombo = { axis.property: axis.defaultValue for each axis }
+combos = [defaultCombo]
+for each axis: for each value != defaultValue: combos.push({ ...defaultCombo, [axis.property]: value })
+```
+
+Yields `1 + Σ(values−1)` combos. If > 30, drop values from lower-priority axes
+(priority: responsive layout > visual-identity > prop states > interactive states > sizes > roundness).
+Single-variant components: `variantAxes: []`, `variantCombos: [{}]`.
+
+**1c — icons.** From `lucide-react` imports, map each to `Icon/{Name}` and size by class:
+`h-3 w-3`=12, `h-3.5 w-3.5`=14, `h-4 w-4`=16, `h-5 w-5`=20, `h-6 w-6`=24. Record `iconUsage`.
+
+**1d — instance reuse → `childComponents`.** One entry per *direct* design-system child
+the source uses (PascalCase imports from `./components/`, `@/components/`, or `lucide-react`
+that resolve to a `builtComponents` key; `Star`→`Icon/Star`). Each:
+`{ figmaName, nodeId: builtComponents[figmaName], usageCount, usages }`. Portal children
+(`ConfirmationDialog`, `AlertDialog`, toasts) MUST be included with `usages` prefixed `"portal:"`.
+Exclude the component itself and transitive grandchildren. **This list is the Step 4a contract** —
+substituting a text node or local frame for any entry is a hard rejection.
+
+**1e — prerequisite gate.** Verify every required child exists in `builtComponents`. If any
+is missing, write the `rejected` / `missing_children` result and STOP. Then run:
+
+```bash
+node ${CLAUDE_SKILL_DIR}/7-build-component/check-prereqs.js {componentName} {sourceFile}
+```
+
+It writes `.temp/figma-from-code/prereqs/{componentName}.ok` (exit 0) or prints rejection JSON
+(exit 1). A `PreToolUse` hook blocks `use_figma` master creation without a fresh `.ok` marker.
+Do not evade the hook. Only proceed past Step 1 if it exits 0.
+
+**1f — text content.** Read `text.json` from the screenshot dir; hold as `textContent`. Use exact
+strings — never placeholders. If 1g will be skipped, write the complete `code.json` now with
+`liveInspection: "skipped_..."`, omitting `computedStyles`/`states`.
+
+**1g — live inspection (authoritative; do not silently skip).**
+
+```bash
+node ${CLAUDE_SKILL_DIR}/10-validator/inspect-styles.js \
+  "{devServerUrl}/{route}" --selector "{selector}" \
+  --output ".temp/figma-from-code/screenshots/{componentName}/"
+```
+
+Produces `computed-styles.json` (resolved colors/spacing/typography/borders + `layoutContext`),
+`state-*.png` (only when visually different), and `states.json`. Use resolved RGB values
+directly. Each captured state screenshot becomes a `State` variant. Skipped states get no variant.
+
+If `{devServerUrl}` is provided, use it. If no route/selector is known, derive: grep for routes
+rendering `{componentName}`, use `[data-component='{componentName}']` or a text match. Only skip
+1g if no dev server is reachable AND it's been confirmed unavailable — record
+`liveInspection: "skipped_no_dev_server"` in the result so the validator can re-check.
+
+**Final write:** merge all in-memory values, set `liveInspection`, fill `computedStyles`/`states`,
+apply any 1a width promotion from `layoutContext`, and overwrite `code.json` in one write.
+
+---
+
+# Step 2 — Build in Figma via `use_figma`
+
+> Before any `use_figma` call, invoke the `figma:figma-use` skill (mandatory prerequisite).
+
+**2-pre. Resolve children first.** Read `code.json.childComponents` — this is the instance
+manifest. Every name MUST appear as an `INSTANCE` in the final build. For each entry,
+`figma.getNodeById(nodeId)` then `.createInstance()` exactly `usageCount` times. Override
+**only text** (`characters`) inside instances; never override `fontSize`/`fontName`/`lineHeight`/`fills`
+during build (the fix loop handles style mismatches with diff evidence). Never replace an
+instance with a text node because it "looks the same."
+
+Build order inside the script: (1) resolve masters → (2) create instances → (3) override
+characters → (4) create component shell (layout/padding/fills) → (5) append instances + plain
+text nodes (only for text NOT owned by a child) → (6) `fixSizing()` + append to parent.
+
+**Background frame — build fresh into `{parentFrameId}`, never reuse a master elsewhere.**
+The orchestrator provides `{parentFrameId}` (a white tier frame); create this component fresh
+and append it there. You will likely find an existing master with the same name on another page
+(via the source modlet's `.figma/figma.json`, a by-name search, or a prior run) — **ignore it.**
+Reusing or returning an off-page master defeats the build: this run must produce a fresh node
+inside `{parentFrameId}`. The only legitimate skip is when `{componentName}` is already a key in
+`builtComponents.json` (the orchestrator already filtered those out before dispatching you).
+
+If `figma.getNodeById('{parentFrameId}')` returns null, the tier frame may not have synced to
+your session yet — re-query once or twice before proceeding. Do **not** fall back to an existing
+off-page master or a stale tier frame; if it is still null after retries, return
+`status: "failed"` with `reason: "parent_frame_missing"` so the orchestrator can re-dispatch.
+
+**2a — single component (variantAxes empty):**
+
+```javascript
+// use_figma
+const parentFrame = figma.getNodeById('{parentFrameId}');
+// resolve masters from code.json.childComponents, create instances, override characters…
+const comp = figma.createComponent();
+comp.name = '{componentName}';
+comp.layoutMode = 'VERTICAL'; // or HORIZONTAL from layout.direction
+comp.primaryAxisSizingMode = 'AUTO';
+comp.counterAxisSizingMode = 'AUTO';
+comp.itemSpacing = GAP; comp.paddingTop = PT; comp.paddingBottom = PB;
+comp.paddingLeft = PL; comp.paddingRight = PR;
+comp.cornerRadius = RADIUS;
+comp.fills = [FILL];
+comp.strokes = [STROKE]; comp.strokeWeight = 1; comp.strokeAlign = 'OUTSIDE'; // if bordered
+// append instances + layout frames + plain text nodes…
+fixSizing(comp);
+parentFrame.appendChild(comp);
+return JSON.stringify({ name: comp.name, id: comp.id });
+```
+
+**2b — component with variants (variantAxes non-empty).** Inline `variantAxes` and
+`variantCombos` from `code.json` into the script (the plugin sandbox has no `fs`). Iterate
+`variantCombos`; do not hardcode variant values. For each combo: create a component, apply
+base layout (from cva base classes / `computedStyles`), then per-axis overrides:
+- `variant-library` → parse `classMap[val]` via the §2d table + §2e color chain
+- `css-pseudo-state` → apply `stateStyles[val]` directly (already resolved)
+- `responsive-breakpoint` → build only the blocks in `visibilityMap[val].include`; mobile
+  variants typically `widthIntent: fill` at 375px
+- `prop-state` → build base + the overlays in `stateConfig[val].overlays` (menu dropdown,
+  modal+backdrop), using exact text from the source props
+
+Name each `"Prop=val, Prop2=val2"`. Then:
+
+```javascript
+const set = figma.combineAsVariants(variants, parentFrame);
+set.name = '{componentName}';
+set.layoutMode = 'HORIZONTAL'; set.layoutWrap = 'WRAP';
+set.primaryAxisSizingMode = 'AUTO'; set.counterAxisSizingMode = 'AUTO';
+set.paddingTop = set.paddingBottom = set.paddingLeft = set.paddingRight = 16;
+set.itemSpacing = 16; set.counterAxisSpacing = 16;
+for (const v of set.children) fixSizing(v);
+fixSizing(set);
+return JSON.stringify({ name: set.name, id: set.id, variants: set.children.map(c => ({ name: c.name, id: c.id })) });
+```
+
+**2c — child element patterns.**
+- Text: `await figma.loadFontAsync({family:'Inter', style})` then `createText()`; set
+  `characters`/`fontSize`/`fontName`/`fills`/`lineHeight`. Text nodes do NOT support padding —
+  wrap in an auto-layout frame with `fills:[]`.
+- Icon instance: `getNodeById(builtComponents['Icon/Check']).createInstance()`, then `resize(16,16)`.
+- Override text inside an instance: pick variant via `inst.setProperties({...})` if it's a set,
+  `inst.findOne(n => n.type==='TEXT' && ...)` (or `findAll` by position/name), `await loadFontAsync(text.fontName)`, set `characters`. Multi-field: match label/value by `findAll` order or `name`.
+- Rectangle (divider): `createRectangle()`, `resize(W,1)`, set `fills`, `layoutSizingHorizontal='FILL'`.
+
+**2d — Tailwind → Figma map.**
+
+| Tailwind | Figma | Value |
+| --- | --- | --- |
+| `flex-col` / `flex`,`flex-row` | `layoutMode` | `VERTICAL` / `HORIZONTAL` |
+| `items-center` | `counterAxisAlignItems` | `CENTER` |
+| `justify-between` / `justify-center` | `primaryAxisAlignItems` | `SPACE_BETWEEN` / `CENTER` |
+| `gap-{n}` / `p-{n}` / `px-{n}` / `py-{n}` | `itemSpacing` / paddings | `n*4` |
+| `rounded-md`/`-lg`/`-xl`/`-full` | `cornerRadius` | `6`/`8`/`12`/`9999` |
+| `border` | `strokeWeight`=1, `strokeAlign` | `'OUTSIDE'` |
+| `text-sm`/`-base`/`-lg`/`-xl`/`-2xl` | `fontSize` (lineHeight) | `14(20)`/`16(24)`/`18(28)`/`20(28)`/`24(32)` |
+| `font-medium`/`-semibold`/`-bold` | fontName style | `Medium`/`Semi Bold`/`Bold` |
+| `w-full`/`flex-1` / `h-full` | `layoutSizingHorizontal`/`Vertical` | `FILL` |
+| `w-[Npx]` | `resize(N,..)` then `layoutSizingHorizontal` | `FIXED` |
+| `truncate` | `textTruncation`,`maxLines` | `ENDING`,1 |
+| `overflow-hidden` | `clipsContent` | `true` |
+| `shadow-sm` | `effects` | `[{type:'DROP_SHADOW',...}]` |
+| `opacity-{n}` | `opacity` | `n/100` |
+
+**2e — colors.** Primary path = Figma variables; fallback = resolved RGB. Read
+`.temp/figma-from-code/variables.json` (Node context) and inline the *relevant* entries into
+the `use_figma` script. For COLOR vars: set a fill then
+`node.setBoundVariable('fills', 0, await figma.variables.getVariableByIdAsync(id))` (same for
+`strokes`, and text-node `fills`). For FLOAT (radius): bind all four corner radii; spacing via
+`itemSpacing`. Fallback chain when a var is absent: `resolved-colors.json.tailwindMap[class]`
+→ `cssVariables[var].rgb`; bare `var(--x)` → strip wrapper → `cssVariables['--x'].rgb`; last
+resort `computed-styles.json`.
+
+**2f — enumerate instances → write `.figma/figma.json`.** This is the built-derived half of
+the Step 4a gate. After `fixSizing`+`appendChild` settle:
+
+```javascript
+const root = figma.getNodeById('<nodeId>');
+const seen = new Map();
+for (const inst of root.findAll(n => n.type === 'INSTANCE')) {
+  const main = inst.mainComponent; if (!main) continue;
+  const isVariant = main.parent && main.parent.type === 'COMPONENT_SET';
+  const name = isVariant ? main.parent.name : main.name;
+  const id = isVariant ? main.parent.id : main.id;
+  if (!seen.has(name)) seen.set(name, id);
+}
+return JSON.stringify([...seen.entries()].map(([componentName, nodeId]) => ({ componentName, nodeId })));
+```
+
+Write `{sourceDir}/.figma/figma.json`: `{ fileKey, nodeId, url: https://figma.com/design/{fileKey}?node-id=<nodeId with - >, componentName, createdAt (preserve if file exists, else now), updatedAt: now, dependencies: [ { componentName, nodeId, url, dependencies } ] }`.
+`dependencies` is always recomputed live; read each child's own `.figma/figma.json` for its
+sub-dependencies (`[]` if missing).
+
+**fixSizing() — mandatory after every build/variant:**
+
+```javascript
+function fixSizing(node, depth = 0) {
+  if (depth > 10 || !node) return;
+  const hasLayout = (node.type === 'COMPONENT' || node.type === 'FRAME' || node.type === 'COMPONENT_SET')
+    && node.layoutMode && node.layoutMode !== 'NONE';
+  if (hasLayout) {
+    if (node.layoutMode === 'VERTICAL') node.primaryAxisSizingMode = 'AUTO';
+    node.counterAxisSizingMode = 'AUTO';
+  }
+  for (const child of ('children' in node ? node.children : [])) fixSizing(child, depth + 1);
+}
+```
+
+During construction, set sizing modes to `AUTO` BEFORE `resize()` — otherwise `resize()` locks
+the height. If `use_figma` hits the incremental limit, split the build across multiple calls. If
+`componentNodeId` is null after Step 2, return `status: "failed"`.
+
+---
+
+# Step 3 — Screenshot the Figma result
+
+Skip guard: if `{screenshotDir}/figma.png` already exists, reuse it and go to Step 4 (the fix
+loop always re-screenshots regardless). Otherwise resolve the node to capture (for a set, pick
+the variant matching the app screenshot; else the component directly), then:
+
+```
+get_screenshot(fileKey, screenshotNodeId)   // request scale: 1
+curl -sL "{image_url}" -o "{screenshotDir}/figma.png"
+```
+
+---
+
+# Step 4 — Compare against the app screenshot (no fixes here)
+
+**4a — instance gate (run FIRST, hard gate).**
+
+```bash
+node ${CLAUDE_SKILL_DIR}/7-build-component/check-instances.js {componentName} {sourceDir}
+```
+
+Exit 0 → writes `.temp/figma-from-code/instances/{componentName}.ok`. Exit 1 → at least one
+required child is missing as a dependency; **stop the compare flow and jump straight to Step 5**
+with `missing_instances` (do NOT run 4b/4c). Crash (non-zero, no JSON) → record
+`instanceCheck: { verdict: "error" }` and treat as 4a failure → Step 5. There is no
+visual-equivalence shortcut: a text-node lookalike for a required instance is always wrong.
+
+**4b — sizing check (before pixel diff).** Inspect the built node:
+
+```javascript
+const node = figma.getNodeById('{nodeId}');
+const built = { w: Math.round(node.width), h: Math.round(node.height),
+  primaryAxisSizingMode: node.primaryAxisSizingMode, counterAxisSizingMode: node.counterAxisSizingMode, layoutMode: node.layoutMode };
+```
+
+Compare to Step 1a sizing intent:
+
+| Intent | Expected | Flag if |
+| --- | --- | --- |
+| `fill` | master FIXED at consumer size, or root child FILL | `*SizingMode==='AUTO'` AND dimension < 50% of expected |
+| `fill:NNN` | width = NNN ± 5% | width < NNN×0.85, or horizontal `AUTO` when parent ≥200px wider |
+| `fixed:NNN` | dimension = NNN ± 2px | diff > 2px |
+| `hug` | `*SizingMode==='AUTO'` | forced FIXED without reason |
+
+Page-level: width ≥ 1200 AND height ≥ 600 (or screen body dims). Record
+`comparison.sizingCheck { verdict, issues, builtSize, expectedSize, expectedSource }`. A
+failed 4b is a `size_mismatch` → feed into Step 5; never declare match on pixel score alone.
+
+**4c — pixel diff.**
+
+```bash
+node ${CLAUDE_SKILL_DIR}/10-validator/compare.js \
+  "{screenshotDir}/app.png" "{screenshotDir}/figma.png" "{screenshotDir}/"
+```
+
+Produces `diff.png` and `comparison.json` `{ matchPct, borderMatchPct, verdict, borderVerdict }`.
+Verdict (combined with 4a+4b):
+- 4a+4b pass AND `matchPct ≥ 90` AND `borderMatchPct ≥ 85` → **match** (done)
+- 4a fail → **missing_instances** ; 4b fail → **size_mismatch** (regardless of pixel score)
+- 4a+4b pass AND `matchPct 75–90` or `borderMatchPct < 85` → **minor_diff**
+- 4a+4b pass AND `matchPct < 75` → **mismatch**
+
+If no `app.png`, skip pixel compare but still run 4a+4b; report `no_app_reference` only if both pass.
+
+---
+
+# Step 5 — Fix loop (up to 3 iterations)
+
+Diagnose from `diff.png` + `comparison.json` — NOT from build assumptions. Read source `.tsx`
+ONLY to resolve specific differences the comparison found. **Never apply blanket fixes to all
+instances** — verify each instance against the diff before modifying it.
+
+Per iteration:
+1. **Diagnose (5a):** address 4a (`missing_instances`) FIRST, then 4b (`size_mismatch`), then
+   read `diff.png` (red = differs), `app.png` (target), `figma.png` (actual), source `.tsx`.
+
+   | Symptom | Fix |
+   | --- | --- |
+   | `missing_instances` | For each name: delete the local stand-in subtree, replace with `getNodeById(builtComponents[name]).createInstance()` (pick variant via `setProperties`); override text via `findOne`+`loadFontAsync`. Re-run 2f enum + check-instances. |
+   | sizing: master too small for `fill` | Set modes FIRST then resize: `primaryAxisSizingMode='FIXED'; counterAxisSizingMode='FIXED'; resizeWithoutConstraints(W,H)`; fill children `layoutSizingHorizontal/Vertical='FILL'`. |
+   | sizing: fixed off >2px | `resizeWithoutConstraints(W,H)` |
+   | red border ring | adjust `strokes`/`strokeWeight`/`strokeAlign` |
+   | red fill / red text | adjust `fills` / font props + text fills |
+   | shifted content | adjust `itemSpacing`/padding |
+   | missing / extra element | add / remove child |
+   | all thin strips | run `fixSizing()` |
+
+2. **Apply fix (5b):** targeted `use_figma` changing only the diagnosed properties; `fixSizing(node)`.
+3. **Re-enumerate, re-screenshot, re-compare (5c):** re-run the Step 2f enumeration + rewrite
+   `figma.json` (the tree changed). If the prior failure was `missing_instances`, re-run
+   check-instances and don't pixel-compare until 4a passes. Then `get_screenshot` →
+   overwrite `figma.png` → re-run `compare.js`.
+4. **Continue/stop (5d):** `match` → exit (fixed). Improved but not match → next iteration.
+   3 iterations reached → exit with `status: "partial_match"`, report remaining issues. Do not
+   retry Step 5.
+
+Optional structural audit before first compare: flag `strokeAlign==='INSIDE'` with strokes
+(double border) and >1 visible fill (color blending); fix before screenshotting.
+
+---
+
+# Step 6 — Finalize tracking files
+
+Both `.figma/code.json` (Step 1) and `.figma/figma.json` (Steps 2f/5c) already exist. Verify
+both are present at `{sourceDir}/.figma/`. Refresh `figma.json.updatedAt` (preserve `createdAt`).
+Sanity-check: `code.json.componentName === figma.json.componentName === {componentName}`;
+`figma.json.fileKey` matches; `figma.json.nodeId` matches the built node; `dependencies` is an
+array. Surface any violation in the result — do not silently repair.
+
+---
+
+# Step 7 — Write result & return
+
+Write `.temp/figma-from-code/build-results/{componentName}.json` and return the same object:
+
+```json
+{
+  "componentName": "{componentName}",
+  "nodeId": "123:45",
+  "type": "COMPONENT" | "COMPONENT_SET",
+  "variants": [ { "name": "Variant=primary, State=Default", "nodeId": "123:46" } ],
+  "comparison": { "matchPct": 94.2, "borderMatchPct": 91.0, "verdict": "match", "iterations": 1, "fixes": ["..."] },
+  "screenshotNodeId": "123:46",
+  "figmaScreenshot": ".temp/figma-from-code/screenshots/{componentName}/figma.png"
+}
+```
+
+For early-exit / failure cases, write the corresponding status object
+(`needs_authorization`, `rejected`, `failed`, `partial_match`, or
+`comparison.verdict: "no_app_reference"`). The orchestrator reads `componentName`, `status`,
+`nodeId`, `verdict`, `matchPct`, and `iterations` from the returned object.

--- a/plugins/figma-from-code/skills/figma-from-code/7-build-component/prompts/compare.md
+++ b/plugins/figma-from-code/skills/figma-from-code/7-build-component/prompts/compare.md
@@ -1,0 +1,33 @@
+## Steps 4b, 4c: Compare — Inputs and Instructions
+
+Compare a Figma component against its app screenshot and produce a verdict.
+Do NOT attempt any fixes — only compare and report. If the verdict is not "match", Step 5 handles fixes.
+
+Read the step-4-compare.md file at:
+${CLAUDE_SKILL_DIR}/7-build-component/step-4-compare.md
+
+Run Step 4b (sizing check), then Step 4c (pixel diff).
+
+### Required inputs
+
+- Component name: {componentName}
+- Figma file key: {fileKey}
+- Component node ID: {componentNodeId}
+- Screenshot node ID: {screenshotNodeId}
+- Sizing intent: from code.json
+- App screenshot: .temp/figma-from-code/screenshots/{componentName}/app.png
+- Figma screenshot: .temp/figma-from-code/screenshots/{componentName}/figma.png
+- Screenshot dir: .temp/figma-from-code/screenshots/{componentName}/
+- Instance check result: from Step 4a
+
+### Expected output
+
+```json
+{
+  "sizingCheck": { "verdict": "pass"|"fail", "issues": [...], "builtSize": {"w": N, "h": N} },
+  "matchPct": 94.2,
+  "borderMatchPct": 91.0,
+  "verdict": "match"|"minor_diff"|"mismatch",
+  "borderVerdict": "border_ok"|"border_diff"
+}
+```

--- a/plugins/figma-from-code/skills/figma-from-code/7-build-component/prompts/fix.md
+++ b/plugins/figma-from-code/skills/figma-from-code/7-build-component/prompts/fix.md
@@ -1,0 +1,46 @@
+## Step 5: Fix Loop — Inputs and Instructions
+
+Fix visual discrepancies in a Figma component by comparing it against its
+app screenshot. Diagnose from comparison data, not build assumptions.
+
+Read the step-5-fix-loop.md file at:
+${CLAUDE_SKILL_DIR}/7-build-component/step-5-fix-loop.md
+
+### Critical rules
+
+- Diagnosis MUST start from diff.png and comparison.json
+- Read the source .tsx ONLY to resolve specific differences the comparison found
+- NEVER apply blanket fixes to all instances of a component type — verify each
+  instance individually against the diff before modifying it
+- After each fix: re-enumerate instances (Step 2f), re-screenshot, re-compare
+
+### Required inputs
+
+- Component name: {componentName}
+- Figma file key: {fileKey}
+- Component node ID: {componentNodeId}
+- Screenshot node ID: {screenshotNodeId}
+- Source file: {sourceFile}
+- CSS file: {cssFile} (or "none" if not available)
+- App screenshot: .temp/figma-from-code/screenshots/{componentName}/app.png
+- Figma screenshot: .temp/figma-from-code/screenshots/{componentName}/figma.png
+- Screenshot dir: .temp/figma-from-code/screenshots/{componentName}/
+- Source dir: {sourceDir}
+- Sizing intent: from code.json
+- Compare verdict: from Step 4
+- Built components: read from `.temp/figma-from-code/builtComponents.json`
+- Pre-existing components: read from `state.json -> preExistingComponents`
+- code.json path: {sourceDir}/.figma/code.json
+- figma.json path: {sourceDir}/.figma/figma.json
+
+### Expected output
+
+```json
+{
+  "verdict": "match"|"minor_diff"|"mismatch",
+  "matchPct": 94.2,
+  "borderMatchPct": 91.0,
+  "iterations": 2,
+  "fixes": ["description of each fix applied"]
+}
+```

--- a/plugins/figma-from-code/skills/figma-from-code/7-build-component/prompts/stages/analyze.md
+++ b/plugins/figma-from-code/skills/figma-from-code/7-build-component/prompts/stages/analyze.md
@@ -1,0 +1,164 @@
+# Stage 1 of 4 — Analyze the component → `code.json`
+
+You are the **analyze** stage of a 4-stage per-component pipeline (analyze → build →
+compare → fix). Your only job: read the source, inspect the live component, and produce a
+complete `code.json`. Do NOT call `use_figma`. Do NOT build anything.
+
+## Inputs
+
+- Component name: `{componentName}`
+- Figma file key: `{fileKey}`
+- Dev server URL: `{devServerUrl}`
+- Built components registry: `.temp/figma-from-code/builtComponents.json`
+- Pre-existing components: `state.json → preExistingComponents`
+- Component map (resolve source path here): `.temp/figma-from-code/component-map.json`
+- Screenshot dir: `.temp/figma-from-code/screenshots/{componentName}/`
+
+**Resolve the source first.** Look up `{componentName}` in `component-map.json`; take its
+file path as `sourceFile` and that file's modlet directory as `sourceDir`. For synthesized
+`Icon/{Name}` / `Asset/{Name}` components, `sourceFile` may be empty and
+`sourceDir` = `<source-dir>/components/<Icon|Asset>/{Name}/`. You MUST return both so
+the later stages don't re-resolve them.
+
+## Early-exit gates (check BEFORE any work)
+
+1. **Pre-existing master** — if `{componentName}` is a key in `preExistingComponents`, write
+   `{ "componentName": "{componentName}", "status": "needs_authorization", "preExistingTouched": ["{componentName}"] }`
+   to `.temp/figma-from-code/build-results/{componentName}.json` and return
+   `status: "needs_authorization"`. Do no further work.
+2. **Missing children** — after step 1d below, if any child (sub-component or `Icon/{Name}`)
+   the source uses is absent from `builtComponents`, write
+   `{ "componentName": "...", "status": "rejected", "reason": "missing_children", "missingChildren": [...] }`
+   to the build-results file and return `status: "rejected"`.
+
+Instancing a child that is itself in `preExistingComponents` is fine (reuse, not modification).
+
+## Step 1 — write `{sourceDir}/.figma/code.json`
+
+Create `.figma/` (and parents) first. Write a skeleton immediately (crash-recovery), accumulate
+sub-step results in memory, then write the complete file once at the end of 1g (or 1f if 1g is
+skipped).
+
+Schema:
+
+```json
+{
+  "componentName": "...",
+  "sourceFile": "...",
+  "analyzedAt": "<ISO 8601 UTC>",
+  "lastCommit": { "hash": "...", "date": "...", "message": "..." },
+  "liveInspection": "complete" | "skipped_no_dev_server" | "skipped_explicitly",
+  "layout": { "direction": "VERTICAL"|"HORIZONTAL", "widthIntent": "...", "heightIntent": "..." },
+  "variantAxes": [ /* 1b */ ],
+  "variantCombos": [ /* 1b-iii */ ],
+  "variantStrategy": "representative",
+  "totalPossibleCombinations": 0,
+  "iconUsage": [ { "name": "Star", "figmaComponent": "Icon/Star", "size": 20 } ],
+  "childComponents": [ { "figmaName": "...", "nodeId": "...", "usageCount": 1, "usages": ["..."] } ],
+  "textContent": { /* from text.json */ },
+  "computedStyles": { /* Step 1g */ },
+  "states": { /* Step 1g */ },
+  "figmaVariables": { /* Step 1h: ONLY the color/radius tokens THIS component uses, pre-resolved so the build stage needn't open the large variable files. Shape: { "<tailwindClass|cssVar>": { "id": "<figmaVariableId|null>", "rgb": { "r":_, "g":_, "b":_, "a":_ } } } */ }
+}
+```
+
+**Step 0 — skeleton.** `git log -1 --format="%H|%aI|%s" -- {sourceFile}` (null if untracked).
+Write the skeleton with all analysis fields `null`.
+
+**1a — structure & sizing intent.** Layout direction (`flex-col`→VERTICAL; `flex`/`flex-row`→
+HORIZONTAL). Classify each axis of the *outermost* container:
+- `fill` — `w-full`, `flex-1`, `flex: 1`, `min-w-full`, or in a flex parent without sized siblings
+- `fixed:NNN` — explicit `w-[200px]`, `w-64`, `h-10`
+- `hug` — content-driven
+
+Promotions: (a) **parent-context (1g ran):** read `layoutContext` from `computed-styles.json`;
+if `parent.clientWidth − padL − padR ≥ element.offsetWidth × 1.25` AND gap ≥ 200px, promote
+`hug` → `fill:<parentContentWidth>` (never over an explicit `fixed:NNN`). (b) **role hint:** path
+under `pages/`/`routes/` or name ends `Page`/`Screen`/`Layout` → page-level, default to filling
+the screen body (~1380×768 from `screensFrameId`). (c) **page-consumed fallback (1g skipped):**
+file imported under `pages/`/`routes/` → treat page-level.
+
+**1b — variant axes & representative combos.**
+- *1b-i variant library:* find `cva()`/`tv()`/`defineRecipe()`/`styleVariants()`. Per `variants`
+  key → axis `{ property: PascalCase(key), values, defaultValue, source: "variant-library", classMap: <verbatim Tailwind per value> }`. Also keep the cva base classes (first arg) and `compoundVariants`.
+- *1b-ii CSS pseudo-states:* if 1g `states.json` has `captured: true` states, add a `State` axis
+  `{ values: ["Default", ...captured], source: "css-pseudo-state", stateStyles: <resolved diffs> }`.
+- *1b-iii responsive:* paired visibility classes (`lg:hidden` vs `hidden lg:flex`) with structurally
+  different blocks → `Layout` axis `{ values:["Desktop","Mobile",...], source:"responsive-breakpoint", breakpoint, visibilityMap:{<v>:{include:[],exclude:[]}} }`. Default = largest breakpoint.
+- *1b-iv prop states:* `useState` controlling overlays/modals/menus → `State` axis with
+  `stateConfig:{<v>:{description, overlays:[{component,trigger,content/props,position}]}}`. Do NOT
+  put hover/focus/disabled here (those are 1b-ii).
+
+Representative set (vary one axis at a time from default):
+`combos = [defaultCombo]; for each axis: for each value≠default: combos.push({...defaultCombo,[prop]:value})`.
+If > 30, drop values from lower-priority axes (responsive > visual-identity > prop states >
+interactive states > sizes > roundness). Single-variant: `variantAxes:[]`, `variantCombos:[{}]`.
+
+**1c — icons.** `lucide-react` imports → `Icon/{Name}`, size by class (`h-3`=12, `h-3.5`=14,
+`h-4`=16, `h-5`=20, `h-6`=24). Record `iconUsage`.
+
+**1d — instance reuse → `childComponents`.** One entry per *direct* design-system child
+(PascalCase imports from `./components/`, `@/components/`, `lucide-react` that resolve to a
+`builtComponents` key; `Star`→`Icon/Star`): `{ figmaName, nodeId: builtComponents[figmaName], usageCount, usages }`. Portal children (`ConfirmationDialog`, `AlertDialog`, toasts) included with
+`usages` prefixed `"portal:"`. Exclude self + transitive grandchildren. **This list is the
+compare-stage 4a contract** — do not omit any.
+
+**1e — prerequisite gate.** Verify every required child is in `builtComponents`; if any missing,
+write the `rejected`/`missing_children` result and return. Then run:
+
+```bash
+node ${CLAUDE_SKILL_DIR}/7-build-component/check-prereqs.js {componentName} {sourceFile}
+```
+
+Exit 0 writes `.temp/figma-from-code/prereqs/{componentName}.ok`. Exit 1 = rejection — write it
+and return. (A `PreToolUse` hook blocks the build stage's `use_figma` without a fresh `.ok`.)
+
+**1f — text content.** Read `text.json` from the screenshot dir → `textContent` (exact strings,
+never placeholders). If 1g will be skipped, write the complete `code.json` now with
+`liveInspection: "skipped_..."`, omitting `computedStyles`/`states`.
+
+**1g — live inspection (authoritative; do not silently skip).**
+
+```bash
+node ${CLAUDE_SKILL_DIR}/10-validator/inspect-styles.js \
+  "{devServerUrl}/{route}" --selector "{selector}" \
+  --output ".temp/figma-from-code/screenshots/{componentName}/"
+```
+
+Produces `computed-styles.json` (resolved colors/spacing/typography/borders + `layoutContext`),
+`state-*.png` (only when visually different), `states.json`. Use resolved RGB directly; each
+captured state becomes a `State` variant. If no route/selector known, derive: grep routes
+rendering `{componentName}`, use `[data-component='{componentName}']` or a text match. Only skip
+1g if no dev server is reachable AND confirmed unavailable — record `liveInspection: "skipped_no_dev_server"`.
+
+**1h — pre-resolve variables (shrinks the build stage's context).** Collect every color/radius
+token this component actually uses (fills, strokes, text colors, corner radii gathered across
+1a–1g). Resolve each ONCE here against `.temp/figma-from-code/variables.json` (→ Figma variable
+`id`) and `.temp/figma-from-code/resolved-colors.json` (`tailwindMap`/`cssVariables` → `rgb`). Inline
+ONLY those used entries into `code.json.figmaVariables` as
+`{ "<tailwindClass|cssVar>": { "id": <figmaVariableId|null>, "rgb": {r,g,b,a} } }`. Do NOT dump the
+whole variable files — the build stage reads only this subset (and falls back to the full files
+solely for a token missing here), so keeping it minimal is what keeps the build agent's context
+small.
+
+**Final write:** merge all in-memory values, set `liveInspection`, fill `computedStyles`/`states`,
+add `figmaVariables`, apply any 1a width promotion, overwrite `code.json` in one write.
+
+## Return (StructuredOutput)
+
+```json
+{
+  "componentName": "{componentName}",
+  "status": "proceed" | "needs_authorization" | "rejected" | "failed",
+  "sourceFile": "...",
+  "sourceDir": "...",
+  "route": "/example",
+  "selector": "[data-component='...']",
+  "hasVariants": true,
+  "liveInspection": "complete" | "skipped_no_dev_server" | "skipped_explicitly",
+  "missingChildren": []
+}
+```
+
+Return `status: "proceed"` only when `code.json` is complete and the prereq gate passed.
+`route`/`selector` are what you used for 1g (pass them downstream for re-inspection).

--- a/plugins/figma-from-code/skills/figma-from-code/7-build-component/prompts/stages/build.md
+++ b/plugins/figma-from-code/skills/figma-from-code/7-build-component/prompts/stages/build.md
@@ -1,0 +1,183 @@
+# Stage 2 of 4 — Build the component in Figma
+
+You are the **build** stage of a 4-stage per-component pipeline (analyze → build → compare →
+fix). The analyze stage already wrote `{sourceDir}/.figma/code.json`. Your job: build the Figma
+component fresh from `code.json` into `{parentFrameId}`, screenshot it, and write
+`{sourceDir}/.figma/figma.json`. Do NOT compare or fix.
+
+> Before any `use_figma` call, invoke the `figma:figma-use` skill (mandatory prerequisite).
+
+## Inputs
+
+- Component name: `{componentName}`
+- Figma file key: `{fileKey}`
+- Parent frame node ID (tier frame — build INTO this): `{parentFrameId}`
+- Source dir (holds `.figma/code.json`): `{sourceDir}`
+- Built components registry: `.temp/figma-from-code/builtComponents.json`
+- Screenshot dir: `.temp/figma-from-code/screenshots/{componentName}/`
+- Colors: **primary source is `code.json.figmaVariables`** (pre-resolved by the analyze stage — only
+  the tokens THIS component uses, each as `{ id, rgb }`). The large files
+  `.temp/figma-from-code/variables.json` and `.temp/figma-from-code/resolved-colors.json` are a
+  **fallback only** — open them solely if a required token is absent from `figmaVariables` (this keeps
+  your context small; do not read them routinely).
+
+## Idempotency check FIRST — then build fresh into `{parentFrameId}`
+
+**Before building, check whether this component already exists INSIDE `{parentFrameId}`.** A crash
+mid-tier or a resumed run may have already created it. Query the parent frame's direct children by
+name: if a `COMPONENT` or `COMPONENT_SET` named exactly `{componentName}` is already a child of
+`{parentFrameId}`, do NOT rebuild it — this would create a duplicate node. Refresh
+`{sourceDir}/.figma/figma.json` if needed and return `status: "built"` with that existing node's
+`id` as `nodeId`. This is what makes Phase 3 safe to re-run after a crash without duplicating nodes.
+
+Otherwise create this component fresh and append it to `{parentFrameId}`. You will likely find an
+existing master with the same name on **another page** (via `.figma/figma.json`, a by-name search,
+or a prior run) — **ignore it.** This run must produce a fresh node inside `{parentFrameId}`. If
+`figma.getNodeById('{parentFrameId}')` returns null, the tier frame may not have synced yet —
+re-query once or twice; if still null, return `status: "failed"`, `reason: "parent_frame_missing"`.
+Do NOT fall back to an off-page master or a stale tier frame.
+
+## Step 2 — build via `use_figma`
+
+**2-pre. Resolve children first.** Read `code.json.childComponents` — the instance manifest.
+Every name MUST become an `INSTANCE`. For each: `figma.getNodeById(nodeId)` then
+`.createInstance()` × `usageCount`. Override **only text** (`characters`); never override
+`fontSize`/`fontName`/`lineHeight`/`fills` at build time (the fix stage handles style mismatches
+with diff evidence). Never replace an instance with a text node.
+
+Script order: (1) resolve masters → (2) create instances → (3) override characters → (4) create
+component shell → (5) append instances + plain text nodes (only for text NOT owned by a child) →
+(6) `fixSizing()` + append to `{parentFrameId}`.
+
+**2a — single component** (`code.json.variantAxes` empty):
+
+```javascript
+// use_figma
+const parentFrame = figma.getNodeById('{parentFrameId}');
+const comp = figma.createComponent();
+comp.name = '{componentName}';
+comp.layoutMode = 'VERTICAL'; // or HORIZONTAL from layout.direction
+comp.primaryAxisSizingMode = 'AUTO';
+comp.counterAxisSizingMode = 'AUTO';
+comp.itemSpacing = GAP; comp.paddingTop = PT; comp.paddingBottom = PB;
+comp.paddingLeft = PL; comp.paddingRight = PR;
+comp.cornerRadius = RADIUS; comp.fills = [FILL];
+comp.strokes = [STROKE]; comp.strokeWeight = 1; comp.strokeAlign = 'OUTSIDE'; // if bordered
+// append instances + layout frames + plain text…
+fixSizing(comp);
+parentFrame.appendChild(comp);
+return JSON.stringify({ name: comp.name, id: comp.id });
+```
+
+**2b — with variants** (`variantAxes` non-empty): inline `variantAxes` + `variantCombos` from
+`code.json` (the sandbox has no `fs`); iterate combos (don't hardcode). Per combo: base layout
+from cva base classes / `computedStyles`, then per-axis overrides — `variant-library` parses
+`classMap[val]` via §2d table + §2e colors; `css-pseudo-state` applies `stateStyles[val]` directly;
+`responsive-breakpoint` builds only `visibilityMap[val].include` (mobile typically fill @ 375px);
+`prop-state` builds base + `stateConfig[val].overlays`. Name each `"Prop=val, Prop2=val2"`. Then:
+
+```javascript
+const set = figma.combineAsVariants(variants, parentFrame);
+set.name = '{componentName}';
+set.layoutMode = 'HORIZONTAL'; set.layoutWrap = 'WRAP';
+set.primaryAxisSizingMode = 'AUTO'; set.counterAxisSizingMode = 'AUTO';
+set.paddingTop = set.paddingBottom = set.paddingLeft = set.paddingRight = 16;
+set.itemSpacing = 16; set.counterAxisSpacing = 16;
+for (const v of set.children) fixSizing(v);
+fixSizing(set);
+return JSON.stringify({ name: set.name, id: set.id, variants: set.children.map(c => ({ name: c.name, id: c.id })) });
+```
+
+**2c — child patterns.** Text: `await figma.loadFontAsync({family:'Inter',style})`, `createText()`;
+text nodes don't support padding — wrap in an auto-layout frame (`fills:[]`). Icon:
+`getNodeById(builtComponents['Icon/Check']).createInstance()` + `resize(16,16)`. Override text in
+an instance: pick variant via `setProperties`, `findOne(n=>n.type==='TEXT'&&...)` (or `findAll` by
+position/name), `await loadFontAsync(text.fontName)`, set `characters`. Divider: `createRectangle()`,
+`resize(W,1)`, `fills`, `layoutSizingHorizontal='FILL'`.
+
+**2d — Tailwind → Figma:**
+
+| Tailwind | Figma | Value |
+| --- | --- | --- |
+| `flex-col` / `flex`,`flex-row` | `layoutMode` | `VERTICAL` / `HORIZONTAL` |
+| `items-center` | `counterAxisAlignItems` | `CENTER` |
+| `justify-between` / `justify-center` | `primaryAxisAlignItems` | `SPACE_BETWEEN` / `CENTER` |
+| `gap-{n}` / `p-{n}` / `px-{n}` / `py-{n}` | `itemSpacing` / paddings | `n*4` |
+| `rounded-md`/`-lg`/`-xl`/`-full` | `cornerRadius` | `6`/`8`/`12`/`9999` |
+| `border` | `strokeWeight`=1, `strokeAlign` | `'OUTSIDE'` |
+| `text-sm`/`-base`/`-lg`/`-xl`/`-2xl` | `fontSize` (lineHeight) | `14(20)`/`16(24)`/`18(28)`/`20(28)`/`24(32)` |
+| `font-medium`/`-semibold`/`-bold` | fontName style | `Medium`/`Semi Bold`/`Bold` |
+| `w-full`/`flex-1` / `h-full` | `layoutSizingHorizontal`/`Vertical` | `FILL` |
+| `w-[Npx]` | `resize(N,..)` then `layoutSizingHorizontal` | `FIXED` |
+| `truncate` | `textTruncation`,`maxLines` | `ENDING`,1 |
+| `overflow-hidden` | `clipsContent` | `true` |
+| `shadow-sm` | `effects` | `[{type:'DROP_SHADOW',...}]` |
+| `opacity-{n}` | `opacity` | `n/100` |
+
+**2e — colors.** Primary source: **`code.json.figmaVariables`** — the analyze stage pre-resolved
+every color/radius token this component uses into `{ "<class|var>": { "id": <figmaVariableId|null>,
+"rgb": {...} } }`. Use its `id` to bind the Figma variable and its `rgb` as the literal fallback;
+you should NOT need to open `variables.json`/`resolved-colors.json`. COLOR: set fill then
+`node.setBoundVariable('fills',0, await figma.variables.getVariableByIdAsync(id))` (same for
+`strokes`, text-node `fills`). FLOAT (radius): bind four corners. **Only if** a required token is
+absent from `figmaVariables`, fall back by reading the full files: `variables.json` for the id, then
+`resolved-colors.json.tailwindMap[class]`→`cssVariables[var].rgb`; bare `var(--x)`→strip→
+`cssVariables['--x'].rgb`; last resort `computed-styles.json`.
+
+**2f — enumerate instances → `{sourceDir}/.figma/figma.json`** (the built-derived 4a contract):
+
+```javascript
+const root = figma.getNodeById('<nodeId>');
+const seen = new Map();
+for (const inst of root.findAll(n => n.type === 'INSTANCE')) {
+  const main = inst.mainComponent; if (!main) continue;
+  const isVariant = main.parent && main.parent.type === 'COMPONENT_SET';
+  const name = isVariant ? main.parent.name : main.name;
+  const id = isVariant ? main.parent.id : main.id;
+  if (!seen.has(name)) seen.set(name, id);
+}
+return JSON.stringify([...seen.entries()].map(([componentName, nodeId]) => ({ componentName, nodeId })));
+```
+
+Write `{ fileKey, nodeId, url, componentName, createdAt (preserve if present else now), updatedAt: now, dependencies:[{componentName,nodeId,url,dependencies}] }`. `dependencies` recomputed live; read each child's own `.figma/figma.json` for its sub-deps (`[]` if missing).
+
+**fixSizing() — mandatory after every build/variant:**
+
+```javascript
+function fixSizing(node, depth = 0) {
+  if (depth > 10 || !node) return;
+  const hasLayout = (node.type === 'COMPONENT' || node.type === 'FRAME' || node.type === 'COMPONENT_SET')
+    && node.layoutMode && node.layoutMode !== 'NONE';
+  if (hasLayout) {
+    if (node.layoutMode === 'VERTICAL') node.primaryAxisSizingMode = 'AUTO';
+    node.counterAxisSizingMode = 'AUTO';
+  }
+  for (const child of ('children' in node ? node.children : [])) fixSizing(child, depth + 1);
+}
+```
+
+Set sizing modes to `AUTO` BEFORE `resize()` (else resize locks height). If `use_figma` hits the
+incremental limit, split across multiple calls. If the node is null after Step 2, return `status: "failed"`.
+
+## Step 3 — screenshot
+
+If `{screenshotDir}/figma.png` already exists, reuse it. Otherwise resolve the node to capture
+(for a set, the variant matching the app screenshot; else the component), then
+`get_screenshot(fileKey, screenshotNodeId)` at `scale: 1`, and
+`curl -sL "{image_url}" -o "{screenshotDir}/figma.png"`.
+
+## Return (StructuredOutput)
+
+```json
+{
+  "componentName": "{componentName}",
+  "status": "built" | "failed",
+  "reason": "parent_frame_missing",
+  "nodeId": "188:81",
+  "screenshotNodeId": "188:81",
+  "type": "COMPONENT" | "COMPONENT_SET",
+  "variants": [ { "name": "Layout=Desktop", "nodeId": "..." } ]
+}
+```
+
+`nodeId` MUST be the fresh node inside `{parentFrameId}`. `reason` only when failed.

--- a/plugins/figma-from-code/skills/figma-from-code/7-build-component/prompts/stages/compare.md
+++ b/plugins/figma-from-code/skills/figma-from-code/7-build-component/prompts/stages/compare.md
@@ -1,0 +1,111 @@
+# Stage 3 of 4 — Compare against the app screenshot → verdict
+
+You are the **compare** stage of a 4-stage per-component pipeline (analyze → build → compare →
+fix). The build stage produced the Figma node and `figma.png`. Your job: run the three gates
+(instance, sizing, pixel), produce a verdict, finalize tracking, and write the result file. Do
+**NOT** fix anything — if the verdict isn't a pass, the workflow dispatches the fix stage next.
+
+## Inputs
+
+- Component name: `{componentName}`
+- Figma file key: `{fileKey}`
+- Source dir (holds `.figma/code.json` + `figma.json`): `{sourceDir}`
+- Component node ID: `{nodeId}`
+- Screenshot node ID: `{screenshotNodeId}`
+- Screenshot dir: `.temp/figma-from-code/screenshots/{componentName}/` (`app.png`, `figma.png`)
+
+## Step 4 — compare
+
+**4a — instance gate (run FIRST):**
+
+```bash
+node ${CLAUDE_SKILL_DIR}/7-build-component/check-instances.js {componentName} {sourceDir}
+```
+
+Exit 0 → writes `instances/{componentName}.ok`, 4a passes. Exit 1 → required child(ren) missing
+as dependencies → verdict `missing_instances` (do NOT run 4b/4c). Crash (non-zero, no JSON) →
+`instanceCheck.verdict: "error"`, treat as 4a failure. There is no visual-equivalence shortcut —
+a text-node lookalike for a required instance is always a fail.
+
+**4b — sizing check** (before pixel diff). Inspect the built node:
+
+```javascript
+const node = figma.getNodeById('{nodeId}');
+const built = { w: Math.round(node.width), h: Math.round(node.height),
+  primaryAxisSizingMode: node.primaryAxisSizingMode, counterAxisSizingMode: node.counterAxisSizingMode, layoutMode: node.layoutMode };
+```
+
+Compare to `code.json` sizing intent:
+
+| Intent | Expected | Flag if |
+| --- | --- | --- |
+| `fill` | master FIXED at consumer size, or root child FILL | `*SizingMode==='AUTO'` AND dimension < 50% of expected |
+| `fill:NNN` | width = NNN ± 5% | width < NNN×0.85, or horizontal `AUTO` when parent ≥200px wider |
+| `fixed:NNN` | dimension = NNN ± 2px | diff > 2px |
+| `hug` | `*SizingMode==='AUTO'` | forced FIXED without reason |
+
+Page-level: width ≥ 1200 AND height ≥ 600 (or screen body dims). Record
+`sizingCheck { verdict, issues, builtSize, expectedSize, expectedSource }`. A failed 4b →
+verdict `size_mismatch` (regardless of pixel score).
+
+**4c — pixel diff.**
+
+```bash
+node ${CLAUDE_SKILL_DIR}/10-validator/compare.js \
+  "{screenshotDir}/app.png" "{screenshotDir}/figma.png" "{screenshotDir}/"
+```
+
+Produces `diff.png` + `comparison.json` `{ matchPct, borderMatchPct, verdict, borderVerdict }`.
+Combined verdict:
+- 4a+4b pass AND `matchPct ≥ 90` AND `borderMatchPct ≥ 85` → **match**
+- 4a fail → **missing_instances** ; 4b fail → **size_mismatch**
+- 4a+4b pass AND (`matchPct 75–90` or `borderMatchPct < 85`) → **minor_diff**
+- 4a+4b pass AND `matchPct < 75` → **mismatch**
+
+If no `app.png`, skip pixel compare but still run 4a+4b; report **no_app_reference** only if both pass.
+
+## Finalize + write result
+
+Write the full `comparison.json`-style block into the result, finalize tracking (Step 6), and
+write `.temp/figma-from-code/build-results/{componentName}.json`:
+
+- **Step 6:** verify `{sourceDir}/.figma/code.json` + `figma.json` exist; refresh `figma.json.updatedAt`
+  (preserve `createdAt`); sanity-check `componentName`/`fileKey`/`nodeId` match. Surface any
+  violation in the result; don't silently repair.
+- **Result file** (`build-results/{componentName}.json`):
+
+```json
+{
+  "componentName": "{componentName}",
+  "nodeId": "{nodeId}",
+  "type": "COMPONENT" | "COMPONENT_SET",
+  "variants": [ ... ],
+  "comparison": {
+    "matchPct": 96.0, "borderMatchPct": 94.7,
+    "verdict": "match" | "minor_diff" | "mismatch" | "size_mismatch" | "missing_instances" | "no_app_reference",
+    "iterations": 0, "fixes": [],
+    "instanceCheck": { "verdict": "pass" | "fail" | "error", "missing": [] },
+    "sizingCheck": { "verdict": "pass" | "fail" | "pass_no_reference", "builtSize": {...}, "expectedSize": {...} }
+  },
+  "screenshotNodeId": "{screenshotNodeId}",
+  "figmaScreenshot": ".temp/figma-from-code/screenshots/{componentName}/figma.png"
+}
+```
+
+## Return (StructuredOutput)
+
+```json
+{
+  "componentName": "{componentName}",
+  "nodeId": "{nodeId}",
+  "verdict": "match" | "minor_diff" | "mismatch" | "size_mismatch" | "missing_instances" | "no_app_reference",
+  "matchPct": 96.0,
+  "borderMatchPct": 94.7,
+  "needsFix": false,
+  "missingInstances": []
+}
+```
+
+Set `needsFix: true` for `minor_diff`, `mismatch`, `size_mismatch`, `missing_instances`.
+Set `needsFix: false` for `match` and `no_app_reference`. Include `missingInstances` when the
+4a gate failed so the fix stage knows what to add.

--- a/plugins/figma-from-code/skills/figma-from-code/7-build-component/prompts/stages/fix.md
+++ b/plugins/figma-from-code/skills/figma-from-code/7-build-component/prompts/stages/fix.md
@@ -1,0 +1,93 @@
+# Stage 4 of 4 — Fix loop (only runs when compare flagged a problem)
+
+You are the **fix** stage of a 4-stage per-component pipeline (analyze → build → compare → fix).
+You only run because the compare stage returned a non-passing verdict. Diagnose from `diff.png`
+and `comparison.json` — NOT from build assumptions. Read source `.tsx` ONLY to resolve specific
+differences the comparison found. **Never apply blanket fixes to all instances** — verify each
+against the diff before modifying it.
+
+> Before any `use_figma` call, invoke the `figma:figma-use` skill (mandatory prerequisite).
+
+## Inputs
+
+- Component name: `{componentName}`
+- Figma file key: `{fileKey}`
+- Source file / dir: `{sourceFile}` / `{sourceDir}`
+- Component node ID: `{nodeId}`
+- Screenshot node ID: `{screenshotNodeId}`
+- Incoming verdict: `{verdict}` (`minor_diff` | `mismatch` | `size_mismatch` | `missing_instances`)
+- Missing instances (if 4a failed): `{missingInstances}`
+- Screenshot dir: `.temp/figma-from-code/screenshots/{componentName}/` (`app.png`, `figma.png`, `diff.png`)
+- Comparison data: `.temp/figma-from-code/screenshots/{componentName}/comparison.json`
+- Built components: `.temp/figma-from-code/builtComponents.json`
+
+If `figma.getNodeById('{nodeId}')` returns null, re-query once or twice (cross-session sync); if
+still null, return `status: "failed"`, `reason: "node_missing"`.
+
+## Step 5 — fix loop (up to 3 iterations)
+
+Per iteration:
+
+**5a. Diagnose** (priority order): address `missing_instances` FIRST, then `size_mismatch`, then
+read `diff.png` (red = differs), `app.png` (target), `figma.png` (actual), source `.tsx`.
+
+| Symptom | Fix |
+| --- | --- |
+| `missing_instances` | For each name in `{missingInstances}`: delete the local stand-in subtree, replace with `getNodeById(builtComponents[name]).createInstance()` (variant via `setProperties`); override text via `findOne`+`loadFontAsync`. Re-run 2f enum + check-instances. |
+| sizing: master too small for `fill` | Modes FIRST then resize: `primaryAxisSizingMode='FIXED'; counterAxisSizingMode='FIXED'; resizeWithoutConstraints(W,H)`; fill children `layoutSizingHorizontal/Vertical='FILL'`. |
+| sizing: fixed off >2px | `resizeWithoutConstraints(W,H)` |
+| red border ring | adjust `strokes`/`strokeWeight`/`strokeAlign` (use `OUTSIDE`) |
+| red fill / red text | adjust `fills` / font props + text fills |
+| shifted content | adjust `itemSpacing`/padding |
+| missing / extra element | add / remove child |
+| all thin strips | run `fixSizing()` |
+
+**5b. Apply** a targeted `use_figma` change (only the diagnosed properties); `fixSizing(node)`.
+
+**5c. Re-enumerate, re-screenshot, re-compare:**
+1. Re-run the 2f enumeration + rewrite `{sourceDir}/.figma/figma.json` (the tree changed).
+2. If the failure was `missing_instances`, re-run `check-instances.js {componentName} {sourceDir}`;
+   don't pixel-compare until 4a passes.
+3. `get_screenshot(fileKey, {screenshotNodeId})` → overwrite `figma.png`.
+4. `node ${CLAUDE_SKILL_DIR}/10-validator/compare.js "{screenshotDir}/app.png" "{screenshotDir}/figma.png" "{screenshotDir}/"`.
+
+**5d. Continue/stop:** `match` → exit (fixed). Improved but not match → next iteration. 3
+iterations reached → exit with `status: "partial_match"`. Do not retry beyond 3.
+
+`fixSizing()` (mandatory after any structural change):
+
+```javascript
+function fixSizing(node, depth = 0) {
+  if (depth > 10 || !node) return;
+  const hasLayout = (node.type === 'COMPONENT' || node.type === 'FRAME' || node.type === 'COMPONENT_SET')
+    && node.layoutMode && node.layoutMode !== 'NONE';
+  if (hasLayout) {
+    if (node.layoutMode === 'VERTICAL') node.primaryAxisSizingMode = 'AUTO';
+    node.counterAxisSizingMode = 'AUTO';
+  }
+  for (const child of ('children' in node ? node.children : [])) fixSizing(child, depth + 1);
+}
+```
+
+## Finalize + overwrite result
+
+Refresh `figma.json.updatedAt` (Step 6), then OVERWRITE
+`.temp/figma-from-code/build-results/{componentName}.json` with the final state (same schema as
+the compare stage's result, with updated `comparison.verdict`, `matchPct`, `iterations`, and a
+`fixes` array describing each change applied).
+
+## Return (StructuredOutput)
+
+```json
+{
+  "componentName": "{componentName}",
+  "status": "built" | "partial_match" | "failed",
+  "nodeId": "{nodeId}",
+  "verdict": "match" | "minor_diff" | "mismatch",
+  "matchPct": 94.2,
+  "iterations": 2
+}
+```
+
+`status: "built"` when the final verdict is `match`; `partial_match` when it improved but didn't
+reach match within 3 iterations.

--- a/plugins/figma-from-code/skills/figma-from-code/7-build-component/step-1-analyze.md
+++ b/plugins/figma-from-code/skills/figma-from-code/7-build-component/step-1-analyze.md
@@ -1,0 +1,650 @@
+# Step 1: Analyze the Component
+
+> **This step runs inline.** Read the component source, reference material, and live styles. Produce `code.json` following the schema below. If `componentName` is in `preExistingComponents`, write a `needs_authorization` rejection and return immediately. If any child component is missing from builtComponents, write a rejection result and return immediately.
+
+Before writing any `use_figma` code, analyze all inputs to plan the Figma structure.
+
+## Pre-Existing Components Rule
+
+**Check this before doing any work.**
+
+- If `componentName` itself is a key in `preExistingComponents`: write `status: "needs_authorization"` and `preExistingTouched: ["<name>"]` to `.temp/figma-from-code/build-results/{componentName}.json` and return immediately. Do not analyze, do not write `code.json`, do not call `use_figma`.
+- If a _child_ you would instantiate (icon, sub-component) is in `preExistingComponents`: **instancing is fine** — that is reuse, not modification. Do not modify its master.
+- The fix-loop (Step 5) must never edit a node in `preExistingComponents`. If the comparison requires it, surface the conflict in the result and let the orchestrator decide.
+
+This rule overrides all analysis steps when in conflict.
+
+## Error Handling
+
+| Scenario                                             | Action                                                                                                              |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `componentName` in `preExistingComponents`           | Write `needs_authorization` result, stop immediately                                                                |
+| Any child component not in `builtComponents`         | Write `rejected` result with `missingChildren` list, stop immediately                                               |
+| Any icon not in `builtComponents` as `Icon/{Name}`   | Include in `missingChildren`, write `rejected` result, stop immediately                                             |
+| `code.json` write fails (permission, missing parent) | Log error; surface in Step 7 result under `trackingFile: { written: false, error: "..." }` — do not block the build |
+
+> **Pre-flight: dev server is required for Step 1g (live inspection).** Step 1g — inspecting the rendered component in a browser via `inspect-styles.js` — is the authoritative source for colors, spacing, typography, and interactive states. **Do not silently skip it.** If you don't already have a dev server URL (from the orchestrator state ledger, project memory, or the caller's arguments), pause and ask the user for one before proceeding past Step 1. Only skip Step 1g if the user explicitly says no dev server is available, or has already said so earlier in this conversation. See Step 1g for the full decision tree.
+
+---
+
+## code.json Schema Reference
+
+This is the contract that Step 2 (build) and Step 4a (instance gate) consume. Each sub-step below writes its fields incrementally — by the end of Step 1g, the file is complete.
+
+```json
+{
+  "componentName": "CustomerInformation",
+  "sourceFile": "<source-dir>/components/.../CustomerInformation.tsx",
+  "analyzedAt": "2026-05-19T15:00:00Z",
+  "lastCommit": { "hash": "...", "date": "...", "message": "..." },
+  "liveInspection": "complete",
+  "layout": { "direction": "VERTICAL", "widthIntent": "fill", "heightIntent": "hug" },
+  "variantAxes": [
+    {
+      "property": "Variant",
+      "values": ["primary", "secondary", "outline", "ghost", "ghost-muted", "destructive"],
+      "defaultValue": "primary",
+      "source": "variant-library",
+      "classMap": {
+        "primary": "bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm",
+        "secondary": "bg-secondary text-secondary-foreground hover:bg-secondary/80 shadow-sm",
+        "outline": "border border-input bg-transparent hover:bg-accent hover:text-accent-foreground shadow-sm",
+        "ghost": "hover:bg-accent hover:text-accent-foreground",
+        "ghost-muted": "hover:bg-accent/50 text-muted-foreground",
+        "destructive": "bg-destructive text-destructive-foreground hover:bg-destructive/90 shadow-sm"
+      }
+    },
+    {
+      "property": "Size",
+      "values": ["large", "regular", "small", "mini"],
+      "defaultValue": "regular",
+      "source": "variant-library",
+      "classMap": {
+        "large": "h-10 px-6 text-sm gap-2",
+        "regular": "h-9 px-4 text-sm gap-2",
+        "small": "h-8 px-3 text-sm gap-2",
+        "mini": "h-6 px-2 text-xs gap-1.5"
+      }
+    },
+    {
+      "property": "Roundness",
+      "values": ["default", "round"],
+      "defaultValue": "default",
+      "source": "variant-library",
+      "classMap": { "default": "rounded-lg", "round": "rounded-full" }
+    },
+    {
+      "property": "State",
+      "values": ["Default", "Hover", "Focus", "Disabled"],
+      "defaultValue": "Default",
+      "source": "css-pseudo-state",
+      "stateStyles": {
+        "Hover": { "backgroundColor": "rgb(37, 99, 235)" },
+        "Focus": { "boxShadow": "0 0 0 3px rgb(203, 213, 225)" },
+        "Disabled": { "opacity": "0.5" }
+      }
+    }
+  ],
+  "variantCombos": [
+    { "Variant": "primary", "Size": "regular", "Roundness": "default", "State": "Default" },
+    { "Variant": "secondary", "Size": "regular", "Roundness": "default", "State": "Default" },
+    { "Variant": "outline", "Size": "regular", "Roundness": "default", "State": "Default" },
+    { "Variant": "ghost", "Size": "regular", "Roundness": "default", "State": "Default" },
+    { "Variant": "ghost-muted", "Size": "regular", "Roundness": "default", "State": "Default" },
+    { "Variant": "destructive", "Size": "regular", "Roundness": "default", "State": "Default" },
+    { "Variant": "primary", "Size": "large", "Roundness": "default", "State": "Default" },
+    { "Variant": "primary", "Size": "small", "Roundness": "default", "State": "Default" },
+    { "Variant": "primary", "Size": "mini", "Roundness": "default", "State": "Default" },
+    { "Variant": "primary", "Size": "regular", "Roundness": "round", "State": "Default" },
+    { "Variant": "primary", "Size": "regular", "Roundness": "default", "State": "Hover" },
+    { "Variant": "primary", "Size": "regular", "Roundness": "default", "State": "Focus" },
+    { "Variant": "primary", "Size": "regular", "Roundness": "default", "State": "Disabled" }
+  ],
+  "variantStrategy": "representative",
+  "totalPossibleCombinations": 192,
+  "iconUsage": [
+    { "name": "Star", "figmaComponent": "Icon/Star", "size": 20 }
+  ],
+  "childComponents": [
+    { "figmaName": "EditableTitle", "nodeId": "1199:2", "usageCount": 3, "usages": ["first name", "last name", "username"] },
+    { "figmaName": "EditableText", "nodeId": "1213:35", "usageCount": 1, "usages": ["email field"] },
+    { "figmaName": "MoreOptionsMenu", "nodeId": "1214:37", "usageCount": 1, "usages": ["portal: more actions menu"] },
+    { "figmaName": "ConfirmationDialog", "nodeId": "1214:48", "usageCount": 1, "usages": ["portal: delete confirmation"] },
+    { "figmaName": "Icon/Star", "nodeId": "1189:6", "usageCount": 5, "usages": ["satisfaction stars"] }
+  ],
+  "textContent": { ... },
+  "computedStyles": { ... },
+  "states": { ... }
+}
+```
+
+### File location
+
+Resolve the component directory from the source file path:
+
+- `Button` → `<source-dir>/components/Button/.figma/code.json`
+- Nested modlet (e.g. `CustomerInformation` under `CustomerDetails/components/...`) → `<source-dir>/components/CustomerDetails/components/CustomerInformation/.figma/code.json`
+- `Icon/Star` → `<source-dir>/components/Icon/Star/.figma/code.json` (synthesized — Lucide icons have no local source file)
+- `Asset/CartonLogoSvg` → `<source-dir>/components/Asset/CartonLogoSvg/.figma/code.json`
+
+Create the `.figma/` directory (and any missing parents) before writing.
+
+### Write protocol
+
+Step 0 writes a skeleton file immediately (crash-recovery signal). Sub-steps 1a–1g accumulate their results **in working memory only** — no intermediate disk writes. At the end of Step 1g (or at the end of the last completed sub-step if 1g is skipped), write the complete code.json in a single atomic operation. This eliminates ~6 redundant file writes per component.
+
+**Failure handling:** if the final write fails (permission, missing parent), log the failure and surface it in the eventual Step 7 result under `trackingFile: { written: false, error: "..." }`. Do not block the build on a write failure — the gate will fail at Step 4a instead, with a clearer error.
+
+---
+
+## Step 0. Initialize code.json
+
+Write the skeleton file immediately. This acts as a crash-recovery signal — if the agent is interrupted, downstream steps see `null` fields and know analysis did not complete. Sub-steps 1a–1g accumulate their results in memory only; the final complete write happens at the end of Step 1g (or 1f if 1g is skipped). Do NOT write to code.json again between Step 0 and the final write.
+
+**Get the git commit for the source file:**
+
+```bash
+git log -1 --format="%H|%aI|%s" -- {sourceFilePath}
+```
+
+Parse pipe-delimited into `hash`, `date`, `message`. If untracked, all three are `null`.
+
+**Write code.json** with this initial content:
+
+```json
+{
+  "componentName": "{componentName}",
+  "sourceFile": "{sourceFilePath}",
+  "analyzedAt": "{ISO 8601 UTC now}",
+  "lastCommit": { "hash": "...", "date": "...", "message": "..." },
+  "liveInspection": null,
+  "layout": null,
+  "variantAxes": null,
+  "variantCombos": null,
+  "variantStrategy": null,
+  "totalPossibleCombinations": null,
+  "iconUsage": null,
+  "childComponents": null,
+  "textContent": null,
+  "computedStyles": null,
+  "states": null
+}
+```
+
+---
+
+## 1a. Identify the component structure
+
+Read the source code and determine:
+
+- **Layout direction**: Is the root a vertical stack (`flex-col`) or horizontal row (`flex`, `flex-row`)?
+- **Sizing intent** (CAPTURE THIS EXPLICITLY — Step 4a verifies the built component matches): For the _outermost_ container, classify each axis as one of:
+  - `fill` — has `w-full`, `flex-1`, `flex: 1`, `min-w-full`, or in a flex parent without sized siblings (Figma equivalent: `primaryAxisSizingMode='FIXED'` on the parent + `layoutSizingHorizontal='FILL'` on the child; or for masters, fixed width matching the consumer)
+  - `fixed:NNN` — has explicit value like `w-[200px]`, `w-64`, `h-10` (Figma: fixed width/height matching NNN)
+  - `hug` — none of the above; content-driven (Figma: `*SizingMode='AUTO'`)
+    Repeat per axis (width AND height). Capture this as `{widthIntent: 'fill' | 'fixed:NNN' | 'hug', heightIntent: ...}`. Record it now — Step 4a uses it.
+- **Parent-context promotion** (when Step 1g ran): read `layoutContext` from `computed-styles.json`. If `parent.clientWidth - parent.paddingLeft - parent.paddingRight ≥ element.offsetWidth × 1.25` AND that gap is ≥ 200px (i.e. the parent slot is meaningfully wider than the element is currently rendering), promote `widthIntent` from `hug` to `fill:<parentContentWidth>`. This catches composites that are _consumed by_ a wider page slot but whose outermost div lacks `w-full`/`flex-1` — a common silent narrowing source. Record the parent width as the expected fill target so Step 4a can verify it. Do NOT promote when the source classification is already `fixed:NNN` — explicit widths win.
+- **Role hint**: If the source file path is under `pages/` or `routes/`, OR the component name ends in `Page` / `Screen` / `Layout`, treat it as a **page-level** component. Page-level components default to filling the screen body (typically ~1380×768 — read `screensFrameId` body size from state if available) regardless of how the captured `app.png` looks, because the precapture selector may have grabbed a hug-content wrapper.
+- **Page-consumed fallback** (when Step 1g was skipped — no dev server): if the component file is imported by anything under `pages/` or `routes/` (grep for `import.*{ ${componentName} }.*from` under those folders), treat it as page-level for sizing purposes. Less precise than the parent-context promotion above — the page-body width is inferred from `figmaNodes.screensFrameId` rather than measured — but prevents the silent-narrow failure mode when no live signal is available.
+- **Spacing**: `gap-*` classes map to `itemSpacing` in Figma. `p-*`, `px-*`, `py-*` map to padding.
+- **Colors**: `bg-*`, `text-*`, `border-*` classes. Resolve CSS variables from `index.css` if needed.
+- **Typography**: Font size, weight, line height from Tailwind classes. Also record the **computed `fontFamily`** from `computed-styles.json` verbatim — it is authoritative. Resolve it to the Figma font the build will use: if it is a system stack (contains `system-ui`, `ui-sans-serif`, `-apple-system`, `BlinkMacSystemFont`, `Segoe UI`, or is bare `sans-serif`), map it to **`Inter`** (this project's documented portable proxy for the OS system font — see Step 2c); only keep a named family when it is a real, loadable web font. Carry both `fontFamily` (computed) and `figmaFontFamily` (resolved) into the final write so Step 4's font guardrail can compare against the font actually applied.
+- **Border radius**: `rounded-*` classes.
+- **Children**: What sub-elements exist? Which are text, which are icons, which are instances of other components?
+
+**Hold in memory:** `layout: { direction, widthIntent, heightIntent }`. Include in final write.
+
+---
+
+## 1b. Extract variant axes and compute representative combos
+
+Extract variant axes from two sources (in order), then compute the representative set of combinations to build.
+
+### 1b-i. Extract from variant library definitions
+
+Search the component source for `cva()`, `tv()`, `defineRecipe()`, `styleVariants()`, or similar variant-library calls. For each key in the `variants` object, create an axis:
+
+- `property` — PascalCase the key name (e.g., `variant` → `Variant`, `size` → `Size`)
+- `values` — array of value names from the variant object keys
+- `defaultValue` — from `defaultVariants` (or first value if no default specified)
+- `source` — `"variant-library"`
+- `classMap` — verbatim Tailwind class strings per value. Copy the exact string from the source code for each variant value (e.g., `{"primary": "bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm", "ghost": "hover:bg-accent hover:text-accent-foreground"}`)
+
+Also capture the cva base classes (the first argument to `cva()`) separately — Step 2b uses these as the shared layout foundation for all variants.
+
+Also capture `compoundVariants` if present (for components where axis combinations override base styles).
+
+**If no variant library is found**, `variantAxes` from this sub-step is empty — proceed to 1b-ii. Components without a variant library may still have CSS pseudo-state variants.
+
+**Example — Button.tsx:**
+
+```js
+cva('inline-flex items-center justify-center gap-2 ...', {
+  variants: {
+    variant: {
+      primary: 'bg-primary ...',
+      secondary: 'bg-secondary ...',
+      outline: '...',
+      ghost: '...',
+      'ghost-muted': '...',
+      destructive: '...',
+    },
+    size: {
+      large: 'h-10 px-6 text-sm gap-2',
+      regular: 'h-9 px-4 text-sm gap-2',
+      small: 'h-8 px-3 text-sm gap-2',
+      mini: 'h-6 px-2 text-xs gap-1.5',
+    },
+    roundness: { default: 'rounded-lg', round: 'rounded-full' },
+  },
+  defaultVariants: { variant: 'primary', size: 'regular', roundness: 'default' },
+});
+```
+
+→ 3 axes: Variant (6 values, default "primary"), Size (4 values, default "regular"), Roundness (2 values, default "default").
+
+### 1b-ii. Merge CSS pseudo-states from states.json
+
+If Step 1g produced `states.json` with any `captured: true` state, add a `State` axis:
+
+- `property`: `"State"`
+- `values`: `["Default"]` + each captured state name capitalized (e.g., `"Hover"`, `"Focus"`, `"Disabled"`)
+- `defaultValue`: `"Default"`
+- `source`: `"css-pseudo-state"`
+- `stateStyles`: per-state computed style diffs from states.json — include the exact resolved values (RGB colors, box-shadow strings, opacity values)
+
+If no states were captured (all `captured: false` in states.json), do not add this axis.
+
+**How CSS states become Figma variants:** CSS pseudo-states cannot be "set" on a static Figma component. Each state becomes a separate variant where the style overrides are baked into the variant's properties:
+
+- `State=Hover`: override fill color to the hover background from `stateStyles.Hover.backgroundColor`
+- `State=Focus`: add a box-shadow effect from `stateStyles.Focus.boxShadow`
+- `State=Disabled`: set `opacity` from `stateStyles.Disabled.opacity`
+
+### 1b-iii. Compute representative variant combos
+
+Compute the combinations to build using the **representative set** algorithm — vary one axis at a time from the default:
+
+```
+defaultCombo = { axis.property: axis.defaultValue for each axis }
+combos = [defaultCombo]
+for each axis in variantAxes:
+  for each value in axis.values where value != axis.defaultValue:
+    combo = copy(defaultCombo)
+    combo[axis.property] = value
+    combos.push(combo)
+```
+
+This yields `1 + SUM(values_per_axis - 1)` combos — every distinct visual treatment without combinatorial explosion.
+
+**Example — Button** with Variant(6) × Size(4) × Roundness(2) × State(4):
+
+- Full cross-product: 192 combos
+- Representative set: 1 + 5 + 3 + 1 + 3 = **13 combos**
+
+**Budget guardrail:** If combos exceed 30, truncate by dropping values from lower-priority axes. Priority order: responsive layout > visual-identity axes (variant, type) > prop-driven states > interactive states (hover, focus, disabled) > sizes > shape modifiers (roundness).
+
+### 1b-iii. Extract responsive breakpoint variants
+
+Scan the JSX for paired Tailwind responsive visibility classes that show/hide entire JSX blocks at different viewport widths. These indicate the component has structurally different layouts per breakpoint.
+
+**Detection patterns:**
+
+| Mobile-only block             | Desktop-only block                                      | Breakpoint    |
+| ----------------------------- | ------------------------------------------------------- | ------------- |
+| `className="...lg:hidden..."` | `className="...hidden lg:flex..."` or `hidden lg:block` | `lg` (1024px) |
+| `className="...md:hidden..."` | `className="...hidden md:flex..."` or `hidden md:block` | `md` (768px)  |
+| `className="...sm:hidden..."` | `className="...hidden sm:flex..."` or `hidden sm:block` | `sm` (640px)  |
+
+**When to create a Layout axis:**
+
+- At least one JSX block uses a responsive hide class (`lg:hidden`, `hidden lg:flex`, etc.)
+- The hidden/shown blocks contain meaningfully different content or layout (not just a minor style tweak)
+
+**Axis creation:**
+
+```json
+{
+  "property": "Layout",
+  "values": ["Desktop", "Mobile"],
+  "defaultValue": "Desktop",
+  "source": "responsive-breakpoint",
+  "breakpoint": "lg",
+  "visibilityMap": {
+    "Desktop": {
+      "include": ["blocks with 'hidden lg:flex' or 'hidden lg:block'"],
+      "exclude": ["blocks with 'lg:hidden'"]
+    },
+    "Mobile": {
+      "include": ["blocks with 'lg:hidden' or no responsive prefix"],
+      "exclude": ["blocks with 'hidden lg:flex' or 'hidden lg:block'"]
+    }
+  }
+}
+```
+
+**`visibilityMap` format:** Each entry lists JSX block identifiers (use a short description or the element's `className` string) that should be included or excluded for that variant value. Step 2 uses this to decide which children to render in each variant.
+
+**Example — CustomerInformation:**
+
+```tsx
+{
+  /* Mobile: Title */
+}
+<div className="flex flex-col gap-1 lg:hidden w-full">...</div>;
+
+{
+  /* Desktop: Title + More menu */
+}
+<div className="hidden lg:flex items-start justify-between w-full">...</div>;
+
+{
+  /* Mobile: More menu */
+}
+<div className="lg:hidden">
+  <MoreOptionsMenu
+    trigger={
+      <Button variant="outline" className="w-full">
+        ...
+      </Button>
+    }
+  >
+    ...
+  </MoreOptionsMenu>
+</div>;
+```
+
+→ Layout axis with `Desktop` (inline three-dot menu) and `Mobile` (stacked name, full-width "More Actions" button at bottom).
+
+**Multiple breakpoints:** If a component uses more than one breakpoint tier (e.g., both `md:` and `lg:`), create values for each distinct layout: `["Desktop", "Tablet", "Mobile"]`. Keep the default as the largest breakpoint since that matches the primary design target and the standard 1440px precapture viewport.
+
+### 1b-iv. Extract prop-driven structural states
+
+Scan the component source for React state hooks that control the visibility of overlays, modals, menus, dialogs, and other structural changes. These produce distinct visual states that designers need to see in Figma.
+
+**Detection patterns:**
+
+1. **State hooks controlling visibility:**
+
+   ```tsx
+   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+   const [isMenuOpen, setIsMenuOpen] = useState(false);
+   ```
+
+2. **Conditional rendering of overlays:**
+
+   ```tsx
+   <ConfirmationDialog open={isDeleteDialogOpen} ... />
+   <Sheet open={isSheetOpen} ... />
+   {isLoading && <Spinner />}
+   ```
+
+3. **Portal-rendered components with trigger patterns:**
+   ```tsx
+   <MoreOptionsMenu trigger={<Button>...</Button>}>
+     <MenuItem onClick={() => setIsDeleteDialogOpen(true)}>Delete</MenuItem>
+   </MoreOptionsMenu>
+   ```
+
+**When to create a State axis:**
+
+- At least one state hook controls an overlay (modal, dialog, menu, sheet, popover, drawer)
+- The overlay produces a meaningfully different visual from the default resting state
+
+**Axis creation:**
+
+```json
+{
+  "property": "State",
+  "values": ["Default", "Menu Open", "Delete Confirmation"],
+  "defaultValue": "Default",
+  "source": "prop-state",
+  "stateConfig": {
+    "Default": {
+      "description": "Resting state — all overlays closed",
+      "overlays": []
+    },
+    "Menu Open": {
+      "description": "MoreOptionsMenu dropdown is visible",
+      "overlays": [
+        {
+          "component": "MoreOptionsMenu",
+          "trigger": "three-dot button",
+          "content": ["MenuItem: Delete Customer (with Trash icon, destructive text)"],
+          "position": "below-right of trigger"
+        }
+      ]
+    },
+    "Delete Confirmation": {
+      "description": "ConfirmationDialog modal is visible",
+      "overlays": [
+        {
+          "component": "ConfirmationDialog",
+          "props": {
+            "title": "Delete Customer",
+            "description": "Are you sure you want to delete this customer? This action cannot be undone and will also delete all associated cases.",
+            "confirmText": "Delete",
+            "confirmClassName": "bg-red-600 hover:bg-red-700"
+          },
+          "position": "centered modal with backdrop"
+        }
+      ]
+    }
+  }
+}
+```
+
+**State naming conventions:**
+
+- Use descriptive names that match the user action: `Menu Open`, `Delete Confirmation`, `Loading`, `Error`, `Empty`
+- Extract overlay content (menu items, dialog text, button labels) from the source code's JSX props
+- Note the trigger element so Step 2 can position the overlay correctly
+
+**What NOT to extract as states:**
+
+- Hover/focus/disabled — these are CSS pseudo-states (source 2, step 1b-ii), not prop states
+- Internal state that doesn't change the visual output (e.g., form field values, API loading that shows the same skeleton)
+- Transient animations or transitions
+
+**Combining with CSS pseudo-states:** If both 1b-ii (CSS states) and 1b-iv (prop states) produce a `State` axis, merge them into a single axis. CSS pseudo-states apply to the base component elements; prop states add overlay content. The representative set algorithm handles the combined axis.
+
+### Future extension points (not implemented — noted for later)
+
+These sources can be added to 1b when the skill encounters codebases that need them:
+
+- **TypeScript union props**: `type?: 'Neutral' | 'Error'` — parse props interface, use `source: "typescript-prop"`
+- **Boolean visual props**: `active?: boolean` — 2-value axis, use `source: "typescript-prop"`
+- **Conditional class patterns**: `cn()` ternaries, style object lookups — use `source: "conditional-class"`
+
+**Hold in memory:** `variantAxes`, `variantCombos`, `variantStrategy`, `totalPossibleCombinations`. Include in final write. Field rules:
+
+- `variantAxes` — array of axis objects (each with `property`, `values`, `defaultValue`, `source`, and source-specific data like `classMap` or `stateStyles`). Empty array `[]` for single-variant components with no CSS states.
+- `variantCombos` — array of combo objects, each mapping axis property names to values. For single-variant components: `[{}]` (one empty combo). Step 2b iterates this array to build each variant.
+- `variantStrategy` — `"representative"` (default). Documents which algorithm produced the combos.
+- `totalPossibleCombinations` — full cross-product count across all axes, for reference only.
+
+---
+
+## 1c. Identify icon and image usage
+
+From the source code imports:
+
+```tsx
+import { Check, X, Loader2 } from 'lucide-react';
+```
+
+Map each icon to its `builtComponents` entry (e.g., `Icon/Check`) and note the size from className:
+
+- `h-3 w-3` = 12x12
+- `h-3.5 w-3.5` = 14x14
+- `h-4 w-4` = 16x16
+- `h-5 w-5` = 20x20
+- `h-6 w-6` = 24x24
+
+**Hold in memory:** `iconUsage` — array of `{ name, figmaComponent, size }` objects, where `figmaComponent` is the resolved Figma-space name (e.g., `"Icon/Star"`) and `size` is the pixel dimension. Include in final write.
+
+---
+
+## 1d. Identify instance reuse
+
+Check if any child components in the source code are already in `builtComponents`. These should be instantiated rather than rebuilt:
+
+```tsx
+// Source has: <Button variant="primary">Save</Button>
+// builtComponents has: { "Button": "123:45" }
+// → Create an instance of Button, don't rebuild it
+```
+
+**The list you identify here is the contract Step 4a enforces.** Substituting a plain text node, a local frame, or any other hand-built mock for a child that exists in `builtComponents` is a **hard rejection** — even when the rest-state visual is pixel-identical. The skill's reason for existing is preserving design-system coupling (variant switching, master propagation, Code Connect snippets in Dev Mode); a text-node lookalike preserves none of that. Includes portal-rendered children like `ConfirmationDialog` — they must appear as detached examples, not be omitted.
+
+**Hold in memory:** `childComponents` — array of child component objects. Include in final write. Field rules (this is both the Step 4a gate contract AND the Step 2 build manifest):
+
+- One entry per _direct_ design-system child the source code uses. Each entry is an object:
+  - `figmaName` — Figma-space name (`Icon/Star`, not `Star`; `EditableTitle`, not `./components/inline-edit`).
+  - `nodeId` — the value from `builtComponents[figmaName]`. Step 2 uses this to call `figma.getNodeById(nodeId).createInstance()`.
+  - `usageCount` — how many times this child appears in the source JSX. Step 2 creates this many instances.
+  - `usages` — short descriptions of each usage (e.g., `["first name", "last name", "username"]`). Helps Step 2 map instances to the right positions and text overrides.
+- Include every PascalCase import from `./components/`, `@/components/`, or `lucide-react` that resolves to a name in `builtComponents`. Resolution rule: `Star` (from `lucide-react`) → `Icon/Star`. `Button` (from `@/components/...`) → `Button`. Skip imports whose resolved name is not in `builtComponents` (those aren't design-system children).
+- Portal-rendered children (`ConfirmationDialog`, `AlertDialog`, toasts) MUST be included with `usages` prefixed by `"portal:"`. The build represents them as detached examples; they are not exempt from the gate.
+- Do NOT include the component itself or transitive grandchildren.
+
+---
+
+## 1e. Verify all child components exist in Figma (prerequisite gate)
+
+After identifying all child components (sub-components and icons) from steps 1c and 1d, verify that **every one** exists in `builtComponents`. Build a list of required children:
+
+- Every sub-component referenced in source code (from step 1d)
+- Every icon referenced in source code (from step 1c), as `Icon/{Name}`
+
+For each required child, check `builtComponents[childName]`. If the node ID is present, the child is available. If **any** child is missing:
+
+**STOP — do not proceed to step 2.** Return immediately with a rejection result:
+
+```json
+{
+  "componentName": "CaseDetails",
+  "status": "rejected",
+  "reason": "missing_children",
+  "missingChildren": ["CaseComments", "Icon/Trash"],
+  "availableChildren": ["Button", "CaseInformation", "Icon/Check"]
+}
+```
+
+Write this result to `.temp/figma-from-code/build-results/{componentName}.json` so the orchestrator can see which children need to be built first.
+
+**Standalone (no orchestrator)** — if the caller is the user directly, also surface the rejection in the conversation and ask how to proceed. Don't fall back to inlining the missing children, building stubs, or downgrading the build into "best effort" — those produce a different artifact than the skill is supposed to produce. The right options are: (a) build the missing children first in dependency order, (b) abandon the build, or (c) get explicit user authorization to deviate.
+
+**Enforcement gate** — before you call `use_figma` to start building, run:
+
+```bash
+node ${CLAUDE_SKILL_DIR}/7-build-component/check-prereqs.js <componentName> <sourceFile.tsx>
+```
+
+The script reads imports from `sourceFile.tsx`, looks each one up in `.temp/figma-from-code/builtComponents.json`, and either writes `.temp/figma-from-code/prereqs/<componentName>.ok` (exit 0) or prints the rejection JSON and exits 1. A `PreToolUse` hook on `mcp__claude_ai_Figma__use_figma` blocks any `use_figma` call that creates a fresh component (contains `figma.createComponent()` with a `<var>.name = '<componentName>'` assignment) unless the matching `.ok` marker exists and is fresh (< 1 hour). The hook is configured at `.claude/hooks/figma-prereqs-gate.js`.
+
+If the script reports `missing_children`, that _is_ the rejection — write it to the build-results file, surface it to the user (when standalone), and stop. Do not work around the hook by renaming the master, splitting `createComponent` across calls to evade the regex, or editing the hook itself.
+
+Only proceed to step 1f and beyond if check-prereqs.js exits 0.
+
+This step does not write to code.json — it is validation only.
+
+---
+
+## 1f. Plan text content
+
+Use `textContent` (from `text.json`) for exact text strings. Never use generic placeholders like "Lorem ipsum" or "Button text". The text.json structure:
+
+```json
+{
+  "full": "complete text content",
+  "lines": ["line 1", "line 2"],
+  "headings": ["Case Details"],
+  "labels": ["Title", "Status"],
+  "inputs": ["Enter case title"],
+  "buttons": ["Save", "Cancel"],
+  "icons": [{ "name": "Check", "size": "h-4 w-4" }]
+}
+```
+
+**Hold in memory:** `textContent` — the full parsed contents of `text.json`. Omit if no `text.json` file exists. Include in final write.
+
+> **If Step 1g will be skipped** (user confirmed no dev server): write the complete code.json here instead of waiting for 1g. Set `liveInspection: "skipped_no_dev_server"` (or `"skipped_explicitly"`), omit `computedStyles` and `states`. Do not proceed to 1g.
+
+---
+
+## 1g. Inspect live component in Playwright
+
+Before building, inspect the actual rendered component in the browser to capture computed styles and interactive state screenshots. This provides ground-truth values that are more reliable than inferring from Tailwind classes alone — especially for resolved colors, inherited styles, and CSS variable chains.
+
+Run `inspect-styles.js` against the component's selector on the dev server:
+
+```bash
+node ${CLAUDE_SKILL_DIR}/10-validator/inspect-styles.js \
+  "<dev-server-url>/{route}" \
+  --selector "{componentSelector}" \
+  --output ".temp/figma-from-code/screenshots/{ComponentName}/"
+```
+
+This produces:
+
+| File                   | Contents                                                                                                                                                                                                                                                                                                                      |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `computed-styles.json` | Key CSS properties from `getComputedStyle` (colors, spacing, typography, layout, borders, shadows) plus the element's class list, plus `layoutContext` (`element.offsetWidth/Height`, `parent.clientWidth` and box-model, `viewport`, and `derived.elementToParentRatio`) used by Step 1a for parent-context sizing promotion |
+| `state-hover.png`      | Screenshot with `:hover` emulated — **only created if visually different from default**                                                                                                                                                                                                                                       |
+| `state-focus.png`      | Screenshot with `:focus-visible` emulated — **only created if visually different**                                                                                                                                                                                                                                            |
+| `state-disabled.png`   | Screenshot with `[disabled]` set — **only created if the element supports it and looks different**                                                                                                                                                                                                                            |
+| `states.json`          | Index of which states were captured vs skipped, with per-state computed style diffs                                                                                                                                                                                                                                           |
+
+**How to use the outputs:**
+
+1. **`computed-styles.json`** — Use resolved color values (RGB) directly instead of tracing Tailwind → CSS variable → HSL → RGB. Use exact `fontSize`, `fontWeight`, `lineHeight`, `borderRadius`, `padding`, `gap` values to set Figma properties. These are the authoritative values.
+
+2. **State screenshots** — Each captured state screenshot becomes a variant in the Figma component set. For example, if `state-hover.png` exists, create a `State=Hover` variant using the hover computed styles from `states.json`. If `state-focus.png` exists, create a `State=Focus` variant. Combine with any prop-based variants from step 1b (e.g., `Variant=primary, State=Hover`).
+
+3. **Skipped states** — If `states.json` shows a state was skipped (`"reason": "no visual difference from default"`), do not create a variant for it.
+
+**Batch mode** — inspect-styles can be pre-run in batch for all components in a tier:
+
+```bash
+node ${CLAUDE_SKILL_DIR}/10-validator/inspect-styles.js --batch manifest.json
+```
+
+Where `manifest.json` contains entries like:
+
+```json
+[
+  {
+    "url": "<dev-server-url>/example",
+    "selector": "[data-component='Button']",
+    "output": ".temp/figma-from-code/screenshots/Button/"
+  },
+  {
+    "url": "<dev-server-url>/example",
+    "selector": "[data-component='Input']",
+    "output": ".temp/figma-from-code/screenshots/Input/"
+  }
+]
+```
+
+**Dev server is required — don't silently skip this step.**
+
+The live-component inspection produces the authoritative ground truth for colors, spacing, typography, and interactive states. Skipping it means the build is inferred entirely from Tailwind classes and CSS variable chains, which routinely drifts from what the app actually renders. Only skip when the user has explicitly told you no dev server is available.
+
+Decide what to do based on what the caller gave you:
+
+1. **Orchestrator-dispatched call** — the orchestrator passes the dev server URL and per-component route/selector in the state ledger. Use those directly. If they're missing from the manifest, treat that as a state-ledger bug and report it back to the orchestrator; do not fall back to skipping.
+
+2. **Standalone call (no orchestrator)** — before falling back to source-only analysis, determine whether a dev server is running:
+   - Check the project for an obvious dev command (`package.json` `scripts.dev`, `npm run dev`, `vite`, etc.) and a likely URL (commonly `<dev-server-url>` for Vite, `localhost:3000` for Next.js/CRA). If memory contains a known dev server URL for this project, use that.
+   - Probe the URL with a quick `curl -s -o /dev/null -w "%{http_code}" <url>` (or equivalent). If it responds, proceed with inspect-styles against it.
+   - If no URL is reachable AND the user has not already told you a dev server is unavailable, **stop and ask the user**: "Is a dev server running for this project? If so, what's the URL and the route/selector for `{ComponentName}`?" Wait for the answer before continuing.
+   - Only skip step 1g if the user explicitly says no dev server is available (or has said so earlier in the conversation). Record that decision in the result file's `notes` field so the omission is visible downstream.
+
+3. **Auto/non-interactive mode** — if you cannot ask the user (e.g., running fully autonomously inside a batch), and probing finds no dev server, still attempt to start one if the project clearly supports it (e.g., `npm run dev &` with a port check loop). If starting the server isn't safe or appropriate, proceed without 1g but explicitly flag `"liveInspection": "skipped_no_dev_server"` in the result so the validator can re-check later.
+
+**If the component has no known selector or route but the dev server IS running**, attempt to derive them: search the codebase for routes that render `{ComponentName}` (e.g., grep imports of the component file), and use a Playwright selector like `[data-component='{ComponentName}']`, the component's display class, or a text-content match from `text.json`. Only fall back to source-only analysis if this derivation also fails — and ask the user before doing so.
+
+**Final write — write complete code.json now.** Merge all values held in memory since Step 0 (`layout`, `variantAxes`, `variantCombos`, `variantStrategy`, `totalPossibleCombinations`, `iconUsage`, `childComponents`, `textContent`) with the Step 1g values below, and overwrite the skeleton file written in Step 0 with the complete object in a single write.
+
+Update `liveInspection` to one of `"complete"` / `"skipped_no_dev_server"` / `"skipped_explicitly"`. Update `computedStyles` and `states` with the full parsed contents of the corresponding files from Step 1g output. Omit `computedStyles` and `states` if Step 1g was skipped. If Step 1a's `layout.widthIntent` should be promoted based on `layoutContext` from `computed-styles.json`, update `layout` as well.

--- a/plugins/figma-from-code/skills/figma-from-code/7-build-component/step-2-build.md
+++ b/plugins/figma-from-code/skills/figma-from-code/7-build-component/step-2-build.md
@@ -1,0 +1,773 @@
+# Step 2: Build the Component in Figma
+
+## 2-pre. Resolve child components BEFORE building (mandatory)
+
+Before writing any `use_figma` code, read `code.json.childComponents` (written incrementally during Step 1) and resolve every entry to a Figma node reference. This is the **instance manifest** — every name in this list MUST appear as an `INSTANCE` in the final build. No exceptions, no plain-text substitutions.
+
+Read `code.json.childComponents` (the array of objects written incrementally during Step 1). Each object has `{ figmaName, nodeId, usageCount, usages }`. This IS the instance manifest — no guesswork:
+
+```json
+// From code.json.childComponents:
+[
+  { "figmaName": "EditableTitle", "nodeId": "1199:2", "usageCount": 3, "usages": ["first name", "last name", "username"] },
+  { "figmaName": "EditableText",  "nodeId": "1213:35", "usageCount": 1, "usages": ["email field"] },
+  { "figmaName": "Button",        "nodeId": "1196:12", "usageCount": 1, "usages": ["more options trigger"] },
+  { "figmaName": "Icon/Star",     "nodeId": "1189:6",  "usageCount": 5, "usages": ["satisfaction stars"] },
+  ...
+]
+```
+
+For each entry: call `figma.getNodeById(nodeId)` to get the master, then call `.createInstance()` exactly `usageCount` times. Use the `usages` descriptions to map each instance to the correct position in the layout and apply the correct text overrides.
+
+**Rules:**
+
+- If a child appears N times in the source JSX, create N instances (e.g., 3 `EditableTitle` instances for first name, last name, username).
+- Portal-rendered children (`ConfirmationDialog`, `AlertDialog`, toasts) get one instance each, appended as a detached example (visible or hidden) — they MUST be present for Step 4a.
+- If a child is a component set (has variants), pick the appropriate variant via `instance.setProperties({ State: 'Rest' })` after creating the instance.
+- Override **only text content** (`characters`) inside instances using `findOne`/`findAll` + `loadFontAsync` + `setCharacters` (see §2c). NEVER replace an instance with a text node because it "looks the same." NEVER override styling properties (`fontSize`, `fontName`, `lineHeight`, `fills`) during the build step — keep the master's defaults and let the comparison step (Step 4) flag any visual mismatches. Style overrides belong in the fix loop (Step 5) where the diff image provides visual evidence of what actually needs changing.
+
+**Structure your `use_figma` code in this order:**
+
+1. Resolve all masters from `instanceManifest` via `figma.getNodeById()`
+2. Create all instances via `master.createInstance()`
+3. Override text content (characters only) on each instance
+4. Create the component shell (layout, padding, fills)
+5. Append instances + any plain text nodes (only for text NOT owned by a child component) into the shell
+6. Run `fixSizing()` and append to parent
+
+This order ensures instances are the primary building blocks, not an afterthought.
+
+## 2-bg. Ensure a white background frame exists
+
+When the orchestrator dispatches a build, it provides `parentFrameId` — a tier frame with a white background already set up. The component is appended directly into that frame.
+
+For **standalone builds** (no orchestrator, no `parentFrameId`), create a container frame before drawing:
+
+```javascript
+// use_figma — only when parentFrameId is not provided
+const page = figma.currentPage;
+const rightEdge = page.children.reduce((max, n) => Math.max(max, n.x + n.width), 0);
+
+const parentFrame = figma.createFrame();
+parentFrame.name = '{componentName} — Build';
+parentFrame.x = rightEdge + 100;
+parentFrame.y = 0;
+parentFrame.resize(800, 600);
+parentFrame.fills = [{ type: 'SOLID', color: { r: 1, g: 1, b: 1 } }];
+parentFrame.layoutMode = 'VERTICAL';
+parentFrame.primaryAxisSizingMode = 'AUTO';
+parentFrame.counterAxisSizingMode = 'AUTO';
+parentFrame.paddingLeft = 40;
+parentFrame.paddingRight = 40;
+parentFrame.paddingTop = 40;
+parentFrame.paddingBottom = 40;
+
+return { parentFrameId: parentFrame.id };
+```
+
+Use the returned `parentFrameId` in subsequent build calls. This ensures the component is always drawn on a white background — matching how it renders in the app — regardless of whether the orchestrator or a user triggered the build.
+
+## 2a. Single component (no variants)
+
+```javascript
+// use_figma
+const parentFrame = figma.getNodeById('{parentFrameId}');
+
+// ── 1. Resolve masters from instanceManifest ──
+const editableTitleMaster = figma.getNodeById('{builtComponents.EditableTitle}');
+const editableTextMaster = figma.getNodeById('{builtComponents.EditableText}');
+const iconStarMaster = figma.getNodeById('{builtComponents["Icon/Star"]}');
+// ... resolve ALL entries from code.json.childComponents ...
+
+// ── 2. Create instances ──
+const firstNameInst = editableTitleMaster.createInstance();
+const lastNameInst = editableTitleMaster.createInstance();
+const usernameInst = editableTitleMaster.createInstance();
+const emailInst = editableTextMaster.createInstance();
+const star1 = iconStarMaster.createInstance();
+// ... etc for every child usage ...
+
+// ── 3. Override text/properties on instances ──
+// (see §2c for override patterns)
+
+// ── 4. Create component shell ──
+const comp = figma.createComponent();
+comp.name = '{componentName}';
+comp.layoutMode = '{VERTICAL or HORIZONTAL}';
+comp.primaryAxisSizingMode = 'AUTO';
+comp.counterAxisSizingMode = 'AUTO';
+comp.itemSpacing = { gapValue };
+comp.paddingTop = { pt };
+comp.paddingBottom = { pb };
+comp.paddingLeft = { pl };
+comp.paddingRight = { pr };
+comp.cornerRadius = { radius };
+comp.fills = [{ fill }];
+comp.strokes = [{ stroke }]; // if bordered
+comp.strokeWeight = 1;
+comp.strokeAlign = 'OUTSIDE'; // always OUTSIDE to match CSS box model
+
+// ── 5. Append instances + layout frames into shell ──
+// Build the frame hierarchy, placing instances where the source code uses child components.
+// Only use plain text nodes for text NOT owned by a child component (e.g. "@" literal, "Date Joined" label).
+
+// ── 6. Finalize ──
+fixSizing(comp);
+parentFrame.appendChild(comp);
+return JSON.stringify({ name: comp.name, id: comp.id });
+```
+
+## 2b. Component with variants
+
+**When to use 2b vs 2a:** If `code.json.variantAxes` has any entries (length > 0), use 2b. If `variantAxes` is empty, use 2a (single component).
+
+Before writing any `use_figma` code, read `code.json.variantAxes` and `code.json.variantCombos`. This is the authoritative build manifest. **Do not hardcode variant values in the use_figma script** — iterate the combos from code.json.
+
+**Build instructions:**
+
+1. Read `code.json.variantAxes` and `code.json.variantCombos`
+2. Inline the variant data into the `use_figma` script (the plugin sandbox has no filesystem access)
+3. For `variant-library` axes: parse the `classMap` Tailwind classes using the §2d mapping table and §2e color resolution chain to determine per-variant Figma property overrides
+4. For `css-pseudo-state` axes: apply the `stateStyles` diffs directly — these are already resolved computed values, no Tailwind parsing needed
+5. For `responsive-breakpoint` axes: each variant builds a **different subset of children** — see §2b-responsive below
+6. For `prop-state` axes: each variant builds the base component plus any **overlay/modal content** visible in that state — see §2b-states below
+7. Base properties (shared by all variants) come from the cva base classes (first argument) or `computedStyles` from Step 1g
+8. Per-combo overrides only change what differs from the default combo — don't re-apply all base properties
+9. Children (instances, text nodes) are the same across all **style** variants — but may differ across **structural** variants (responsive-breakpoint, prop-state)
+10. The §2c instance rules apply: resolve masters from instanceManifest, override only characters, never substitute plain text for instances
+
+```javascript
+// use_figma
+const parentFrame = figma.getNodeById('{parentFrameId}');
+
+// ── 1. Resolve masters from instanceManifest (same as 2a) ──
+const iconMaster = figma.getNodeById('{builtComponents["Icon/Check"]}');
+// ... resolve ALL entries from code.json.childComponents ...
+
+// ── 2. Inline variant manifest from code.json ──
+// (plugin sandbox has no fs — inline the data)
+const variantAxes = {
+  Variant: {
+    source: 'variant-library',
+    defaultValue: 'primary',
+    classMap: {
+      primary: 'bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm',
+      secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80 shadow-sm',
+      // ... all values from code.json.variantAxes[0].classMap
+    },
+  },
+  Size: {
+    source: 'variant-library',
+    defaultValue: 'regular',
+    classMap: {
+      large: 'h-10 px-6 text-sm gap-2',
+      regular: 'h-9 px-4 text-sm gap-2',
+      small: 'h-8 px-3 text-sm gap-2',
+      mini: 'h-6 px-2 text-xs gap-1.5',
+    },
+  },
+  Roundness: {
+    source: 'variant-library',
+    defaultValue: 'default',
+    classMap: { default: 'rounded-lg', round: 'rounded-full' },
+  },
+  State: {
+    source: 'css-pseudo-state',
+    defaultValue: 'Default',
+    stateStyles: {
+      Hover: { backgroundColor: 'rgb(37, 99, 235)' },
+      Focus: { boxShadow: '0 0 0 3px rgb(203, 213, 225)' },
+      Disabled: { opacity: '0.5' },
+    },
+  },
+};
+const variantCombos = [
+  { Variant: 'primary', Size: 'regular', Roundness: 'default', State: 'Default' },
+  { Variant: 'secondary', Size: 'regular', Roundness: 'default', State: 'Default' },
+  // ... all combos from code.json.variantCombos
+];
+
+// ── 3. Base style values (from cva base classes + computedStyles) ──
+// Parse the cva() first argument to get shared layout properties.
+// Use computedStyles from Step 1g as the authoritative fallback.
+const baseLayout = 'HORIZONTAL'; // from inline-flex
+const basePadding = { top: 0, bottom: 0, left: 16, right: 16 }; // from px-4
+const baseGap = 8; // from gap-2
+const baseRadius = 8; // from rounded-lg (default roundness)
+
+// ── 4. Build each variant ──
+const variants = [];
+
+for (const combo of variantCombos) {
+  const v = figma.createComponent();
+  // Variant naming convention: "Variant=primary, Size=regular, State=Default"
+  v.name = Object.entries(combo)
+    .map(([k, val]) => `${k}=${val}`)
+    .join(', ');
+
+  // Start with base layout properties (shared by all variants)
+  v.layoutMode = baseLayout;
+  v.primaryAxisSizingMode = 'AUTO';
+  v.counterAxisSizingMode = 'AUTO';
+  v.primaryAxisAlignItems = 'CENTER';
+  v.counterAxisAlignItems = 'CENTER';
+  v.itemSpacing = baseGap;
+  v.paddingTop = basePadding.top;
+  v.paddingBottom = basePadding.bottom;
+  v.paddingLeft = basePadding.left;
+  v.paddingRight = basePadding.right;
+  v.cornerRadius = baseRadius;
+  // Apply default fills, strokes from base classes or computedStyles
+
+  // Apply per-axis overrides for this combo
+  for (const [prop, val] of Object.entries(combo)) {
+    const axis = variantAxes[prop];
+    if (!axis) continue;
+
+    if (axis.source === 'variant-library' && axis.classMap?.[val]) {
+      // Parse Tailwind classes from classMap to override specific properties.
+      // Use the §2d Tailwind-to-Figma mapping table for property translation.
+      // Use the §2e color resolution chain (variables.json → resolved-colors.json → computedStyles).
+      //
+      // Examples:
+      //   'h-10 px-6 text-sm gap-2' → resize height to 40, paddingLeft/Right to 24, gap to 8
+      //   'bg-destructive text-destructive-foreground' → override fills and text color
+      //   'rounded-full' → cornerRadius = 9999
+      //   'border border-input bg-transparent' → add stroke, clear fills
+      const classes = axis.classMap[val];
+      // ... parse and apply each relevant class to v ...
+    }
+
+    if (axis.source === 'css-pseudo-state' && axis.stateStyles?.[val]) {
+      // Apply computed style diffs directly as Figma property overrides.
+      // These are already resolved values — no Tailwind parsing needed.
+      const styles = axis.stateStyles[val];
+      if (styles.backgroundColor) {
+        // Parse 'rgb(R, G, B)' → { r: R/255, g: G/255, b: B/255 }
+        v.fills = [{ type: 'SOLID', color: parseRgb(styles.backgroundColor) }];
+      }
+      if (styles.boxShadow) {
+        // Parse CSS box-shadow → Figma DROP_SHADOW or INNER_SHADOW effect
+        v.effects = [parseShadow(styles.boxShadow)];
+      }
+      if (styles.opacity) {
+        v.opacity = parseFloat(styles.opacity);
+      }
+    }
+  }
+
+  // ── Build children (same for all style variants) ──
+  // Create instances from instanceManifest per §2c rules.
+  // Override only characters on instances (screenshot-first rule).
+  // Add text nodes for text NOT owned by a child component.
+
+  fixSizing(v);
+  variants.push(v);
+}
+
+// ── 5. Combine into a component set ──
+const set = figma.combineAsVariants(variants, parentFrame);
+set.name = '{componentName}';
+set.layoutMode = 'HORIZONTAL';
+set.layoutWrap = 'WRAP';
+set.primaryAxisSizingMode = 'AUTO';
+set.counterAxisSizingMode = 'AUTO';
+set.paddingTop = 16;
+set.paddingBottom = 16;
+set.paddingLeft = 16;
+set.paddingRight = 16;
+set.itemSpacing = 16;
+set.counterAxisSpacing = 16;
+
+for (const v of set.children) fixSizing(v);
+fixSizing(set);
+
+return JSON.stringify({
+  name: set.name,
+  id: set.id,
+  variants: set.children.map((c) => ({ name: c.name, id: c.id })),
+});
+```
+
+## 2b-responsive. Building responsive breakpoint variants
+
+When a combo includes a `responsive-breakpoint` axis value, the variant must include **only** the JSX blocks visible at that breakpoint. Read the `visibilityMap` from the axis data to determine which blocks to include and exclude.
+
+**Key principle:** Each responsive variant is a structurally different component — different children, different layout, sometimes different sizing. Don't just toggle `visible` on nodes; build separate content for each variant.
+
+**How to apply the visibilityMap:**
+
+1. Read `visibilityMap[value].include` and `visibilityMap[value].exclude` for the current combo's Layout value
+2. For included blocks: build their full child tree (instances, text, icons)
+3. For excluded blocks: skip them entirely — don't create hidden nodes
+
+**Example — CustomerInformation with Layout axis:**
+
+```javascript
+// For Layout=Desktop:
+// - Include: "hidden lg:flex" title row (name + inline three-dot menu)
+// - Exclude: "lg:hidden" mobile title, "lg:hidden" mobile more actions button
+
+// For Layout=Mobile:
+// - Include: "lg:hidden" mobile title (stacked name), "lg:hidden" more actions button
+// - Exclude: "hidden lg:flex" desktop title row
+```
+
+**Sizing per variant:** Mobile variants typically use `widthIntent: 'fill'` at a narrower reference width (375px for phone). Desktop variants use the standard fill width from Step 1a. Set the component's `resize()` accordingly so each variant previews at its natural breakpoint width.
+
+**Child components shared across variants:** The same child instances (EditableTitle, EditableText, etc.) appear in both variants but may be arranged differently. Create separate instances for each variant — don't try to share instances between variant components.
+
+## 2b-states. Building prop-driven structural state variants
+
+When a combo includes a `prop-state` axis value, the variant must include the base component content **plus** any overlay or modal content that becomes visible in that state. Read `stateConfig[value].overlays` from the axis data.
+
+**Key principle:** State variants show what the user sees at a specific moment in an interaction flow. The base component is always present; overlays are added on top of or alongside it.
+
+**How to build each state:**
+
+### State = Default
+
+Build the component normally — all overlays closed, no menus visible.
+
+### State = Menu Open
+
+Build the base component, then add the dropdown menu content positioned near its trigger:
+
+```javascript
+// 1. Build base component content (same as Default)
+// 2. Add the open menu as a child frame
+
+const menuFrame = figma.createFrame();
+menuFrame.name = 'Menu Dropdown';
+menuFrame.layoutMode = 'VERTICAL';
+menuFrame.fills = [{ type: 'SOLID', color: { r: 1, g: 1, b: 1 } }];
+menuFrame.cornerRadius = 8;
+menuFrame.effects = [
+  {
+    type: 'DROP_SHADOW',
+    color: { r: 0, g: 0, b: 0, a: 0.1 },
+    offset: { x: 0, y: 4 },
+    radius: 12,
+    visible: true,
+  },
+];
+menuFrame.paddingTop = 4;
+menuFrame.paddingBottom = 4;
+
+// Add menu items from stateConfig overlays[].content
+// Each menu item: icon instance + text label in a horizontal row
+// Use destructive styling (red text) when specified
+```
+
+Position the menu relative to its trigger using absolute positioning within a wrapper frame, or append it as a sibling in the layout and annotate with the position description from `stateConfig`.
+
+### State = Dialog/Modal Open
+
+Build the base component, then add the modal as a detached overlay:
+
+```javascript
+// 1. Build base component content (same as Default, optionally dimmed)
+// 2. Add modal overlay
+
+const modalFrame = figma.createFrame();
+modalFrame.name = 'Modal Overlay';
+modalFrame.layoutMode = 'VERTICAL';
+
+// Backdrop (semi-transparent)
+const backdrop = figma.createFrame();
+backdrop.name = 'Backdrop';
+backdrop.fills = [{ type: 'SOLID', color: { r: 0, g: 0, b: 0 }, opacity: 0.5 }];
+
+// Dialog content from stateConfig overlays[].props
+// Title, description, confirm/cancel buttons
+// Apply confirmClassName for destructive actions (red button)
+```
+
+**Overlay content source:** Read the exact text strings from `stateConfig[value].overlays[].props` (title, description, confirmText, etc.). These were extracted from the source code's JSX props during Step 1b-iv. Never use placeholder text.
+
+**Instance reuse in overlays:** If the overlay component (ConfirmationDialog, MoreOptionsMenu) exists in `builtComponents`, create an instance and override its text content per §2c rules. If it doesn't exist in `builtComponents`, build the overlay content inline using frames and text nodes — the comparison step will validate the visual output either way.
+
+## 2c. Creating child elements
+
+**Text nodes:**
+
+> **Font family — use `Inter` deliberately, not by accident.** This project ships no custom web font: text resolves to the OS system stack (`ui-sans-serif, system-ui, sans-serif` in `code.json`), which renders as the platform UI font (SF Pro on macOS, Segoe UI on Windows). `system-ui` cannot be rendered portably in Figma, so this project maps every system stack to **Inter** as the documented, portable proxy. Inter is a *deliberate approximation*, not a true match — Step 4 must treat any residual text diff accordingly (see the font guardrail in Step 4c). Only build text in a different family when `code.json`'s `fontFamily` names a real, loadable web font (not a system stack); in that case load and use that family instead.
+
+```javascript
+await figma.loadFontAsync({ family: 'Inter', style: 'Regular' });
+const text = figma.createText();
+text.characters = '{exact text from text.json}';
+text.fontSize = { size };
+text.fontName = { family: 'Inter', style: '{Regular|Medium|Semi Bold|Bold}' };
+text.fills = [{ type: 'SOLID', color: { rgb } }];
+text.lineHeight = { value: { lh }, unit: 'PIXELS' };
+parent.appendChild(text);
+```
+
+**Text nodes do NOT support padding.** Wrap in a frame:
+
+```javascript
+// WRONG: text.paddingLeft = 4;
+// CORRECT:
+const wrapper = figma.createFrame();
+wrapper.layoutMode = 'HORIZONTAL';
+wrapper.primaryAxisSizingMode = 'AUTO';
+wrapper.counterAxisSizingMode = 'AUTO';
+wrapper.paddingLeft = 4;
+wrapper.paddingRight = 4;
+wrapper.fills = [];
+wrapper.appendChild(text);
+```
+
+**Icon instances:**
+
+```javascript
+const iconComp = figma.getNodeById(builtComponents['Icon/Check']);
+const iconInstance = iconComp.createInstance();
+iconInstance.resize(16, 16); // h-4 w-4
+parent.appendChild(iconInstance);
+```
+
+**Sub-component instances:**
+
+```javascript
+const subComp = figma.getNodeById(builtComponents['Button']);
+const instance = subComp.createInstance();
+parent.appendChild(instance);
+```
+
+**Overriding text inside an instance** — when the source code passes a custom string (e.g. `<EditableTitle value="Lisa" />`, `<EditableText label="Email Address" value="..." />`), find the instance's internal TEXT node and override its `characters`. **Do not** substitute a plain text node for the instance — Step 4a rejects that.
+
+**Screenshot-first override rule:** Only override `characters` (text content) during the initial build. Do NOT override styling properties (`fontSize`, `fontName`, `lineHeight`, `fills`) based on source code analysis — source code className interpretation is error-prone (e.g. confusing mobile-only styles with desktop styles, misreading conditional classes). Instead:
+
+1. **Build with master defaults** — override only `characters`, keep the master's font size, weight, color, and line height.
+2. **Let the comparison step (Step 4) catch mismatches** — if the master's default styling doesn't match the app screenshot, the pixel diff will show exactly where and how.
+3. **Fix in Step 5 using the diff image** — the fix loop has the app screenshot and the diff overlay as visual evidence. Apply style overrides there, guided by what the diff actually shows rather than what the source code suggests.
+
+This prevents the common failure mode where source code analysis produces confident-but-wrong style overrides that pass the comparison threshold but don't match the live app.
+
+```javascript
+const inst = subComp.createInstance();
+
+// Pick the variant first if the master is a component set:
+inst.setProperties({ State: 'Rest' });
+
+// Find the target text node by current characters (placeholder), name, or position:
+const text = inst.findOne(
+  (n) => n.type === 'TEXT' && n.characters === 'Title' // placeholder in the master
+);
+await figma.loadFontAsync(text.fontName); // mandatory — instance text inherits the master font
+text.characters = 'Lisa';
+// DO NOT override fontSize, fontName, lineHeight, or fills here.
+// The master's defaults are used. Step 4 comparison will flag mismatches.
+
+parent.appendChild(inst);
+```
+
+Multi-field components (e.g. `EditableText` with a label slot and a value slot) typically expose multiple text descendants. Match each by its placeholder string, name, or `findAll` index. Example:
+
+```javascript
+const inst = editableTextComp.createInstance();
+const [labelText, valueText] = inst.findAll((n) => n.type === 'TEXT');
+await figma.loadFontAsync(labelText.fontName);
+await figma.loadFontAsync(valueText.fontName);
+labelText.characters = 'Email Address';
+valueText.characters = 'lisa.anderson@customer.com';
+```
+
+If the masters' placeholder strings change, `findOne(characters === 'X')` will stop matching. Prefer matching by _position_ within `findAll((n) => n.type === 'TEXT')` (label first, value second) or by the text node's `name` field — both survive content edits to the master.
+
+**Rectangles (dividers, backgrounds, decorative elements):**
+
+```javascript
+const divider = figma.createRectangle();
+divider.name = 'Divider';
+divider.resize(200, 1);
+divider.fills = [{ type: 'SOLID', color: { r: 0.898, g: 0.906, b: 0.922 } }];
+divider.layoutSizingHorizontal = 'FILL'; // stretch to fill parent width
+parent.appendChild(divider);
+```
+
+## 2d. Tailwind-to-Figma mapping reference
+
+| Tailwind            | Figma Property                                           | Value                          |
+| ------------------- | -------------------------------------------------------- | ------------------------------ |
+| `flex-col`          | `layoutMode`                                             | `'VERTICAL'`                   |
+| `flex` / `flex-row` | `layoutMode`                                             | `'HORIZONTAL'`                 |
+| `items-center`      | `counterAxisAlignItems`                                  | `'CENTER'`                     |
+| `justify-between`   | `primaryAxisAlignItems`                                  | `'SPACE_BETWEEN'`              |
+| `justify-center`    | `primaryAxisAlignItems`                                  | `'CENTER'`                     |
+| `gap-{n}`           | `itemSpacing`                                            | `n * 4` (px)                   |
+| `p-{n}`             | all paddings                                             | `n * 4`                        |
+| `px-{n}`            | `paddingLeft/Right`                                      | `n * 4`                        |
+| `py-{n}`            | `paddingTop/Bottom`                                      | `n * 4`                        |
+| `rounded-md`        | `cornerRadius`                                           | `6`                            |
+| `rounded-lg`        | `cornerRadius`                                           | `8`                            |
+| `rounded-xl`        | `cornerRadius`                                           | `12`                           |
+| `rounded-full`      | `cornerRadius`                                           | `9999`                         |
+| `border`            | `strokeWeight`                                           | `1`, `strokeAlign: 'OUTSIDE'`  |
+| `text-sm`           | `fontSize`                                               | `14`, lineHeight `20`          |
+| `text-base`         | `fontSize`                                               | `16`, lineHeight `24`          |
+| `text-lg`           | `fontSize`                                               | `18`, lineHeight `28`          |
+| `text-xl`           | `fontSize`                                               | `20`, lineHeight `28`          |
+| `text-2xl`          | `fontSize`                                               | `24`, lineHeight `32`          |
+| `font-medium`       | fontName style                                           | `'Medium'`                     |
+| `font-semibold`     | fontName style                                           | `'Semi Bold'`                  |
+| `font-bold`         | fontName style                                           | `'Bold'`                       |
+| `w-full` / `flex-1` | `layoutSizingHorizontal`                                 | `'FILL'`                       |
+| `h-full`            | `layoutSizingVertical`                                   | `'FILL'`                       |
+| `w-[Npx]`           | `resize(N, ...)` then `layoutSizingHorizontal = 'FIXED'` | explicit width                 |
+| `truncate`          | `textTruncation`                                         | `'ENDING'`, `maxLines: 1`      |
+| `overflow-hidden`   | `clipsContent`                                           | `true`                         |
+| `shadow-sm`         | `effects`                                                | `[{type: 'DROP_SHADOW', ...}]` |
+| `opacity-{n}`       | `opacity`                                                | `n / 100`                      |
+
+## 2e. Resolving Tailwind color variables
+
+When source code references Tailwind semantic colors (e.g., `bg-primary`, `text-muted-foreground`, `border-input`), use the Figma variable system as the **primary path** and hardcoded RGB as the **fallback**.
+
+### Step 1 — Before writing `use_figma` code (Node.js context, has `fs`)
+
+Read `variables.json` at the start of Step 2 and extract the entries relevant to this component:
+
+```javascript
+const fs = require('fs');
+const varMap = JSON.parse(fs.readFileSync('.temp/figma-from-code/variables.json', 'utf-8'));
+// varMap keys are CSS var names like "var(--primary)", "var(--radius)", etc.
+// varMap values: { id, name, collectionName, resolvedType }
+```
+
+Identify every Tailwind class in the component's source, resolve it to a CSS variable name via `tailwind.config.js`, then check if that CSS variable name exists in `varMap`. Embed the **relevant subset** as an inline JSON literal inside the `use_figma` script (the plugin sandbox has no `fs` access — you must inline the data):
+
+```javascript
+// use_figma — inline the relevant variable entries
+const variableMap = {
+  'var(--primary)': { id: 'VariableID:123:1', resolvedType: 'COLOR' },
+  'var(--background)': { id: 'VariableID:123:2', resolvedType: 'COLOR' },
+  'var(--muted-foreground)': { id: 'VariableID:123:3', resolvedType: 'COLOR' },
+  'var(--input)': { id: 'VariableID:123:4', resolvedType: 'COLOR' },
+  'var(--radius)': { id: 'VariableID:123:5', resolvedType: 'FLOAT' },
+  // only include vars actually used by this component
+};
+```
+
+### Step 2 — Inside `use_figma` (plugin sandbox): bind variables, fallback to RGB
+
+**COLOR variables** (fills, strokes, text fills):
+
+```javascript
+// After resolving "bg-primary" → "--primary" → "var(--primary)":
+const varEntry = variableMap['var(--primary)'];
+if (varEntry) {
+  const figmaVar = await figma.variables.getVariableByIdAsync(varEntry.id);
+  // For fills[0]:
+  comp.fills = [{ type: 'SOLID', color: { r: 0, g: 0, b: 0 } }]; // set fill type first
+  comp.setBoundVariable('fills', 0, figmaVar);
+} else {
+  // Fallback: hardcode the resolved RGB
+  comp.fills = [{ type: 'SOLID', color: { r: 0.141, g: 0.31, b: 0.722 } }];
+}
+```
+
+**Binding fills vs strokes vs text fills** — the property name differs by node type:
+
+```javascript
+// fills — frame, component, rectangle
+comp.fills = [{ type: 'SOLID', color: { r: 0, g: 0, b: 0 } }];
+comp.setBoundVariable('fills', 0, figmaVar); // binds fills[0]
+
+// strokes — frame, component, rectangle
+comp.strokes = [{ type: 'SOLID', color: { r: 0, g: 0, b: 0 } }];
+comp.setBoundVariable('strokes', 0, figmaVar); // binds strokes[0]
+
+// text fills — text node (same API, different node)
+textNode.fills = [{ type: 'SOLID', color: { r: 0, g: 0, b: 0 } }];
+textNode.setBoundVariable('fills', 0, figmaVar); // binds text color
+```
+
+**FLOAT variables** (corner radius, spacing):
+
+```javascript
+// cornerRadius — bind all four corners individually
+const radiusVar = await figma.variables.getVariableByIdAsync(variableMap['var(--radius)'].id);
+comp.setBoundVariable('topLeftRadius', radiusVar);
+comp.setBoundVariable('topRightRadius', radiusVar);
+comp.setBoundVariable('bottomLeftRadius', radiusVar);
+comp.setBoundVariable('bottomRightRadius', radiusVar);
+
+// itemSpacing (gap) — if a spacing token maps to a CSS var
+const gapVar = await figma.variables.getVariableByIdAsync(variableMap['var(--spacing-4)'].id);
+comp.setBoundVariable('itemSpacing', gapVar);
+```
+
+### Fallback resolution chain (when no variable entry exists)
+
+If a CSS variable is not in `variableMap` (not in Phase 1 collections, or plain color value), fall back to the pre-computed color lookup:
+
+1. Read `.temp/figma-from-code/resolved-colors.json` (generated once by the orchestrator during Phase 1 — see SKILL.md "Phase 1 post-step: Resolve CSS colors").
+2. To resolve a Tailwind class (e.g. `bg-primary`):
+   - Look up the class in `resolved-colors.json.tailwindMap` to get the CSS variable name (e.g. `"--primary"`).
+   - Look up that variable name in `resolved-colors.json.cssVariables["--primary"].rgb`.
+   - Use the pre-computed `{ r, g, b }` values directly — no arithmetic needed.
+3. To resolve a bare CSS variable (e.g. `var(--muted-foreground)`):
+   - Strip the `var()` wrapper to get `--muted-foreground`.
+   - Look up `resolved-colors.json.cssVariables["--muted-foreground"].rgb` directly.
+4. Only if the variable is absent from `resolved-colors.json`: fall back to `computed-styles.json` values from Step 1g as a final fallback.
+
+Example lookup:
+
+```javascript
+const resolvedColors = JSON.parse(
+  fs.readFileSync('.temp/figma-from-code/resolved-colors.json', 'utf8')
+);
+
+function resolveClass(tailwindClass) {
+  const varName = resolvedColors.tailwindMap[tailwindClass];
+  if (varName && resolvedColors.cssVariables[varName]) {
+    return resolvedColors.cssVariables[varName].rgb;
+  }
+  return null;
+}
+
+function resolveVar(cssVarName) {
+  const key = cssVarName
+    .replace(/^var\(/, '')
+    .replace(/\)$/, '')
+    .trim();
+  return resolvedColors.cssVariables[key]?.rgb ?? null;
+}
+
+const primaryColor = resolveClass('bg-primary');
+const mutedFgColor = resolveVar('var(--muted-foreground)');
+```
+
+## 2f. Enumerate built instances + write `.figma/figma.json`
+
+After `fixSizing` and `appendChild` have settled the structure, enumerate every `INSTANCE` inside the built component and write the result to `<sourceDir>/.figma/figma.json`. This is the **built-derived half** of the Step 4a gate. It must reflect the _actual_ Figma node tree, not the source-side intent.
+
+**Enumerate via `use_figma`:**
+
+```javascript
+const root = figma.getNodeById('<nodeId>');
+const seen = new Map(); // figmaName -> { nodeId, fileKey }
+const instances = root.findAll((n) => n.type === 'INSTANCE');
+for (const inst of instances) {
+  const main = inst.mainComponent;
+  if (!main) continue;
+  const isVariant = main.parent && main.parent.type === 'COMPONENT_SET';
+  const name = isVariant ? main.parent.name : main.name;
+  const id = isVariant ? main.parent.id : main.id;
+  if (!seen.has(name)) seen.set(name, id);
+}
+return JSON.stringify(
+  [...seen.entries()].map(([componentName, nodeId]) => ({ componentName, nodeId }))
+);
+```
+
+For each `{ componentName, nodeId }` returned, build the dependency entry:
+
+1. `url` — `https://figma.com/design/{fileKey}?node-id={nodeId.replace(':', '-')}`.
+2. `dependencies` — read from the child's own `.figma/figma.json` (e.g. `<source-dir>/components/EditableTitle/.figma/figma.json`). If missing or unparseable, use `[]`. Components are built bottom-up, so child tracking files will already exist.
+
+**Schema (the file you write):**
+
+```json
+{
+  "fileKey": "<figmaFileKey>",
+  "nodeId": "<componentSetIdOrComponentId>",
+  "url": "https://figma.com/design/<fileKey>?node-id=<nodeIdWithDashes>",
+  "componentName": "CustomerInformation",
+  "createdAt": "2026-05-15T14:32:00Z",
+  "updatedAt": "2026-05-19T15:00:00Z",
+  "dependencies": [
+    {
+      "componentName": "EditableTitle",
+      "nodeId": "23:18",
+      "url": "https://figma.com/design/<fileKey>?node-id=23-18",
+      "dependencies": [ ... ]
+    },
+    ...
+  ]
+}
+```
+
+**Read-then-write for `createdAt`:**
+
+1. If `<sourceDir>/.figma/figma.json` exists, parse it and preserve `createdAt`. Refresh everything else.
+2. If a legacy `<sourceDir>/figma.json` (root-level, pre-`.figma/` layout) exists, read it only to recover `createdAt`.
+3. If neither exists, set both `createdAt` and `updatedAt` to the current ISO 8601 UTC timestamp.
+
+`dependencies` is **always recomputed from the live enumeration** — never carried over from a prior run. The whole point of this file is to mirror current Figma state.
+
+**Folder resolution** (same rules as Step 1 — see schema reference at top of step-1-analyze.md):
+
+- `Button` → `<source-dir>/components/Button/.figma/figma.json`
+- Nested modlets follow the source path.
+- `Icon/{Name}` → `<source-dir>/components/Icon/{Name}/.figma/figma.json` (synthesized).
+- `Asset/{Name}` → `<source-dir>/components/Asset/{Name}/.figma/figma.json` (synthesized).
+
+**Failure handling:** if the write fails, log the error and surface it in the Step 7 result under `trackingFile`. The Step 4a gate will then fail (missing `figma.json`), making the failure unambiguous.
+
+After Step 2f completes, the two `.figma/*.json` files exist and Step 4a is ready to diff them.
+
+---
+
+## fixSizing() — Mandatory After Every Build
+
+Call `fixSizing()` on every component and every variant before appending to the parent frame. This corrects frames whose height was locked by a `resize()` call during construction.
+
+```javascript
+function fixSizing(node, depth = 0) {
+  if (depth > 10 || !node) return;
+  const hasLayout =
+    (node.type === 'COMPONENT' || node.type === 'FRAME' || node.type === 'COMPONENT_SET') &&
+    node.layoutMode &&
+    node.layoutMode !== 'NONE';
+  if (hasLayout) {
+    if (node.layoutMode === 'VERTICAL') node.primaryAxisSizingMode = 'AUTO';
+    node.counterAxisSizingMode = 'AUTO';
+  }
+  const children = 'children' in node ? node.children : [];
+  for (const child of children) fixSizing(child, depth + 1);
+}
+```
+
+**During construction**, always set sizing modes to `AUTO` before `resize()` — otherwise `resize()` locks the height:
+
+```javascript
+// WRONG — locks height to 10px
+comp.counterAxisSizingMode = 'FIXED';
+comp.resize(200, 10);
+
+// CORRECT — height grows with content; resize() sets width only
+comp.primaryAxisSizingMode = 'AUTO';
+comp.counterAxisSizingMode = 'AUTO';
+comp.resize(200, 10);
+```
+
+---
+
+## Pitfalls
+
+| Pitfall                                               | Prevention                                                                                                                                           |
+| ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| All components appear as thin strips                  | `fixSizing()` was not called — run it on every component and variant                                                                                 |
+| Text node padding error                               | Text nodes do not support padding — wrap in an auto-layout frame (see §2c)                                                                           |
+| `strokeAlign: 'INSIDE'` double-border                 | Always use `strokeAlign: 'OUTSIDE'` to match the CSS box model                                                                                       |
+| Placeholder text instead of real text                 | Always use exact strings from `textContent` / `text.json`                                                                                            |
+| Rebuilding a sub-component that already exists        | Check `builtComponents` first, create an instance instead                                                                                            |
+| Rebuilding an icon that already exists                | Check `builtComponents` for `Icon/{Name}`, create an instance                                                                                        |
+| Component set has no layout after `combineAsVariants` | Explicitly set `layoutMode`, sizing, padding, and spacing on the set                                                                                 |
+| Manual x/y positioning inside auto-layout parent      | Never set x/y when the parent frame has `layoutMode` set — auto-layout manages positioning                                                           |
+| Colors don't match app                                | Resolve Tailwind CSS variables through the full chain: class → config → CSS variable → HSL/OKLCH → RGB (see §2e)                                     |
+| Icon at wrong size                                    | Check Tailwind size class: `h-4 w-4` = 16×16, `h-5 w-5` = 20×20, `h-6 w-6` = 24×24                                                                   |
+| Instance styling overrides don't match the live app   | During Step 2, only override `characters` — never `fontSize`, `fontName`, `lineHeight`, or `fills`. Keep master defaults; let Step 4 flag mismatches |
+
+## Error Handling
+
+| Scenario                                          | Action                                                                                        |
+| ------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `use_figma` fails                                 | Diagnose error, fix script, retry once. If still failing, return `status: "failed"`           |
+| `use_figma` incremental limit reached             | Split the build across multiple `use_figma` calls — build sub-structures first, then assemble |
+| Font not available                                | Fall back to `{ family: 'Inter', style: 'Regular' }` — Inter is always available in Figma     |
+| `componentNodeId` is null or missing after Step 2 | Return `status: "failed"` immediately — do not proceed to Step 3                              |

--- a/plugins/figma-from-code/skills/figma-from-code/7-build-component/step-3-screenshot.md
+++ b/plugins/figma-from-code/skills/figma-from-code/7-build-component/step-3-screenshot.md
@@ -1,0 +1,51 @@
+# Step 3: Screenshot the Figma Result
+
+After building, capture the Figma component for comparison.
+
+## Skip guard — existing screenshot
+
+Before capturing, check whether `{screenshotDir}/figma.png` already exists on disk:
+
+```bash
+test -f "{screenshotDir}/figma.png"
+```
+
+If the file **exists**: skip steps 3a and 3b entirely. Use the existing path as the Figma screenshot and proceed directly to step 4.
+
+If the file **does not exist**: proceed with steps 3a and 3b below.
+
+> **Fix loop exception**: Step 5 (fix loop) must always take a fresh screenshot after each fix to measure improvement — this skip guard applies only to the initial step-3 capture.
+
+## 3a. Determine what to screenshot
+
+- **Single component**: screenshot the component node directly
+- **Component set**: resolve the specific variant that matches the app screenshot
+
+```javascript
+// use_figma — resolve variant for screenshot
+const node = figma.getNodeById('{componentOrSetId}');
+if (node.type === 'COMPONENT_SET') {
+  const targetProps = { Variant: 'primary', State: 'Default' }; // from figmaVariant input
+  let match = node.children.find((child) =>
+    Object.entries(targetProps).every(
+      ([k, v]) => child.variantProperties?.[k]?.toLowerCase() === v.toLowerCase()
+    )
+  );
+  match = match ?? node.children[0];
+  return JSON.stringify({ screenshotNodeId: match.id, variantName: match.name });
+} else {
+  return JSON.stringify({ screenshotNodeId: node.id, variantName: node.name });
+}
+```
+
+## 3b. Capture the screenshot
+
+```
+get_screenshot(fileKey, screenshotNodeId)
+```
+
+Save the result to `{screenshotDir}/figma.png`:
+
+```bash
+curl -sL "{image_url}" -o "{screenshotDir}/figma.png"
+```

--- a/plugins/figma-from-code/skills/figma-from-code/7-build-component/step-4-compare.md
+++ b/plugins/figma-from-code/skills/figma-from-code/7-build-component/step-4-compare.md
@@ -1,0 +1,163 @@
+# Step 4: Compare Against App Screenshot
+
+> **All of Step 4 runs inline.** Run 4a (instance check), then 4b (sizing check), then 4c (pixel diff). Produce a structured verdict. Do NOT attempt any fixes in this step — if the verdict is not "match", Step 5 handles fixes.
+
+## 4a. Instance usage check (run FIRST — hard gate)
+
+Before any visual comparison, verify that every design-system child the source code imports is actually present as an `INSTANCE` inside the built component. A pixel diff cannot catch substitution failures: rendering an `EditableTitle` as a plain text node produces a visually identical rest-state result, but breaks design-system coupling, variant switching, and Code Connect.
+
+The gate consumes the two `.figma/*.json` tracking files written earlier:
+
+- `<sourceDir>/.figma/code.json` — Step 1 wrote this (incrementally across sub-steps). The `childComponents` field is the **source-derived** required set, in Figma name space.
+- `<sourceDir>/.figma/figma.json` — Step 2f wrote this. The `dependencies[].componentName` list is the **built-derived** actual set, enumerated from the live Figma node tree.
+
+### Run the gate
+
+```bash
+node ${CLAUDE_SKILL_DIR}/7-build-component/check-instances.js \
+  <componentName> \
+  <sourceDir>
+```
+
+`<sourceDir>` is the directory whose `.figma/` subfolder contains both tracking files (the modlet root for normal components, or the synthesized `Icon/{Name}/` directory for icons).
+
+**Exit codes:**
+
+- `0` — every required child appears in `figma.dependencies`. Writes `.temp/figma-from-code/instances/<componentName>.ok`.
+- `1` — at least one required child is missing as a dependency. Prints rejection JSON to stderr (see below).
+
+If the script reports a missing tracking file, the earlier step that should have written it (Step 1 for `code.json`, Step 2f for `figma.json`) is the place to fix — don't paper over by hand-writing the file from inside Step 4.
+
+### Hard rejection — what to do when it fails
+
+If the script exits 1, **stop the comparison flow and jump straight to Step 5 fix-loop with `missing_instances` as the discrepancy.** Do NOT proceed to 4b/4c (sizing & pixel diff) — those would waste iterations on a build that is structurally wrong regardless of pixel score.
+
+Rejection JSON shape:
+
+```json
+{
+  "status": "rejected",
+  "reason": "missing_instances",
+  "missingInstances": ["EditableText", "EditableTitle", "MoreOptionsMenu"],
+  "missingDetails": [
+    {
+      "figmaName": "EditableTitle",
+      "sourceName": "EditableTitle",
+      "origin": "@/components/inline-edit"
+    }
+  ],
+  "howToFix": "Replace each local subtree with figma.getNodeById(builtComponents[name]).createInstance()..."
+}
+```
+
+Feed `missingInstances` into Step 5 — each entry must become an instance in the next fix iteration. Substituting plain text or local frames for any required instance is **always wrong**, even when the rest-state visual is identical. There is no acceptable visual-equivalence shortcut.
+
+### Acceptable exceptions
+
+There are none for design-system components in `builtComponents`. Portal-rendered components (`ConfirmationDialog`, `AlertDialog`, toasts) must still appear in the Figma master as **detached examples** (instances placed inside or next to the component) so designers can see and prototype them. They are not excluded from the check.
+
+If a fix-loop iteration genuinely cannot reach a passing state (e.g. the design-system component itself is broken), surface the failure in the Step 7 result with `instanceCheck: { verdict: "fail", missing: [...] }` and let the user decide whether to override.
+
+## 4b. Sizing sanity check (run BEFORE the pixel compare)
+
+A pixel diff against a narrow `app.png` can pass even when the component is built far smaller than it will render in real usage — this is the most common silent failure mode. Run this check first; it is independent of the screenshot.
+
+Inspect the built component (`use_figma`) and read its top-level frame:
+
+```javascript
+const node = figma.getNodeById('{nodeId}');
+const built = {
+  w: Math.round(node.width),
+  h: Math.round(node.height),
+  primaryAxisSizingMode: node.primaryAxisSizingMode,
+  counterAxisSizingMode: node.counterAxisSizingMode,
+  layoutMode: node.layoutMode,
+};
+```
+
+Compare against the **sizing intent** captured in Step 1a (only run this if 4a passed):
+
+| Intent (per axis)                                  | Expected built state                                                                                                                                        | Flag if …                                                                                                                                          |
+| -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `fill`                                             | Master is FIXED at the consumer's expected size (page body width for page-level; parent slot width otherwise). Or the root child is FILL inside its parent. | `*SizingMode === 'AUTO'` AND the dimension is much smaller than the expected fill size (< 50%)                                                     |
+| `fill:NNN` (parent-context promotion from Step 1a) | Master width equals NNN ± 5% (i.e. parent content-box width measured by Step 1g).                                                                           | Built width < NNN × 0.85, OR `primaryAxisSizingMode === 'AUTO'` on the horizontal axis when the parent was ≥ 200px wider than the element rendered |
+| `fixed:NNN`                                        | Dimension equals NNN ± 2px                                                                                                                                  | Difference > 2px                                                                                                                                   |
+| `hug`                                              | `*SizingMode === 'AUTO'`                                                                                                                                    | Forced FIXED with no clear reason                                                                                                                  |
+
+**Additional checks:**
+
+- **Page-level component (role hint from Step 1a)**: width must be ≥ 1200px AND height must be ≥ 600px (or the screen body dimensions read from `figmaNodes.screensFrameId`). If the master is 622×304 because precapture cropped the screenshot, this check catches it. Includes components flagged via the _page-consumed fallback_ (Step 1a, used when Step 1g was skipped).
+- **Children with `flex-1` siblings in source but matching `*SizingMode='HUG'` in Figma**: the auto-layout will collapse the component. Flag.
+
+If any check fails, **treat this as a `size_mismatch` discrepancy and feed it into Step 5 alongside (or before) the pixel diff results.** Do not declare a match based on pixel score alone if the sizing check failed — pixel match against a too-narrow `app.png` is a false positive. (4a must already have passed before you reach this point.)
+
+Record the sizing check result in the eventual result file:
+
+```json
+"comparison": {
+  "sizingCheck": {
+    "verdict": "pass" | "fail",
+    "issues": ["fill:1240 intent, built width 622 (< 1054 = 1240 × 0.85)"],
+    "builtSize": {"w": 622, "h": 304},
+    "expectedSize": {"w": 1240, "h": 768},
+    "expectedSource": "parent-context (Step 1g)"
+  },
+  "matchPct": 95.26,
+  ...
+}
+```
+
+`expectedSource` is one of: `"page-level role hint"`, `"parent-context (Step 1g)"`, `"page-consumed fallback (Step 1g skipped)"`, or `"explicit fixed:NNN"` — surfaces which Step 1a signal produced the expected size, so a fix-loop diagnosis (or a later validator) can tell whether a failure reflects a stale signal vs. an actual sizing bug.
+
+## Screenshot Scale Convention
+
+Both sides of the comparison must use 1x scale to avoid dimension mismatches:
+
+- **App screenshots** are captured at 1440x900 viewport with `deviceScaleFactor: 1` (enforced in `screenshot.js`). This prevents Retina 2x doubling.
+- **Figma screenshots** via `get_screenshot` must request `scale: 1` to produce a 1x export. Without this, Figma defaults may produce higher-resolution images.
+- Minor size differences between app and Figma screenshots are acceptable. The comparison focuses on visual fidelity, not pixel-exact dimensions.
+- **`app.png` is the immutable precaptured reference — read it from `{screenshotDir}/app.png` on disk. Never re-capture or re-fetch it.** Only the Figma side (`figma.png`) is (re)captured, and Step 3's skip-guard already avoids redundant initial captures.
+
+## 4c. Pixel diff comparison
+
+Run the pixel diff comparison:
+
+```bash
+node ${CLAUDE_SKILL_DIR}/10-validator/compare.js \
+  "{screenshotDir}/app.png" \
+  "{screenshotDir}/figma.png" \
+  "{screenshotDir}/"
+```
+
+This produces:
+
+- `diff.png` — red pixels mark differences, matching pixels dimmed
+- `comparison.json` — `{ matchPct, borderMatchPct, verdict, borderVerdict }`
+
+**Verdict thresholds (combined with 4a + 4b results):**
+
+- 4a + 4b passed AND `matchPct >= 90%` AND `borderMatchPct >= 85%` → **match** (done)
+- 4a failed → **missing_instances** (fix structure first, then re-enumerate and re-run 4a)
+- 4b failed (regardless of pixel score) → **size_mismatch** (fix sizing first, then re-screenshot, then re-run 4a–4c)
+- 4a + 4b passed AND `matchPct 75-90%` or `borderMatchPct < 85%` → **minor_diff** (needs fixing)
+- 4a + 4b passed AND `matchPct < 75%` → **mismatch** (needs fixing)
+
+A passing pixel verdict alone is NOT enough — 4a AND 4b must also pass. Otherwise the build is silently wrong-structured or wrong-sized and the validation phase will reject it later.
+
+If no app screenshot exists (`appScreenshot` is null), skip pixel comparison — but still run 4a and 4b. Report `no_app_reference` only if both pass; otherwise report the failure of whichever check failed.
+
+**Font guardrail — never excuse a text diff you have not verified.** When a text-heavy component lands in `minor_diff`/`mismatch`, do NOT attribute the residual to "font rasterization", "glyph rendering", "Inter vs the app font", or any font hand-wave **unless** the Figma text node's family equals the resolved `figmaFontFamily` from Step 1 (i.e. the font you actually built with is the project's mapped target for the app's computed `fontFamily`). Concretely:
+
+- If the built font family **matches** the mapped target (e.g. app computes a system stack → mapped to Inter → built in Inter), a small residual on text-heavy components is expected proxy drift; it stays the threshold-assigned verdict and needs no font fix. Note it as `font: proxy-approximation (system-ui→Inter)` with the two family names, not as "rasterization".
+- If the built font family **differs** from the mapped target (wrong family was applied), classify it as a fixable **`font_mismatch`** and feed it to Step 5 to set the correct family — do not bury it in `minor_diff`.
+
+Either way, record `fontCheck: { computed, mappedTarget, built, matches }` in the comparison output so the verdict is auditable and the validation phase can re-check it.
+
+## Error Handling
+
+| Scenario                                                          | Action                                                                                                                           |
+| ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `check-instances.js` crashes (non-zero exit, no JSON output)      | Surface error in result under `instanceCheck: { verdict: "error", error: "..." }`; treat as 4a failure and proceed to Step 5 fix loop |
+| `check-instances.js` reports missing instances (exit 1 with JSON) | Hard reject — proceed to Step 5 fix loop with `missing_instances` discrepancy; do not proceed to 4b/4c                               |
+| `get_screenshot` fails                                            | Retry once. If still failing, return component as built-but-unvalidated with `comparison: { verdict: "screenshot_error" }`       |
+| `compare.js` fails or crashes                                     | Report `comparison: { verdict: "compare_error", error: "..." }`; return component with `nodeId` but no match score               |

--- a/plugins/figma-from-code/skills/figma-from-code/7-build-component/step-5-fix-loop.md
+++ b/plugins/figma-from-code/skills/figma-from-code/7-build-component/step-5-fix-loop.md
@@ -1,0 +1,127 @@
+# Step 5: Fix Loop (Up to 3 Iterations)
+
+> **This step runs inline.** Diagnose discrepancies from `diff.png` and `comparison.json`, not from assumptions about what "should" be wrong. Read the source `.tsx` ONLY to resolve specific differences the comparison identified — never to form a prior about what the component "probably" looks like.
+>
+> **Anti-pattern: blanket fixes.** Never apply the same fix to all instances of a component type without diff evidence that each instance is wrong. If `diff.png` shows a problem with one EditableTitle but not another, fix only the one the diff flags. Each instance must be individually verified against the diff before modification. The build phase may have left some instances correct and others incorrect — you cannot know which without checking the comparison data.
+
+## Iteration model
+
+Step 5 runs up to 3 fix iterations inline:
+
+- **Iteration 1**: Diagnose only from `diff.png`, `comparison.json`, and the step inputs. Focus on comparison data, not build assumptions.
+- **Iterations 2 and 3**: Continue with the context of previous fix attempts and their outcomes.
+
+If all 3 iterations complete without reaching `verdict: "match"`, exit the loop. Return `status: "partial_match"` and proceed to Step 6 — do **not** retry Step 5. Also exit **early** — before consuming all 3 iterations — when an iteration fails to improve the score or when the comparison baseline turns out to be invalid/unreachable; see the bail conditions in 5d. Running all 3 iterations is a ceiling, not a quota.
+
+If the verdict is `minor_diff` or `mismatch`, enter the fix loop.
+
+## Screenshot economy
+
+Each `get_screenshot` call is a network round-trip and a token cost — do not re-pull images you already have on disk:
+
+- **`app.png` is immutable.** It is the precaptured app reference (Step 1g / precapture). Always **read it from `{screenshotDir}/app.png`**; never call `get_screenshot` on it or re-run the app capture — it does not change between iterations.
+- **Capture `figma.png` at most once per iteration**, and only *after* a structural edit + the Step 4a gate passes (§5c). Do not re-screenshot the Figma node speculatively or more than once per iteration.
+- **`diff.png` and `comparison.json` are produced locally by `compare.js`.** Read them from disk; never fetch them remotely.
+- Read each input image **once** per iteration. If you already read `diff.png`/`comparison.json` this iteration, reuse what you have rather than re-reading.
+
+## Per-iteration process
+
+### 5a. Diagnose the discrepancy
+
+Use all four inputs together to identify specific differences:
+
+1. **Step 4a instance-usage check result** — if it failed, address it FIRST. Missing instances break design-system coupling and Code Connect; no amount of pixel tweaking fixes them.
+2. **Step 4b sizing check result** — if it failed, address sizing next. A too-small master will mask everything else and will re-fail validation later.
+3. **Read `diff.png`** — red regions show exactly where pixels differ
+4. **Read `app.png`** — what the component should look like
+5. **Read `figma.png`** — what was actually built
+6. **Read source `.tsx`** — Tailwind classes reveal intended values (colors, spacing, radii, font weights)
+
+Cross-reference to identify the exact Figma properties that need correction. Common discrepancy patterns:
+
+| Symptom                                                              | Likely Cause                                                                                                                                                         | Fix                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| -------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Step 4a instance check failed** (`missing_instances`)              | Source imports `X` from the design system, but the build rendered `X` as text nodes or local frames. Rest-state visual may look identical but is structurally wrong. | For each name in `missingInstances`: locate the local subtree in the build that stands in for it, delete it, and replace with `figma.getNodeById(builtComponents[name]).createInstance()`. For component sets, choose the matching variant via `instance.setProperties({ ... })`. To override text inside an instance, `instance.findOne(n => n.type === 'TEXT')` then `await figma.loadFontAsync(text.fontName)` then `text.characters = '...'`. After replacing, re-run the 4a enumeration query and `check-instances.js`. |
+| **Step 4b sizing check failed** (master too small for `fill` intent) | Master built with `*SizingMode='AUTO'`, hugged content, app.png was cropped narrow                                                                                   | Set sizing modes FIRST, then resize: `node.primaryAxisSizingMode='FIXED'; node.counterAxisSizingMode='FIXED'; node.resizeWithoutConstraints(W, H)`. Set fill children to `layoutSizingHorizontal='FILL'` / `layoutSizingVertical='FILL'`. Order matters — sizing modes before `resize()`, otherwise the resize collapses back to AUTO.                                                                                                                                                                                       |
+| **Step 4b sizing check failed** (fixed dimension off by > 2px)       | Wrong literal width/height from Tailwind class                                                                                                                       | `node.resizeWithoutConstraints(intendedW, intendedH)`                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| Red border ring around component                                     | Wrong border color, extra stroke, missing stroke                                                                                                                     | Adjust `strokes`, `strokeWeight`, `strokeAlign`                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| Red fill region                                                      | Wrong background color                                                                                                                                               | Adjust `fills` color values                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| Red text area                                                        | Wrong font size/weight, wrong text color, wrong text content                                                                                                         | Adjust font properties, text fills                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| Shifted content                                                      | Wrong padding or spacing                                                                                                                                             | Adjust `itemSpacing`, padding values                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| Missing element                                                      | Child not created or wrong visibility                                                                                                                                | Add missing child element                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| Extra element                                                        | Decorative element not in source                                                                                                                                     | Remove unexpected child                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Size mismatch (from pixel diff, not 4a)                              | Wrong resize values or sizing mode                                                                                                                                   | Adjust `resize()` or `layoutSizingMode`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Components all thin strips                                           | `fixSizing()` not applied, or `counterAxisSizingMode = 'FIXED'`                                                                                                      | Run `fixSizing()` on the component                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+
+### 5b. Apply the fix via `use_figma`
+
+Write a targeted fix — change only the properties identified in diagnosis:
+
+```javascript
+// use_figma — fix specific property
+const node = figma.getNodeById('{nodeId}');
+// Example: fix border radius
+node.cornerRadius = 8; // was 4, should be rounded-lg (8px)
+// Example: fix fill color
+node.fills = [{ type: 'SOLID', color: { r: 0.141, g: 0.31, b: 0.722 } }];
+fixSizing(node);
+return 'fixed';
+```
+
+### 5c. Re-enumerate, re-screenshot, re-compare
+
+The Figma node tree has changed, so the `.figma/figma.json` written by Step 2f is now stale. Re-run the Step 2f enumeration + write before re-checking — otherwise Step 4a will compare against the previous build's instance list and either pass a still-broken build or fail one that's already fixed.
+
+1. **Re-enumerate** — run the Step 2f `findAll(INSTANCE)` query against the (possibly-mutated) root node and re-write `<sourceDir>/.figma/figma.json`. Preserve `createdAt` from the prior file; refresh `updatedAt`. Recompute the dependencies list from scratch.
+2. **Re-run the Step 4a gate** if the previous iteration's failure was `missing_instances`:
+   ```bash
+   node ${CLAUDE_SKILL_DIR}/7-build-component/check-instances.js <componentName> <sourceDir>
+   ```
+   If it still rejects, diagnose the next missing entry and loop back to 5b. Do not proceed to pixel re-compare until 4a passes.
+3. **Re-screenshot** — only after Step 4a passes:
+   ```
+   get_screenshot(fileKey, screenshotNodeId)
+   ```
+   Save to `{screenshotDir}/figma.png` (overwrite previous).
+4. **Re-compare pixels:**
+   ```bash
+   node ${CLAUDE_SKILL_DIR}/10-validator/compare.js \
+     "{screenshotDir}/app.png" \
+     "{screenshotDir}/figma.png" \
+     "{screenshotDir}/"
+   ```
+
+### 5d. Evaluate and continue or stop
+
+Track `matchPct` (and `borderMatchPct`) across iterations so you can tell whether the fixes are actually helping — an iteration that doesn't move the numbers is wasted.
+
+- If verdict is now `match` → exit loop, report as fixed.
+- **No-improvement bail.** If this iteration's `matchPct` did not improve over the previous iteration by at least **1 percentage point** (and `borderMatchPct` likewise stalled), STOP. Do not spend another iteration. Report `status: "partial_match"` with the best verdict reached. Re-applying near-identical fixes that don't move the score is a strong signal the remaining diff is not addressable from the build side.
+- **Invalid / unreachable-reference bail.** If diagnosis shows the comparison baseline is not a valid target for this component, STOP immediately rather than iterating against it:
+  - `app.png` captured the wrong element (a stray avatar, a sibling, an empty slot) — report `no_app_reference` with the reason.
+  - the component only renders inside an interaction you cannot reproduce here — report `no_app_reference`.
+  - the residual is the documented system-ui→Inter **font-proxy drift** (`fontCheck.matches` is true; see Step 4c) — report `partial_match` with `residual: "font-proxy"`. The text will never pixel-match because Inter is a deliberate proxy for the OS system font; further iterations cannot fix it.
+  Record the reason so the validation phase can re-check it instead of re-fixing it.
+- If the verdict improved **meaningfully** (≥ 1 pt) but is still `minor_diff` or `mismatch`, and iteration count < 3 → continue to next iteration.
+- If iteration count reaches 3 → exit loop, report remaining issues.
+
+## Structural audit (run before first comparison if issues suspected)
+
+```javascript
+// use_figma
+function auditNode(node) {
+  const issues = [];
+  if ('strokeAlign' in node && node.strokeAlign === 'INSIDE' && node.strokes?.length > 0) {
+    issues.push({ type: 'inside_stroke', node: node.id, name: node.name });
+  }
+  if ('fills' in node && node.fills.filter((f) => f.visible !== false).length > 1) {
+    issues.push({ type: 'multiple_fills', node: node.id, count: node.fills.length });
+  }
+  if ('children' in node) node.children.forEach((c) => issues.push(...auditNode(c)));
+  return issues;
+}
+const node = figma.getNodeById('{nodeId}');
+return JSON.stringify(auditNode(node));
+```
+
+Fix structural issues before screenshotting — `strokeAlign: 'INSIDE'` causes double-border visuals, multiple fills cause color blending.

--- a/plugins/figma-from-code/skills/figma-from-code/7-build-component/step-6-track.md
+++ b/plugins/figma-from-code/skills/figma-from-code/7-build-component/step-6-track.md
@@ -1,0 +1,29 @@
+# Step 6: Finalize Tracking Files
+
+By the time Step 6 runs, both `.figma/*.json` tracking files have already been written by earlier steps:
+
+- **`.figma/code.json`** — written incrementally by **Step 1** (sub-steps 0 through 1g). Source-derived. Contains `childComponents` (the contract enforced by Step 4a) and the full Step 1 analysis snapshot (layout, variants, icons, text, computed styles, git commit). Always overwritten fresh on each build.
+- **`.figma/figma.json`** — written by **Step 2f** at the end of build, and re-written by **Step 5c** after each fix iteration. Built-derived: `dependencies` is enumerated live from the Figma node tree via `findAll(n => n.type === 'INSTANCE')`, not from Step 1's source analysis. Preserves `createdAt` across runs; refreshes `updatedAt` on every write.
+
+Step 6 is a small finalizer — not a writer:
+
+1. **Verify both files exist** at `<sourceDir>/.figma/`. If either is missing, the earlier step that owns it (Step 1 for `code.json`, 2f for `figma.json`) is broken; surface this in the Step 7 result with `trackingFile: { written: false, missing: "code.json" }` and let the orchestrator/user investigate.
+2. **Refresh `updatedAt`** on `figma.json` to the current ISO 8601 UTC timestamp if the last writer didn't already. Preserve `createdAt`. Do not modify any other fields — `dependencies` and `nodeId` are authoritative from Step 2f/5c.
+3. **Sanity-check structural invariants** before returning success:
+   - `code.json.componentName === figma.json.componentName === <componentName>`
+   - `figma.json.fileKey` matches the build's `fileKey`
+   - `figma.json.nodeId` matches the built node (the node Step 7 will report)
+   - `figma.json.dependencies` is a (possibly empty) array
+
+If any invariant fails, return the discrepancy in the result file. Do not try to silently repair — the violation likely indicates a bug in Step 1 or 2f that needs surfacing.
+
+## Folder resolution (shared by Step 1 and 2f)
+
+Both writers use the same path rules; they are documented here for reference.
+
+- `Button` → `<source-dir>/components/Button/.figma/`
+- Nested modlet (e.g. `CustomerInformation` under `CustomerDetails/components/...`) → `<source-dir>/components/CustomerDetails/components/CustomerInformation/.figma/`
+- `Icon/{Name}` → `<source-dir>/components/Icon/{Name}/.figma/` (synthesized — Lucide icons have no local source file)
+- `Asset/{Name}` → `<source-dir>/components/Asset/{Name}/.figma/` (synthesized)
+
+If a legacy `<sourceDir>/figma.json` (root-level, pre-`.figma/` layout) exists, Step 2f should read it to recover `createdAt`, then ignore it on subsequent runs. Do not delete it from Step 6.

--- a/plugins/figma-from-code/skills/figma-from-code/7-build-component/step-7-return.md
+++ b/plugins/figma-from-code/skills/figma-from-code/7-build-component/step-7-return.md
@@ -1,0 +1,39 @@
+# Step 7: Return Result
+
+Return a structured result for the caller:
+
+```json
+{
+  "componentName": "Button",
+  "nodeId": "123:45",
+  "type": "COMPONENT_SET",
+  "variants": [
+    { "name": "Variant=primary, Size=regular", "nodeId": "123:46" },
+    { "name": "Variant=secondary, Size=regular", "nodeId": "123:47" }
+  ],
+  "comparison": {
+    "matchPct": 94.2,
+    "borderMatchPct": 91.0,
+    "verdict": "match",
+    "iterations": 1,
+    "fixes": ["border-radius 4px -> 8px"]
+  },
+  "screenshotNodeId": "123:46",
+  "figmaScreenshot": ".temp/figma-from-code/screenshots/Button/figma.png"
+}
+```
+
+If no app screenshot was available:
+
+```json
+{
+  "componentName": "Skeleton",
+  "nodeId": "200:10",
+  "type": "COMPONENT",
+  "comparison": {
+    "verdict": "no_app_reference",
+    "matchPct": null,
+    "iterations": 0
+  }
+}
+```

--- a/plugins/figma-from-code/skills/figma-from-code/8-build-screens/SKILL.md
+++ b/plugins/figma-from-code/skills/figma-from-code/8-build-screens/SKILL.md
@@ -1,0 +1,730 @@
+# Skill: Build Screens (Phase 4)
+
+Builds full-page screen frames in Figma by composing built component instances into 1440x900 layouts. Each screen assembles navigation, list panels, and detail/form panels using instances of components already created in Phase 3, then validates them visually against an app screenshot — iterating up to 3 fix passes to converge on visual fidelity.
+
+> **All Figma MCP tools (`use_figma`, `get_screenshot`, etc.) are available.** This skill runs its entire workflow — analyze, build, screenshot, compare, fix — inline when dispatched by the orchestrator.
+
+## When to Use
+
+- When `figma-from-code` reaches Phase 4
+- Standalone to rebuild screen layouts after component changes
+- To add new screens after adding pages to the app
+
+## Required Inputs
+
+| Input                | Description                                                                                    | Source                                                       |
+| -------------------- | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `screenName`         | PascalCase name (e.g., `ExamplePage`, `ExampleFormPage`)                                          | Route → PascalCase conversion                                |
+| `route`              | URL path on the dev server (e.g., `/example`, `/example/new`)                                      | `component-map.json → routes`                                |
+| `pageSourceFile`     | Path to the page's `.tsx` source                                                               | Component source discovery                                   |
+| `fileKey`            | Figma file key                                                                                 | State ledger or caller                                       |
+| `screensFrameId`     | Node ID of the Screens container to append into                                                | `state.json → figmaNodes`                                    |
+| `appScreenshot`      | Path to the app screenshot PNG                                                                 | `.temp/figma-from-code/screenshots/screens/{name}/app.png`   |
+| `textContent`        | Extracted text JSON from the live page                                                         | `.temp/figma-from-code/screenshots/screens/{name}/text.json` |
+| `keyComponents`      | Top-level components rendered on the route + their descendants                                 | `component-map.json → tree`                                  |
+| `builtComponents`    | Map of `{componentName: nodeId}` for all components built in Phase 3                           | `state.json → builtComponents`                               |
+| `preExistingScreens` | Immutable snapshot of screen frames that existed in Figma BEFORE this orchestrator run started | `state.json → preExistingScreens` (Phase 0a snapshot)        |
+| `screenshotDir`      | Directory for saving Figma screenshots and diff artifacts                                      | `.temp/figma-from-code/screenshots/screens/{name}/`          |
+
+### Optional Inputs
+
+| Input            | Description                                                                                                                                                                                                                   |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `computedStyles` | Resolved CSS values from `computed-styles.json` (produced by `inspect-styles.js` against the page root). Authoritative for colors, spacing, typography on screen chrome (the page's own elements, not its component children) |
+| `screenBodySize` | Body dimensions read from `state.json → screenBodySize` if the project uses a non-default screen size (default 1440x900)                                                                                                      |
+
+---
+
+## Pre-Existing Screens Rule
+
+Before doing any work that resolves to a node ID in `preExistingScreens`, **stop**. That node existed in Figma before this run; modifying it (rebuild, resize, delete + recreate, restructure) requires explicit user authorization.
+
+Concretely:
+
+- If `screenName` itself maps to a node in `preExistingScreens` and the caller's intent is to **rebuild** that node: write a result file with `"status": "needs_authorization"` and `"preExistingTouched": ["<name>"]`, then return. Do not call `use_figma` to delete, replace, resize, or restyle the existing node. Building a _fresh_ screen with the same name into the same `screensFrameId` is also a modification (creates a duplicate the orchestrator must reconcile) — don't do it without authorization.
+- Instancing a component that is itself in `preExistingComponents` is fine — that's reuse, not modification.
+- The fix-loop in Step 5 must never edit a node in `preExistingScreens`. If the comparison says you need to, escalate to the orchestrator instead.
+
+This rule overrides Steps 2–5 of the workflow when in conflict.
+
+---
+
+## Execution Mode
+
+The orchestrator dispatches one subagent per screen. Each subagent runs the **entire workflow** (Steps 1–7) independently — analyze, build via `use_figma`, screenshot via `get_screenshot`, compare, fix loop, and return results.
+
+The subagent writes its result to `.temp/figma-from-code/build-results/screens/{screenName}.json`. The orchestrator collects results after all subagents complete using `collect-screen-results.js`.
+
+Screens can run in parallel — they only instantiate (not modify) already-built Phase 3 components.
+
+### Agent Prompt Template
+
+The orchestrator dispatches one agent per screen. Send all agents in a **single message** so they run in parallel.
+
+```
+Build a Figma screen frame by composing built component instances, then validate visually.
+
+Follow the figma-from-code-build-screens skill (all 7 steps):
+0. Verify all referenced components exist in builtComponents
+1. FIRST study the app screenshot to understand what the default view shows,
+   THEN analyze the page source — only include components visible in the screenshot.
+   Exclude components behind conditional branches (ternaries, state guards, URL params)
+   and portal-rendered overlays (Dialog, Sheet, etc.) that aren't visible by default.
+2. Build the screen in Figma via use_figma (1440x900 fixed frame)
+3. Screenshot the result via get_screenshot
+4. Structural check (content must match), then sizing check, then pixel diff
+5. If mismatch, diagnose and fix (up to 3 iterations)
+6. Write figma-screen.json tracking file
+7. Write results to .temp/figma-from-code/build-results/screens/{screenName}.json
+
+Inputs:
+- Screen name: {screenName}
+- Route: {route}
+- Page source file: {pageSourceFile}
+- Figma file key: {fileKey}
+- Screens frame node ID: {screensFrameId}
+- App screenshot: .temp/figma-from-code/screenshots/screens/{screenName}/app.png
+- Text content: .temp/figma-from-code/screenshots/screens/{screenName}/text.json
+- Screenshot dir: .temp/figma-from-code/screenshots/screens/{screenName}/
+- Built components (for instance reuse): .temp/figma-from-code/builtComponents.json
+- Pre-existing screens (DO NOT MODIFY): {JSON.stringify(preExistingScreens)}
+
+Read the figma-from-code-build-screens skill for the full workflow,
+fixSizing() function, variant resolution, and common pitfalls.
+```
+
+---
+
+## Workflow
+
+```
+Step 0    Prereqs       Verify all referenced components exist in builtComponents
+Step 1    Analyze       Study appScreenshot first, then read page source; filter out non-default conditional branches
+Step 2    Build         Create the screen frame in Figma via use_figma
+Step 3    Screenshot    Capture the Figma result via get_screenshot
+Step 4    Compare       Structural check + sizing sanity check + pixel diff against the app screenshot
+Step 5    Fix Loop      If mismatch, diagnose and fix (up to 3 iterations)
+Step 6    Track         Write figma-screen.json into the page folder
+Step 7    Return        Report result with node ID, match score, and any remaining issues
+```
+
+---
+
+## Step 0: Verify all components exist (prerequisite gate)
+
+Before building any screen, verify that **every component** referenced by the screen exists in `builtComponents` from `state.json`.
+
+Identify the screen's key components from `component-map.json → tree` (the top-level components on that route and all their descendants). Check each one against `builtComponents`. Also check every icon imported by the page source (e.g., `Icon/Check`).
+
+If **any** component or icon is missing from `builtComponents`:
+
+**STOP — do not proceed to Step 1.** Return immediately with a rejection result:
+
+```json
+{
+  "screenName": "ExamplePage",
+  "status": "rejected",
+  "reason": "missing_components",
+  "missingComponents": ["CaseDetails", "MenuList"],
+  "missingIcons": ["Icon/Trash"],
+  "availableComponents": ["AppHeader", "Sidebar", "Button"]
+}
+```
+
+Write this to `.temp/figma-from-code/build-results/screens/{screenName}.json` so the orchestrator can see what's missing.
+
+**Standalone (no orchestrator)** — if the caller is the user directly, surface the rejection in the conversation and ask how to proceed. Don't fall back to inlining the missing components, building stubs, or downgrading the build into "best effort" — those produce a different artifact than the skill is supposed to produce. The right options are: (a) build the missing components first via `${CLAUDE_SKILL_DIR}/7-build-component/SKILL.md`, (b) abandon the screen, or (c) get explicit user authorization to deviate.
+
+Only proceed to Step 1 if every required component and icon is confirmed present.
+
+---
+
+## Step 1: Analyze the Screen
+
+Before writing any `use_figma` code, analyze all inputs to plan the screen structure.
+
+> **Pre-flight: dev server is required for Step 1f (live inspection).** Step 1f — inspecting the rendered page in a browser via `inspect-styles.js` — is the authoritative source for colors, spacing, and layout on the page chrome (the elements the page itself renders, outside of component children). **Do not silently skip it.** If you don't already have a dev server URL (from the orchestrator state ledger, project memory, or the caller's arguments), pause and ask the user for one before proceeding past Step 1. Only skip Step 1f if the user explicitly says no dev server is available.
+
+### 1-pre. Screenshot-first composition (MANDATORY)
+
+**Before reading source code, look at `appScreenshot` (app.png).** This screenshot shows the ACTUAL default view of the page as rendered in the browser with no user interaction. It is the **ground truth** for what the screen should look like.
+
+Study the screenshot and identify:
+
+- Which regions are visible (sidebar, main content area, detail panels, headers, footers)
+- Whether the main content area shows populated data or an empty/placeholder state (e.g., "No case selected", "Select an item")
+- Which component instances are actually rendered vs hidden by conditional logic
+- Whether any overlays, dialogs, or menus are open (they should not be in the default state)
+
+**The source code analysis in Steps 1a–1b must MATCH what the screenshot shows, not the full component tree from the JSX.** If the source code contains components behind conditional branches that are not visible in the screenshot, those components must be excluded from composition.
+
+### 1a. Identify the page composition
+
+Read the page source file and determine:
+
+- **Layout direction**: Is the page root a vertical stack (`flex-col`), horizontal row (`flex`, `flex-row`), or a grid (`grid`)?
+- **Sizing**: Screens are **always fixed 1440x900** (or `screenBodySize` if overridden). The outermost screen frame is `primaryAxisSizingMode='FIXED'` and `counterAxisSizingMode='FIXED'`. Capture this explicitly — Step 4a verifies it.
+- **Container children**: What is the top-level region structure? Typical pages have: top nav (full width), sidebar (fixed width), main content (fill), or a hero + sections stack. Identify each region and which built component instance lives there.
+- **Spacing**: `gap-*` classes on the page root map to `itemSpacing`. `p-*`, `px-*`, `py-*` map to padding.
+- **Background**: `bg-*` class on the page root. Resolve through CSS variables if needed (see Step 1g of `${CLAUDE_SKILL_DIR}/7-build-component/SKILL.md` for the full chain).
+
+### 1b. Identify component instances (default state only)
+
+Walk the page source JSX and list component references, but **only include components visible in the default state** (as shown in `appScreenshot` from Step 1-pre).
+
+For each included component:
+
+- Map it to `builtComponents[name]` — that's the node ID to instantiate
+- Note the variant props passed in code (e.g., `<Button variant="primary" size="lg">`) — these resolve to a specific variant inside the component set
+- Note any sizing classes applied at the call site (`className="w-full"`, `className="flex-1"`) — these translate to `layoutSizingHorizontal='FILL'` etc. on the instance
+
+```tsx
+// Source has: <Sidebar className="w-64" />
+// builtComponents has: { "Sidebar": "230:5" }
+// → Instantiate Sidebar at fixed width 256 inside the page frame
+```
+
+#### Conditional rendering analysis
+
+When walking the JSX, identify and handle conditional patterns:
+
+1. **Ternary expressions** (`condition ? <A /> : <B />`): Determine which branch is visible when the page first loads with no user interaction and no URL params beyond the base route. Cross-reference with `appScreenshot` — only include the branch that matches.
+
+   ```tsx
+   // Example: {id ? <CaseDetails /> : <EmptyState />}
+   // If appScreenshot shows "No case selected" → include EmptyState, EXCLUDE CaseDetails
+   ```
+
+2. **URL-param-gated components**: For components guarded by `useParams()` values (e.g., `id ? <Detail /> : <Fallback />`), use the param-absent branch as default since the screen captures the base route.
+
+3. **State-hook-gated components**: Components behind `useState(false)` or `useState(null)` guards are hidden by default — exclude them.
+
+   ```tsx
+   // Example: const [isOpen, setIsOpen] = useState(false);
+   // {isOpen && <Modal />}  → EXCLUDE Modal from default screen
+   ```
+
+4. **Logical AND guards** (`{flag && <C />}`): Exclude unless the guard's initial value is truthy.
+
+**DO NOT** compose components from non-default conditional branches. Those belong in separate screen variants if the pipeline supports them.
+
+#### Portal-rendered overlay exclusion
+
+Portal-rendered overlays — Dialog, Sheet, ConfirmationDialog, DropdownMenu, Popover, Drawer, AlertDialog, Tooltip, etc. — are **NEVER** visible in the default resting state. Exclude them from screen composition unless the `appScreenshot` explicitly shows them open.
+
+These components are already handled by the component-level State axis in Phase 3 (see `7-build-component/step-1-analyze.md` → "Conditional rendering of overlays"). Do not duplicate them in the screen frame.
+
+### 1c. Identify icon usage on the page chrome
+
+If the page renders any Lucide icons directly (not via a child component), map each to its `builtComponents` entry (`Icon/{Name}`) and size from the className. See Step 1c of `${CLAUDE_SKILL_DIR}/7-build-component/SKILL.md` for the size mapping table.
+
+### 1d. Plan text content
+
+Use `textContent` (from `text.json`) for any text the page itself renders (page titles, section headings, empty states). Never use generic placeholders. Text rendered _inside_ a component instance is handled by that component's own master — don't try to override it from the screen.
+
+### 1e. Identify pre-existing screen conflicts
+
+Check whether `screenName` is in `preExistingScreens`. If yes — apply the **Pre-Existing Screens Rule** above and stop.
+
+### 1f. Inspect the live page in Playwright
+
+Before building, inspect the actual rendered page in the browser to capture computed styles on the page chrome. This provides ground-truth values for the page-level background, padding, and layout — more reliable than inferring from Tailwind classes alone.
+
+Run `inspect-styles.js` against the page root selector on the dev server:
+
+```bash
+node ${CLAUDE_SKILL_DIR}/10-validator/inspect-styles.js \
+  "<dev-server-url>/{route}" \
+  --selector "[data-page='{ScreenName}'], main, #root > div" \
+  --output ".temp/figma-from-code/screenshots/screens/{ScreenName}/"
+```
+
+This produces:
+
+| File                   | Contents                                                                                                                                                            |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `computed-styles.json` | Resolved CSS properties on the page root (background, padding, layout direction, gap), the element's class list, and `layoutContext` (viewport, offsetWidth/Height) |
+
+**How to use the outputs:**
+
+Use resolved color values (RGB) directly instead of tracing Tailwind → CSS variable → HSL → RGB. Use exact `padding` and `gap` values to set Figma properties. These are the authoritative values for the page chrome.
+
+**Dev server is required — don't silently skip this step.**
+
+See Step 1g of `${CLAUDE_SKILL_DIR}/7-build-component/SKILL.md` for the full decision tree: orchestrator-dispatched vs standalone vs auto/non-interactive, how to derive selectors, and when escalation to the user is required.
+
+---
+
+## Step 2: Build the Screen in Figma
+
+### 2a. Create the screen frame
+
+```javascript
+// use_figma
+const screensFrame = figma.getNodeById('{screensFrameId}');
+screensFrame.layoutWrap = 'WRAP';
+screensFrame.counterAxisSpacing = 80;
+
+const screen = figma.createFrame();
+screen.name = '{screenName}';
+screen.resize(1440, 900); // or screenBodySize values
+screen.layoutMode = '{VERTICAL or HORIZONTAL}'; // from page root direction
+screen.primaryAxisSizingMode = 'FIXED';
+screen.counterAxisSizingMode = 'FIXED';
+screen.itemSpacing = { gapValue };
+screen.paddingTop = { pt };
+screen.paddingBottom = { pb };
+screen.paddingLeft = { pl };
+screen.paddingRight = { pr };
+screen.fills = [{ type: 'SOLID', color: { ...pageBackground } }];
+screen.clipsContent = true;
+
+// ... add region frames and component instances (Step 2b) ...
+
+screensFrame.appendChild(screen); // do NOT set x/y — wrap layout positions it
+return JSON.stringify({ name: screen.name, id: screen.id });
+```
+
+### 2b. Add component instances
+
+For each component identified in Step 1b:
+
+```javascript
+const comp = figma.getNodeById(builtComponents['{ComponentName}']);
+
+// If component is a COMPONENT_SET, resolve the target variant
+let master = comp;
+if (comp.type === 'COMPONENT_SET') {
+  const targetProps = { Variant: 'primary', Size: 'regular' }; // from source props
+  master =
+    comp.children.find((child) =>
+      Object.entries(targetProps).every(
+        ([k, v]) => child.variantProperties?.[k]?.toLowerCase() === v.toLowerCase()
+      )
+    ) ?? comp.children[0];
+}
+
+const instance = master.createInstance();
+// Apply call-site sizing classes
+if (callSiteHasWFull) instance.layoutSizingHorizontal = 'FILL';
+if (callSiteHasFlex1) instance.layoutSizingHorizontal = 'FILL';
+if (callSiteHasHFull) instance.layoutSizingVertical = 'FILL';
+parent.appendChild(instance);
+```
+
+### 2c. Add region frames for nested layout
+
+When the page source nests multiple components inside a layout container (e.g., a sidebar + main content row), create a region frame:
+
+```javascript
+const row = figma.createFrame();
+row.layoutMode = 'HORIZONTAL';
+row.primaryAxisSizingMode = 'FIXED';
+row.counterAxisSizingMode = 'FIXED';
+row.layoutSizingHorizontal = 'FILL';
+row.layoutSizingVertical = 'FILL';
+row.itemSpacing = 0;
+row.fills = [];
+// ... append child instances ...
+screen.appendChild(row);
+```
+
+### 2d. Tailwind-to-Figma mapping
+
+Use the same mapping table as `${CLAUDE_SKILL_DIR}/7-build-component/SKILL.md` Section 2d. Key entries for screen composition:
+
+| Tailwind                  | Figma Property           | Value          |
+| ------------------------- | ------------------------ | -------------- |
+| `flex-col`                | `layoutMode`             | `'VERTICAL'`   |
+| `flex` / `flex-row`       | `layoutMode`             | `'HORIZONTAL'` |
+| `gap-{n}`                 | `itemSpacing`            | `n * 4` (px)   |
+| `p-{n}`                   | all paddings             | `n * 4`        |
+| `w-full` / `flex-1`       | `layoutSizingHorizontal` | `'FILL'`       |
+| `h-full` / `min-h-screen` | `layoutSizingVertical`   | `'FILL'`       |
+| `w-64` (sidebar widths)   | `resize(W, ...)` + FIXED | explicit width |
+
+### 2e. Resolving page background colors
+
+When the page root uses semantic colors (`bg-background`, `bg-muted`), resolve through `tailwind.config.js` → CSS variable → HSL/OKLCH → Figma RGB. Prefer the resolved RGB from `computed-styles.json` (Step 1f) over re-tracing the chain.
+
+---
+
+## Step 3: Screenshot the Figma Result
+
+```
+get_screenshot(fileKey, screenFrameId)
+```
+
+Save to `{screenshotDir}/figma.png`:
+
+```bash
+curl -sL "{image_url}" -o "{screenshotDir}/figma.png"
+```
+
+---
+
+## Step 4: Compare Against App Screenshot
+
+### 4-pre. Structural match check (run BEFORE sizing or pixel checks)
+
+Before running any automated comparison, **visually inspect both `app.png` and `figma.png`** side by side. Check whether the two images show the same content structure:
+
+- Do both show the same regions filled with the same type of content (list, detail, empty state)?
+- Does one show an empty state ("No case selected") while the other shows a populated detail view?
+- Are there overlays, dialogs, or menus visible in the Figma screenshot that don't appear in the app screenshot?
+- Are there entire sections present in one but missing in the other?
+
+If the two images show **fundamentally different content** — not just styling differences, but different components or states entirely — flag as `structural_mismatch`. This indicates the composition in Step 1b included wrong conditional branches and the screen must be rebuilt, not patched.
+
+A `structural_mismatch` **overrides any pixel score**. Do not accept a high match percentage as valid when the content is visibly different — structural similarity in shared chrome (headers, sidebars) can inflate pixel scores even when the main content area is completely wrong.
+
+```json
+"comparison": {
+  "structuralCheck": {
+    "verdict": "pass" | "structural_mismatch",
+    "issues": ["Figma shows case detail view but app shows empty state 'No case selected'"]
+  }
+}
+```
+
+If `structural_mismatch`: enter Step 5 fix loop, but the fix is to **re-run Step 1b** with stricter screenshot-informed filtering, not to patch colors or spacing.
+
+### 4a. Sizing sanity check (run BEFORE the pixel compare)
+
+A pixel diff against `app.png` can pass even when the screen is built much smaller than 1440x900 — most commonly when the outermost frame collapsed to hug content. Run this check first; it is independent of the screenshot.
+
+Inspect the built screen (`use_figma`) and read its top-level frame:
+
+```javascript
+const node = figma.getNodeById('{screenNodeId}');
+const built = {
+  w: Math.round(node.width),
+  h: Math.round(node.height),
+  primaryAxisSizingMode: node.primaryAxisSizingMode,
+  counterAxisSizingMode: node.counterAxisSizingMode,
+  layoutMode: node.layoutMode,
+};
+```
+
+Compare against the expected screen body size (default 1440x900, or `screenBodySize` from state):
+
+| Check                  | Pass criteria                                                                                   | Flag if …                             |
+| ---------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------- |
+| Width                  | `built.w === expectedW ± 2px`                                                                   | Off by more than 2px                  |
+| Height                 | `built.h === expectedH ± 2px`                                                                   | Off by more than 2px                  |
+| Sizing modes           | `primaryAxisSizingMode === 'FIXED'` AND `counterAxisSizingMode === 'FIXED'`                     | Either is `'AUTO'`                    |
+| Layout mode            | Set (`'VERTICAL'` or `'HORIZONTAL'`)                                                            | `'NONE'` — children won't auto-layout |
+| Top-level region count | Matches the page source structure (e.g., 2 for nav + body, 3 for header + sidebar row + footer) | Region count differs from source      |
+| Fill children          | Any child whose call-site has `flex-1` / `w-full` has `layoutSizingHorizontal='FILL'`           | Source says fill, built says hug      |
+
+If any check fails, **treat this as a `size_mismatch` discrepancy and feed it into Step 5 alongside (or before) the pixel diff results.** Do not declare a match based on pixel score alone if the sizing check failed — pixel match against a too-small `app.png` is a false positive.
+
+Record the sizing check result in the eventual result file:
+
+```json
+"comparison": {
+  "sizingCheck": {
+    "verdict": "pass" | "fail",
+    "issues": ["counterAxisSizingMode='AUTO' (expected FIXED)", "built height 412 (expected 900)"],
+    "builtSize": {"w": 1440, "h": 412},
+    "expectedSize": {"w": 1440, "h": 900}
+  },
+  "matchPct": 95.26,
+  ...
+}
+```
+
+### 4b. Pixel diff comparison
+
+Run the pixel diff comparison:
+
+```bash
+node ${CLAUDE_SKILL_DIR}/10-validator/compare.js \
+  "{screenshotDir}/app.png" \
+  "{screenshotDir}/figma.png" \
+  "{screenshotDir}/"
+```
+
+This produces:
+
+- `diff.png` — red pixels mark differences, matching pixels dimmed
+- `comparison.json` — `{ matchPct, borderMatchPct, verdict, borderVerdict }`
+
+**Verdict thresholds (combined with Step 4a result):**
+
+- 4a passed AND `matchPct >= 88%` AND `borderMatchPct >= 80%` → **match** (done)
+- 4a failed (regardless of pixel score) → **size_mismatch** (needs fixing — fix sizing first, then re-screenshot, then re-run 4a + 4b)
+- 4a passed AND `matchPct 72-88%` or `borderMatchPct < 80%` → **minor_diff** (needs fixing)
+- 4a passed AND `matchPct < 72%` → **mismatch** (needs fixing)
+
+Screen thresholds are slightly more lenient than component thresholds because screens contain many instances whose internal pixels are already validated at the component level — a small per-instance drift compounds across the page.
+
+A passing pixel verdict alone is NOT enough — 4a must also pass. Otherwise the build is silently wrong-sized and the validation phase will reject it later.
+
+If no app screenshot exists (`appScreenshot` is null), skip pixel comparison — but still run Step 4a. Report `no_app_reference` only if 4a also passes; otherwise report `size_mismatch`.
+
+---
+
+## Step 5: Fix Loop (Up to 3 Iterations)
+
+If the verdict is `minor_diff`, `mismatch`, or `size_mismatch`, enter the fix loop.
+
+### Per-iteration process
+
+**5a. Diagnose the discrepancy**
+
+Use all five inputs together to identify specific differences:
+
+1. **Step 4a sizing check result** — if it failed, address sizing FIRST. A wrong-sized screen will mask everything else and will re-fail validation later.
+2. **Read `diff.png`** — red regions show exactly where pixels differ
+3. **Read `app.png`** — what the screen should look like
+4. **Read `figma.png`** — what was actually built
+5. **Read page source `.tsx`** — Tailwind classes reveal intended values
+
+Cross-reference to identify the exact Figma properties that need correction. Common screen-level discrepancy patterns:
+
+| Symptom                                             | Likely Cause                                                           | Fix                                                                                                                                                      |
+| --------------------------------------------------- | ---------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **4a failed** (frame collapsed to hug)              | Outermost frame has `*SizingMode='AUTO'`                               | `node.primaryAxisSizingMode='FIXED'; node.counterAxisSizingMode='FIXED'; node.resizeWithoutConstraints(1440, 900)`. Order matters — modes before resize. |
+| **4a failed** (region didn't fill width)            | Child region missing `layoutSizingHorizontal='FILL'`                   | Set `child.layoutSizingHorizontal='FILL'` (and `Vertical` if appropriate)                                                                                |
+| Sidebar / header in wrong position                  | Layout direction wrong, or x/y manually set inside auto-layout         | Set `screen.layoutMode` correctly; remove any manual x/y assignments                                                                                     |
+| Component instance shows wrong variant              | Targeted the wrong variant during Step 2b                              | `instance.setProperties({ Variant: 'secondary' })` or recreate from correct master                                                                       |
+| Whole page shifted by ~24px                         | Wrong padding on the screen frame                                      | Adjust `paddingTop/Bottom/Left/Right`                                                                                                                    |
+| Background color wrong                              | Wrong fill on the screen frame                                         | Adjust `screen.fills` — prefer `computed-styles.json` resolved RGB                                                                                       |
+| Two components touching where source has gap        | Wrong `itemSpacing` on the parent region                               | Set `region.itemSpacing` to match source `gap-*` class                                                                                                   |
+| Missing region (e.g., footer absent)                | Region frame not created during Step 2c                                | Add the missing region with its children                                                                                                                 |
+| Component appears tiny in the corner                | Instance added before auto-layout was set, or appended to wrong parent | Re-parent the instance; verify `screen.layoutMode` is set before appending children                                                                      |
+| Screen positioned at wrong x/y inside Screens frame | Manual x/y set despite `screensFrame.layoutWrap='WRAP'`                | Remove x/y assignments — let the wrap layout position it                                                                                                 |
+
+**5b. Apply the fix via `use_figma`**
+
+Write a targeted fix — change only the properties identified in diagnosis:
+
+```javascript
+// use_figma — fix specific property
+const node = figma.getNodeById('{nodeId}');
+node.primaryAxisSizingMode = 'FIXED';
+node.counterAxisSizingMode = 'FIXED';
+node.resizeWithoutConstraints(1440, 900);
+fixSizing(node, { exemptRoot: true }); // root stays FIXED, descendants may auto
+return 'fixed';
+```
+
+**5c. Re-screenshot and re-compare**
+
+```
+get_screenshot(fileKey, screenFrameId)
+```
+
+Save to `{screenshotDir}/figma.png` (overwrite previous).
+
+```bash
+node ${CLAUDE_SKILL_DIR}/10-validator/compare.js \
+  "{screenshotDir}/app.png" \
+  "{screenshotDir}/figma.png" \
+  "{screenshotDir}/"
+```
+
+**5d. Evaluate and continue or stop**
+
+- If verdict is now `match` → exit loop, report as fixed
+- If verdict improved but still `minor_diff`, `mismatch`, or `size_mismatch` → continue to next iteration
+- If iteration count reaches 3 → exit loop, report remaining issues
+
+### Structural audit (run before first comparison if issues suspected)
+
+```javascript
+// use_figma
+function auditScreen(node) {
+  const issues = [];
+  if (node.layoutMode === 'NONE') {
+    issues.push({ type: 'no_layout_mode', node: node.id, name: node.name });
+  }
+  if (node.primaryAxisSizingMode === 'AUTO' || node.counterAxisSizingMode === 'AUTO') {
+    issues.push({ type: 'screen_not_fixed', node: node.id });
+  }
+  for (const child of node.children) {
+    if (child.x !== 0 && child.parent?.layoutMode && child.parent.layoutMode !== 'NONE') {
+      issues.push({ type: 'manual_xy_in_autolayout', node: child.id });
+    }
+  }
+  return issues;
+}
+const node = figma.getNodeById('{screenNodeId}');
+return JSON.stringify(auditScreen(node));
+```
+
+Fix structural issues before screenshotting — manual x/y inside an auto-layout parent causes silent layout drift, and missing `layoutMode` collapses all children to (0,0).
+
+---
+
+## Step 6: Write figma-screen.json tracking file
+
+Write a tracking record to the page's source folder so the codebase has a durable link back to the Figma screen node.
+
+**Path:** Resolve from `pageSourceFile`. If the page is `<source-dir>/pages/ExamplePage.tsx`, write to `<source-dir>/pages/ExamplePage.figma-screen.json`. If pages live in a folder (`<source-dir>/pages/ExamplePage/index.tsx`), write to `<source-dir>/pages/ExamplePage/figma-screen.json`.
+
+**Schema:**
+
+```json
+{
+  "fileKey": "{figmaFileKey}",
+  "nodeId": "{screenFrameId}",
+  "url": "https://figma.com/design/{fileKey}?node-id={nodeIdWithDashes}",
+  "screenName": "ExamplePage",
+  "route": "/example",
+  "createdAt": "2026-05-15T14:32:00Z",
+  "updatedAt": "2026-05-15T14:32:00Z"
+}
+```
+
+**Read-then-write semantics:**
+
+1. If `figma-screen.json` already exists at the target path: parse it, preserve the existing `createdAt`, and refresh `nodeId`, `url`, `updatedAt` (and `screenName`/`route` if they changed) with current values.
+2. If it does not exist: write a fresh file with `createdAt` and `updatedAt` both set to the current ISO 8601 UTC timestamp.
+
+**Failure handling:** if the write fails (permission, missing parent path that can't be created), log the failure and continue — do not fail the build. Surface the failure in the Step 7 return result under a `trackingFile` field with `{ written: false, error: "..." }` so the orchestrator can report it.
+
+---
+
+## Step 7: Return Result
+
+Return a structured result for the caller:
+
+```json
+{
+  "screenName": "ExamplePage",
+  "nodeId": "600:1",
+  "route": "/example",
+  "comparison": {
+    "matchPct": 92.4,
+    "borderMatchPct": 86.0,
+    "verdict": "match",
+    "iterations": 1,
+    "fixes": ["counterAxisSizingMode AUTO -> FIXED, resize to 1440x900"],
+    "sizingCheck": {
+      "verdict": "pass",
+      "builtSize": { "w": 1440, "h": 900 },
+      "expectedSize": { "w": 1440, "h": 900 }
+    }
+  },
+  "figmaScreenshot": ".temp/figma-from-code/screenshots/screens/ExamplePage/figma.png",
+  "trackingFile": {
+    "written": true,
+    "path": "<source-dir>/pages/ExamplePage.figma-screen.json"
+  }
+}
+```
+
+If no app screenshot was available:
+
+```json
+{
+  "screenName": "EmptyStatePage",
+  "nodeId": "600:9",
+  "route": "/empty",
+  "comparison": {
+    "verdict": "no_app_reference",
+    "matchPct": null,
+    "iterations": 0,
+    "sizingCheck": {
+      "verdict": "pass",
+      "builtSize": { "w": 1440, "h": 900 },
+      "expectedSize": { "w": 1440, "h": 900 }
+    }
+  }
+}
+```
+
+If rejected for missing components:
+
+```json
+{
+  "screenName": "ExamplePage",
+  "status": "rejected",
+  "reason": "missing_components",
+  "missingComponents": ["CaseDetails"]
+}
+```
+
+### Aggregate output
+
+Across all screens, write `.temp/figma-from-code/build-screens.json`:
+
+```json
+{
+  "screens": [
+    {
+      "name": "ExamplePage",
+      "nodeId": "600:1",
+      "verdict": "match",
+      "matchPct": 92.4,
+      "iterations": 1
+    }
+  ],
+  "failed": [],
+  "rejected": []
+}
+```
+
+---
+
+## fixSizing() — for descendants, not the screen root
+
+The screen frame itself must stay `FIXED` on both axes (1440x900). But descendant frames may need `fixSizing()` to release height locks introduced by `resize()` calls. Use the same helper as the component skill, but exempt the root:
+
+```javascript
+function fixSizing(node, { exemptRoot = false } = {}, depth = 0) {
+  if (depth > 10 || !node) return;
+  const hasLayout =
+    (node.type === 'COMPONENT' || node.type === 'FRAME' || node.type === 'COMPONENT_SET') &&
+    node.layoutMode &&
+    node.layoutMode !== 'NONE';
+  if (hasLayout && !(exemptRoot && depth === 0)) {
+    if (node.layoutMode === 'VERTICAL') node.primaryAxisSizingMode = 'AUTO';
+    node.counterAxisSizingMode = 'AUTO';
+  }
+  const children = 'children' in node ? node.children : [];
+  for (const child of children) fixSizing(child, { exemptRoot }, depth + 1);
+}
+```
+
+Call `fixSizing(screen, { exemptRoot: true })` after composition — the root stays at FIXED 1440x900 while descendants are released to grow with content.
+
+---
+
+## Common Pitfalls
+
+| Pitfall                                                 | Prevention                                                                                         |
+| ------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| Screen frame collapses to hug content                   | Set `primaryAxisSizingMode='FIXED'` and `counterAxisSizingMode='FIXED'` BEFORE `resize(1440, 900)` |
+| Children stacked at (0,0)                               | `screen.layoutMode` not set — children need an auto-layout parent to position                      |
+| Screen positioned at hardcoded x/y inside Screens frame | Use `screensFrame.layoutWrap='WRAP'` + `appendChild`; never set x/y                                |
+| Wrong component variant rendered                        | Resolve `COMPONENT_SET` to the specific variant matching source props before `createInstance()`    |
+| Sidebar appears as a thin strip                         | Forgot `layoutSizingVertical='FILL'` on the sidebar instance                                       |
+| Page background missing                                 | Set `screen.fills` to the resolved page-root background, or `[]` if transparent                    |
+| Manual padding inside an auto-layout child              | Use parent `itemSpacing` for gaps, child `padding*` for insets — never manual x offsets            |
+| `fixSizing()` collapsed the screen to hug               | Always pass `{ exemptRoot: true }` when calling `fixSizing` on the screen frame                    |
+| Modifying a pre-existing screen without authorization   | Check `preExistingScreens` in Step 1e before building                                              |
+| Wrong-text inside component instance                    | Don't override component instance text from the screen — the component master owns its text        |
+| Screen shows non-default conditional branch             | Study `appScreenshot` in Step 1-pre; exclude components behind ternaries/guards that aren't visible |
+| Portal overlay (Dialog, Sheet, etc.) visible on screen  | Portals are never visible by default — exclude unless `appScreenshot` explicitly shows them open    |
+| High pixel match but fundamentally different content    | Run Step 4-pre structural check; don't trust pixel score when content structure differs             |
+
+---
+
+## Error Handling
+
+| Scenario                                 | Action                                                                                                                                 |
+| ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Component missing from `builtComponents` | Reject the entire build — return `status: "rejected"` with the missing components list (Step 0)                                        |
+| Icon missing from `builtComponents`      | Reject — return `status: "rejected"` with the missing icon in `missingIcons` (Step 0)                                                  |
+| `use_figma` fails                        | Diagnose error, fix script, retry once. If it fails again, return screen as `failed`                                                   |
+| `use_figma` incremental limit            | Split the build across multiple `use_figma` calls. Create the screen frame and regions first, then append instances in follow-up calls |
+| `get_screenshot` fails                   | Retry once. If still failing, return screen as built but unvalidated                                                                   |
+| `compare.js` fails                       | Report comparison error, return the screen with `nodeId` but no match score                                                            |
+| App screenshot missing                   | Build from source code alone, run Step 4a sizing check, report `no_app_reference` if 4a passes                                         |
+| Pre-existing screen targeted             | Return `status: "needs_authorization"` with `preExistingTouched` — do not modify                                                       |
+| Dev server unavailable for Step 1f       | Ask the user (standalone) or flag `liveInspection: "skipped_no_dev_server"` (auto mode)                                                |
+
+Never fail silently. Every error or skip must appear in the returned result.

--- a/plugins/figma-from-code/skills/figma-from-code/9-validate/SKILL.md
+++ b/plugins/figma-from-code/skills/figma-from-code/9-validate/SKILL.md
@@ -1,0 +1,155 @@
+# Skill: Validate + Fix (Phase 5)
+
+Validates every built Figma component against its app screenshot, runs fix loops on mismatches (built-during-run components only), cleans up misplaced components on the Components page, and produces a structured report. Runs as a subagent dispatched by the orchestrator.
+
+## When to Use
+
+- When `figma-from-code` orchestrator reaches Phase 5
+- Standalone to validate a completed rebuild
+
+## Required Inputs
+
+| Input                   | Description                                      | Source                                  |
+| ----------------------- | ------------------------------------------------ | --------------------------------------- |
+| `fileKey`               | Figma file key                                   | State ledger                            |
+| `builtComponents`       | Map of `{name: nodeId}` for all built components | `state.json -> builtComponents`         |
+| `preExistingComponents` | Immutable snapshot of pre-run components         | `state.json -> preExistingComponents`   |
+| `figmaNodes`            | All page and frame node IDs                      | `state.json -> figmaNodes`              |
+| `buildOrder`            | Tiered component list                            | `state.json -> buildOrder`              |
+| `devServerUrl`          | URL of the running dev server                    | State ledger or `<dev-server-url>` |
+
+## Output Files
+
+| File                                            | Contents                                     | Consumed by       |
+| ----------------------------------------------- | -------------------------------------------- | ----------------- |
+| `.temp/figma-validation/report.md`              | Full validation report with comparison table | User review       |
+| `.temp/figma-from-code/validation-summary.json` | Small summary for the orchestrator           | Orchestrator only |
+
+## Workflow
+
+### 1. Run validation
+
+Read and execute the `${CLAUDE_SKILL_DIR}/10-validator/SKILL.md` workflow inline. This:
+
+- Inventories all Figma components
+- Resolves variant nodes for component sets
+- Captures app + Figma screenshots and runs pixel diffs for each component sequentially (by tier)
+- Runs structural checks (variables, pages, screen sizes)
+- Produces `.temp/figma-validation/report.md`
+
+**Pre-Existing Components gate:** Components in `preExistingComponents` are validated **read-only**. Run screenshot + compare, record the verdict, but DO NOT invoke the fix loop. Surface mismatches in the report for user review.
+
+Components built during this run (in `builtComponents` but not in `preExistingComponents`) follow the full fix loop (up to 3 iterations) per the review/fix workflow in `${CLAUDE_SKILL_DIR}/7-build-component/7b-review-fix-component/SKILL.md`.
+
+### 1b. Write re-measured scores back to build-results
+
+The build phase wrote each component's verdict to `.temp/figma-from-code/build-results/{name}.json`. When validation re-measures a component (fresh screenshot + pixel diff, or a fix-loop iteration), that new number **supersedes** the build-phase one — the two artifacts must not silently diverge (the build-result said 83.8% while the report said 81.9% on a prior run). After validating each component, update its build-result file:
+
+- Write a `validation` block: `{ verdict, matchPct, borderMatchPct, fixedDuringValidation: <bool>, reclassifiedFrom: <verdict|null>, evidence: <string|null>, validatedAt: <iso> }`.
+- Do **not** delete the original `comparison` block — it stays as the build-time record. The `validation` block is the authoritative current score.
+- `validation-summary.json` and `report.md` must report the `validation` numbers, never the stale build-phase ones.
+
+This keeps `build-results/{name}.json`, `validation-summary.json`, and `report.md` mutually consistent and traceable to one source. Any reclassification recorded here must carry `evidence` per the reclassification-discipline rule below.
+
+### 2. Clean up Components page layout
+
+After validation, clean up any misplaced components on the Components page. Subagents sometimes create their own frames instead of using the designated tier frames.
+
+```javascript
+const componentsPage = figma.root.children.find((p) => p.name.includes('Components'));
+await figma.setCurrentPageAsync(componentsPage);
+
+const tierFrameIds = new Set([
+  iconsFrameId,
+  tier1FrameId,
+  tier2FrameId,
+  // ... all tier frames from figmaNodes
+]);
+
+const strayFrames = componentsPage.children.filter((c) => !tierFrameIds.has(c.id));
+
+// For each stray frame, move its children to the correct tier frame
+// based on which tier the component belongs to (from buildOrder.tiers)
+// Then delete the empty stray frame
+
+// Re-stack all tier frames vertically with 80px gaps
+const frameOrder = [iconsFrameId, tier1FrameId, tier2FrameId /* ... */];
+let yPos = 0;
+const gap = 80;
+for (const id of frameOrder) {
+  const frame = figma.getNodeById(id);
+  frame.x = 0;
+  frame.y = yPos;
+  yPos += Math.round(frame.height) + gap;
+}
+```
+
+### 3. Stop the Playwright server
+
+```bash
+kill $(cat .temp/figma-from-code/pw-server.pid 2>/dev/null) 2>/dev/null
+rm -f .temp/figma-from-code/pw-endpoint.txt
+```
+
+### 4. Write validation summary
+
+Parse the report and write a concise summary for the orchestrator:
+
+```json
+{
+  "fileKey": "<figma-file-key>",
+  "componentsCompared": 60,
+  "comparable": 48,
+  "match": 41,
+  "minorDiff": 5,
+  "mismatch": 2,
+  "noAppReference": 12,
+  "matchRate": 0.854,
+  "fixedDuringValidation": 3,
+  "averageMatchPct": 91.4,
+  "overallVerdict": "PASS",
+  "preExistingFlagged": [{ "name": "OldButton", "verdict": "mismatch", "matchPct": 68.2 }],
+  "reclassifications": [{ "name": "Badge", "from": "mismatch", "to": "no_app_reference", "evidence": "build-phase app ref was the wrong 'AM' avatar element; the Figma master renders correctly. Re-captured the correct route crop — no comparable app render exists." }],
+  "reportPath": ".temp/figma-validation/report.md"
+}
+```
+
+Write to `.temp/figma-from-code/validation-summary.json`.
+
+**Overall verdict — compute it; do not assert it.** The verdict is a pure function of the counts and MUST be derived, not narrated:
+
+1. `comparable = match + minorDiff + mismatch` (everything with a real app reference; `noAppReference` is excluded from BOTH numerator and denominator — never count it as a pass).
+2. `matchRate = match / comparable` where `match` counts **only the `match` verdict**. `minor_diff` is NOT a match — it is a real (if small) difference that needs fixing, per the build-stage thresholds.
+3. **`PASS` requires BOTH `mismatch === 0` AND `matchRate >= 0.80`.** Otherwise `FAIL`. Report the exact `match`/`comparable` fraction and `matchRate` in the summary and the report so the verdict is independently checkable.
+
+**Reclassification discipline.** Lowering a raw `mismatch` to `minor_diff` or `no_app_reference` is only permitted with **per-item evidence** recorded in `reclassifications[]` (and in the report) that would survive an independent re-check — e.g. a captured screenshot showing the original app reference was the wrong element. A blanket or unevidenced reclassification to reach PASS is forbidden; if you cannot justify it per-item, leave it a `mismatch` and let the verdict be `FAIL`.
+
+**Font diffs are not a free pass.** Do not explain away a text diff as "font rasterization", "glyph rendering", or "Inter vs the app font" unless the component's `fontCheck.matches` is true (the built family equals the project's mapped target for the app's computed `fontFamily` — see the Step 4c font guardrail). If `fontCheck.matches` is false, the wrong family was applied: treat it as a fixable `font_mismatch` and fix it (set the mapped family), do not reclassify it downward. This project maps the app's system font stack (`ui-sans-serif, system-ui`) to **Inter** as a documented portable proxy; a small residual when Inter is correctly applied is acceptable proxy drift, but it must be labelled as such with both family names — never as unavoidable rasterization.
+
+### 5. Report
+
+```
+Phase 5 complete:
+- {componentsCompared} components validated ({comparable} with an app reference)
+- {match} match, {minorDiff} minor diff, {mismatch} mismatch
+- {noAppReference} skipped (no app reference)
+- {fixedDuringValidation} fixed during validation
+- Match rate: {match}/{comparable} = {matchRate} (PASS needs mismatch=0 AND >= 0.80)
+- Average match: {averageMatchPct}%
+- Overall verdict: {overallVerdict}
+- {reclassifications.length} reclassifications (each evidenced)
+- {preExistingFlagged.length} pre-existing components flagged for review
+```
+
+## Skip / Resume
+
+Skip if `.temp/figma-from-code/validation-summary.json` exists and `state.json -> phases.phase5` is `complete`.
+
+## Error Handling
+
+| Scenario                          | Action                                                                       |
+| --------------------------------- | ---------------------------------------------------------------------------- |
+| Validator skill fails             | Report error; partial results may exist in `.temp/figma-validation/`         |
+| Cleanup `use_figma` fails         | Report error; cleanup is non-critical — the components are already validated |
+| Playwright server already stopped | Ignore the kill failure                                                      |
+| Dev server not running            | Halt validation and tell the user to start the dev server                    |

--- a/plugins/figma-from-code/skills/figma-from-code/SKILL.md
+++ b/plugins/figma-from-code/skills/figma-from-code/SKILL.md
@@ -1,0 +1,335 @@
+---
+name: figma-from-code
+description: Orchestrates the full code-to-Figma rebuild workflow for a web application. Thin dispatcher that delegates all substantial work to subagents and reads only small summary files. Runs eight tracked phases (phase0a, phase0b, phase1, phase2, phase2_5, phase3, phase4, phase5). Never calls use_figma or get_screenshot directly.
+---
+
+# Skill: Build Figma from Code (Orchestrator)
+
+Thin dispatcher. Delegates every phase to a subagent, reads only small summary files, and tracks progress in `state.json`. Never calls `use_figma` or `get_screenshot` directly.
+
+## Required Inputs
+
+- `fileKey`: Figma file key
+- `resume` (optional): `true` to skip completed phases
+
+---
+
+## Hard Gates — Files the Orchestrator Must Never Read
+
+The orchestrator is a **thin dispatcher**. It must not open, read, or load any sub-skill `SKILL.md` files. Those files are for subagents only.
+
+**Forbidden reads (orchestrator):**
+
+| File                                                 | Why forbidden                                                         |
+| ---------------------------------------------------- | --------------------------------------------------------------------- |
+| `1-discovery-components/SKILL.md`                    | Subagent reads it to execute Phase 0a                                 |
+| `2-discovery-assets/SKILL.md`                        | Subagent reads it to execute Phase 0b                                 |
+| `3-setup-tokens/SKILL.md`                            | Subagent reads it to execute Phase 1                                  |
+| `4-setup-structure/SKILL.md`                         | Subagent reads it to execute Phase 2                                  |
+| `5-precapture/SKILL.md`                              | Subagent reads it to execute Phase 2.5                                |
+| `6-build-tier/SKILL.md`                              | Subagent reads it to execute Phase 3                                  |
+| `7-build-component/7a/SKILL.md`                      | Subagent reads it to execute per-component **build** (steps 1–3)      |
+| `7-build-component/7b-review-fix-component/SKILL.md` | Subagent reads it to execute per-component **review/fix** (steps 4–7) |
+| `8-build-screens/SKILL.md`                           | Subagent reads it to execute Phase 4                                  |
+| `9-validate/SKILL.md`                                | Subagent reads it to execute Phase 5                                  |
+| `10-validator/SKILL.md`                              | Subagent reads it for validation logic and Component App Map          |
+
+**What the orchestrator reads instead:** only small summary/output files under `.temp/figma-from-code/` (e.g., `discovery-summary.json`, `tokens-summary.json`, `structure-summary.json`).
+
+If you find yourself opening a sub-skill `SKILL.md` to understand inputs, outputs, or workflow steps — stop. That information belongs in the dispatch table and per-phase notes in _this_ file. If those notes are missing, ask the user before proceeding.
+
+---
+
+## Subagent Dispatch Pattern
+
+When dispatching a subagent:
+
+1. Give the subagent **only**: the skill filepath + `fileKey` + any state fields it needs (listed in the table below)
+2. Instruct the subagent to read its own skill file for full instructions
+3. Tell the subagent to **report back only**: `{ "success": true/false, "outputFile": "<path>" }`
+4. Read the output file yourself after the subagent completes
+
+The orchestrator never re-explains what a skill does — the skill file is the source of truth.
+The orchestrator never opens a sub-skill's `SKILL.md` file — see Hard Gates above.
+
+---
+
+## State Ledger
+
+Maintain `.temp/figma-from-code/state.json`:
+
+```json
+{
+  "fileKey": "{fileKey}",
+  "startedAt": "ISO timestamp",
+  "phases": {
+    "phase0a": "complete|in_progress|pending",
+    "phase0b": "complete|in_progress|pending",
+    "phase1": "complete|in_progress|pending",
+    "phase2": "complete|in_progress|pending",
+    "phase2_5": "complete|in_progress|pending",
+    "phase3": "complete|in_progress|pending",
+    "phase4": "complete|in_progress|pending",
+    "phase5": "complete|in_progress|pending"
+  },
+  "tierProgress": { "tier1": "complete|in_progress|pending" },
+  "buildOrder": { "tierCount": 0, "tiers": [{ "tier": 1, "label": "...", "components": ["..."] }] },
+  "figmaNodes": {
+    "foundationsPageId": "...",
+    "componentsPageId": "...",
+    "screensPageId": "...",
+    "foundationsFrameId": "...",
+    "iconsFrameId": "...",
+    "screensFrameId": "...",
+    "tier1FrameId": "...",
+    "tier2FrameId": "..."
+  },
+  "existingCollections": [],
+  "existingPages": [],
+  "variableMapPath": ".temp/figma-from-code/variables.json",
+  "builtComponents": {},
+  "preExistingComponents": {},
+  "preExistingScreens": {},
+  "iconDiscovery": { "iconCount": 0, "icons": [], "assetCount": 0, "assets": [] }
+}
+```
+
+**Subagents do not modify state.json.** Each writes its own output file; the orchestrator reads it and updates state.
+
+`figmaNodes` uses the pattern `tier{N}FrameId` for each tier (e.g., `tier1FrameId`, `tier2FrameId`, ...). The number of keys matches `buildOrder.tierCount`.
+
+### Fresh Run: Initialize state.json
+
+Before Phase 0a, create `.temp/figma-from-code/state.json` from the template above. Set `fileKey` and `startedAt` to current ISO timestamp; all `phases` values to `"pending"`; all other fields empty.
+
+---
+
+## Pre-Existing Components Rule
+
+`preExistingComponents` is an **immutable snapshot** from Phase 0a. Never update it after Phase 0a.
+
+**Hard rule:** Pause and get explicit user authorization before any action that modifies, replaces, or deletes a node in `preExistingComponents`. This includes rebuilding, running the icon preamble over existing icons, or any Phase 3 build that resolves to a pre-existing node.
+
+---
+
+## Phase Dispatch Table
+
+All skill files live under `${CLAUDE_SKILL_DIR}/`. Shell steps (normalization after Phase 0b, aggregation scripts after Phase 3 tiers and Phase 4) are in Per-Phase Notes. After each subagent succeeds, set `phases.{phase}: complete` in addition to the listed state fields.
+
+**Important:** Each subagent does all of its work inline — no subagent spawns further subagents. The tier subagent (Phase 3) builds all components in that tier sequentially. The validation subagent (Phase 5) processes all tiers sequentially.
+
+| Phase   | Skill file                                       | Inputs to pass                                                                                                                                                                                                      | Output file to read          | State fields to update                                                                                                                                                                                | Skip if                                                                    |
+| ------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| 0a      | `1-discovery-components/SKILL.md`                | `fileKey`                                                                                                                                                                                                           | `discovery-summary.json`     | `buildOrder`, `builtComponents`, `preExistingComponents`, `preExistingScreens`; also extract `figma.variableCollections` → `existingCollections` and `figma.pages` → `existingPages` from the summary | `phase0a: complete`                                                        |
+| 0b      | `2-discovery-assets/SKILL.md`                    | `sourceDir` (e.g., `<source-dir>/`)                                                                                                                                                                          | `icons-summary.json`         | `iconDiscovery`                                                                                                                                                                                       | `phase0b: complete`                                                        |
+| 1       | `3-setup-tokens/SKILL.md`                        | `fileKey`, `existingCollections`                                                                                                                                                                                    | `tokens-summary.json`        | `variableMapPath`                                                                                                                                                                                     | `phase1: complete` AND `.temp/figma-from-code/tokens-summary.json` exists  |
+| 2       | `4-setup-structure/SKILL.md`                     | `fileKey`, `existingPages`                                                                                                                                                                                          | `structure-summary.json`     | `figmaNodes` (`foundationsPageId`, `componentsPageId`, `screensPageId`, `foundationsFrameId`, `iconsFrameId`, `screensFrameId`)                                                                       | `phase2: complete` AND page/icons/screens IDs in `figmaNodes` are non-null |
+| 2.5     | `5-precapture/SKILL.md` (one subagent)           | `fileKey` only — subagent builds all manifests itself from `component-map.json`                                                                                                                                     | `precapture-all.json`        | `phases.phase2_5`                                                                                                                                                                                     | `phase2_5: complete`                                                       |
+| 3 pre   | `6-build-tier/SKILL.md` (icon preamble mode)     | `fileKey`, `figmaNodes`; subagent reads `builtComponents.json` from disk                                                                                                                                            | `icon-preamble-results.json` | merge `created` into `builtComponents`; rewrite `builtComponents.json`                                                                                                                                | all icons already in `builtComponents`                                     |
+| 3 tiers | `6-build-tier/SKILL.md` (one subagent/tier)      | `fileKey`, `tier` (number), `tierLabel`, `componentsPageId` (from `figmaNodes`); subagent reads `builtComponents.json` from disk                                                                                    | `build-tier{N}.json`         | `builtComponents`, `figmaNodes.tier{N}FrameId` (from `build-tier{N}.json`), `tierProgress.tier{N}`; rewrite `builtComponents.json`; set `phases.phase3: complete` after all tiers                     | `tierProgress.tier{N}: complete`                                           |
+| 4       | `8-build-screens/SKILL.md` (one subagent/screen) | `fileKey`, `figmaNodes`, `preExistingScreens`; per-screen: `screenName`, `route`, `pageSourceFile`, `keyComponents` (read from `component-map.json → routes/tree`); subagent reads `builtComponents.json` from disk | `build-screens.json`         | `phases.phase4`                                                                                                                                                                                       | `phase4: complete`                                                         |
+| 5       | `9-validate/SKILL.md`                            | `fileKey`, `builtComponents`, `figmaNodes`, `buildOrder`                                                                                                                                                            | `validation-summary.json`    | `phases.phase5`                                                                                                                                                                                       | always runs                                                                |
+
+---
+
+## Phase Execution Order
+
+Phases have dependency constraints but several can overlap. Follow this wave structure to minimize wall-clock time:
+
+```
+Wave 1  (parallel): Phase 0a  ||  Phase 0b
+          - 0a: browser crawl + Figma inspection
+          - 0b: static icon/asset scan (no Figma, no browser needed)
+          ⏸ PAUSE — write progress.md, ask user to continue or stop
+
+Wave 2  (as soon as 0a is done, don't wait for 0b):
+          Phase 1  ||  Phase 2  (parallel — both only need 0a outputs)
+          After 0b completes: run normalization script
+          ⏸ PAUSE — write progress.md, ask user to continue or stop
+
+Wave 3  (starts when normalization + Phase 1 + Phase 2 are ALL done):
+          Phase 2.5 — dispatch ONE subagent with unified manifest (all
+          components in a single sorted batch; chunked at 15 entries per
+          script run to stay within the 60s timeout)
+          Write manifests before dispatching; read precapture-all.json after complete.
+          ⏸ PAUSE — write progress.md, ask user to continue or stop
+
+Wave 4  (sequential): Phase 3 preamble → Phase 3 tiers (one tier at a time)
+          Each tier waits for the prior tier; preamble runs before Tier 1.
+          ⏸ PAUSE after preamble
+          ⏸ PAUSE after EACH tier — write progress.md, ask user
+
+Wave 5  (parallel): Phase 4 screens — dispatch ALL in parallel
+          Screens only instance built components, never modify masters.
+          ⏸ PAUSE — write progress.md, ask user to continue or stop
+
+Wave 6  (sequential): Phase 5 validation
+          ⏸ PAUSE — write final progress.md (build complete)
+```
+
+**Dependency summary:**
+
+- Phase 1 needs: Phase 0a (`existingCollections`)
+- Phase 2 needs: Phase 0a (`existingPages`)
+- Phase 2.5 needs: normalization done (normalized `component-map.json` for selectors); Phase 1 + Phase 2 must also be done before Phase 3 can start, but Phase 2.5 itself only needs normalization
+- Phase 3 needs: Phase 1 (`variables.json`), Phase 2 (`figmaNodes`), Phase 2.5 (screenshots)
+- Phase 4 needs: Phase 3 (`builtComponents`), Phase 2 (`figmaNodes.screensFrameId`)
+- Phase 5 needs: Phase 4 (all screens built)
+
+---
+
+## Per-Phase Notes
+
+### After Phase 0b: Normalization (Phase 0b+)
+
+Run the normalization script, then re-read `discovery-summary.json` to refresh `buildOrder` in state. Skip if `phase0b: complete` AND `phase3` is `in_progress` or `complete` (normalization already applied).
+
+```bash
+node ${CLAUDE_SKILL_DIR}/1-discovery-components/normalize-component-map.js \
+  .temp/figma-from-code/component-map.json \
+  .temp/figma-from-code/icons.json \
+  --write
+```
+
+The script regenerates `discovery-summary.json` automatically. Re-read it and update `buildOrder` in state.
+
+### Phase 2.5: Reading pre-capture results
+
+After the pre-capture subagent completes, read `precapture-all.json` and `precapture-screens.json` and verify that screenshot file counts are non-zero. There is no aggregation script — the orchestrator reads each file directly.
+
+### Before Phase 3 (preamble): Materialize builtComponents.json
+
+`builtComponents.json` is the on-disk pass mechanism for all Phase 3 and Phase 4 subagents — they read it directly rather than receiving `builtComponents` inline. Keep it in sync with `state.builtComponents` before every dispatch.
+
+Write current `state.builtComponents` to disk before dispatching the preamble subagent:
+
+```bash
+node -e "const s=JSON.parse(require('fs').readFileSync('.temp/figma-from-code/state.json','utf-8')); require('fs').writeFileSync('.temp/figma-from-code/builtComponents.json', JSON.stringify(s.builtComponents||{},null,2));"
+```
+
+After preamble completes, merge new icons into `state.builtComponents` and rewrite `builtComponents.json`. The file persists through all of Phase 3 and Phase 4 as the live registry of built components.
+
+### Phase 3 Tiers: Post-tier aggregation
+
+After all subagents for a tier complete, run:
+
+```bash
+node ${CLAUDE_SKILL_DIR}/collect-tier-results.js --tier {N} --components "{comma-separated}"
+```
+
+Read stdout for the one-line JSON summary. Then follow the **End-of-Phase Pause Protocol**: update `state.json`, write `progress.md`, and ask the user whether to continue to the next tier or stop. Each tier is a full pause point — the user may stop and a new orchestrator agent can resume from the next tier.
+
+### Phase 4: Post-screen aggregation
+
+After all screen subagents complete:
+
+```bash
+mkdir -p .temp/figma-from-code/build-results/screens
+node ${CLAUDE_SKILL_DIR}/collect-screen-results.js --screens "{comma-separated}"
+```
+
+---
+
+## Progress File
+
+After every pause point, the orchestrator writes `.temp/figma-from-code/progress.md` — a human-readable narrative that allows a **fresh orchestrator agent** (with no memory of prior work) to understand what happened and where to continue.
+
+`progress.md` is the **handoff document**. `state.json` is the machine-readable truth. Both must exist and stay in sync.
+
+### Template
+
+```markdown
+# Figma-from-Code Build Progress
+
+**File Key:** {fileKey}
+**Last Updated:** {ISO timestamp}
+**Status:** Paused after {phase/tier description}
+
+## Completed Phases
+
+| Phase | Description          | Key Output                                       | Completed At |
+| ----- | -------------------- | ------------------------------------------------ | ------------ |
+| 0a    | Component discovery  | {component count} components, {tier count} tiers | {timestamp}  |
+| 0b    | Asset/icon discovery | {icon count} icons, {asset count} assets         | {timestamp}  |
+| ...   | ...                  | ...                                              | ...          |
+
+## Current State
+
+- **Built components:** {count} / {total}
+- **Tiers completed:** {N} / {total tiers}
+- **Screens built:** {count} / {total}
+- **Figma nodes created:** {list key node IDs}
+
+## Next Step
+
+**Phase to execute:** {phase ID and name}
+**Prerequisites:** {what must be true — e.g., "dev server running on localhost:5173"}
+**What it does:** {one-sentence description}
+**Estimated dispatches:** {number of subagents or script runs}
+
+## Warnings / Partial State
+
+- {any incomplete tiers, failed retries, or pre-existing component conflicts}
+```
+
+---
+
+## Startup Protocol
+
+On **every invocation**, before doing any work:
+
+1. Check if `.temp/figma-from-code/progress.md` exists
+2. **If it exists:**
+   - Read `progress.md` in full
+   - Present a concise summary to the user: which phases are done, what comes next
+   - Ask: _"A previous build was paused after {phase}. Resume from {next phase}?"_
+   - If user confirms → read `state.json`, validate it matches `progress.md`, skip to next incomplete phase
+   - If user declines → ask if they want a fresh start (which deletes `.temp/figma-from-code/`) or manual phase selection
+3. **If it does not exist:**
+   - Check if `state.json` exists (orphaned state without progress file)
+   - If `state.json` exists → warn user, offer to reconstruct progress from state or start fresh
+   - If neither exists → initialize fresh run (create `state.json` from template, proceed to Phase 0a)
+
+---
+
+## End-of-Phase Pause Protocol
+
+After completing any pause point (see Pause Points below), the orchestrator MUST:
+
+1. **Update `state.json`** — mark the phase/tier complete, update all relevant state fields
+2. **Write `progress.md`** — regenerate the full file from current `state.json` using the template above
+3. **Report to user** — show key metrics (counts, node IDs, any warnings)
+4. **Ask the user:**
+
+   > _"{Phase/tier} complete. {Brief metric summary}. Continue to {next phase/tier}, or stop here so a new agent can resume later?"_
+
+5. **If user says stop** → confirm `progress.md` is written, say "Build paused. A new agent can resume by invoking this skill." and terminate
+6. **If user says continue** → proceed to the next dispatch
+
+The orchestrator **never auto-continues** to the next pause point without explicit user confirmation.
+
+### Pause Points
+
+Every wave boundary and every Phase 3 tier is a mandatory pause point:
+
+| Pause Point      | After                                    | Before                            |
+| ---------------- | ---------------------------------------- | --------------------------------- |
+| Wave 1 → 2       | Phase 0a + 0b complete (+ normalization) | Phase 1 + Phase 2                 |
+| Wave 2 → 3       | Phase 1 + Phase 2 complete               | Phase 2.5                         |
+| Wave 3 → 4       | Phase 2.5 complete                       | Phase 3 preamble                  |
+| Phase 3 preamble | Icon preamble complete                   | Tier 1                            |
+| Phase 3 Tier N   | Tier N complete                          | Tier N+1 (or Wave 5 if last tier) |
+| Wave 4 → 5       | Phase 3 all tiers complete               | Phase 4 screens                   |
+| Wave 5 → 6       | Phase 4 screens complete                 | Phase 5 validation                |
+| End              | Phase 5 complete                         | — (build finished)                |
+
+---
+
+## Error Handling
+
+| Scenario                                  | Action                                                      |
+| ----------------------------------------- | ----------------------------------------------------------- |
+| Dev server not running                    | Halt before Phase 2.5, tell user to start it                |
+| Subagent reports `success: false`         | Report error, offer retry — never silently skip             |
+| State inconsistency                       | Trust per-tier build JSON files; rebuild state from outputs |
+| Pre-existing component needs modification | Pause, apply authorization protocol, wait for user          |

--- a/plugins/figma-from-code/skills/figma-from-code/collect-screen-results.js
+++ b/plugins/figma-from-code/skills/figma-from-code/collect-screen-results.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const args = process.argv.slice(2);
+const screensIdx = args.indexOf('--screens');
+
+if (screensIdx === -1) {
+  console.error('Usage: collect-screen-results.js --screens "Screen1,Screen2,..."');
+  process.exit(1);
+}
+
+const screens = args[screensIdx + 1].split(',').map(s => s.trim()).filter(Boolean);
+const baseDir = '.temp/figma-from-code';
+const resultsDir = path.join(baseDir, 'build-results', 'screens');
+
+const completed = [];
+const failed = [];
+const rejected = [];
+
+for (const name of screens) {
+  const resultPath = path.join(resultsDir, `${name}.json`);
+  if (!fs.existsSync(resultPath)) {
+    failed.push({ name, error: 'no_result_file' });
+    continue;
+  }
+  try {
+    const result = JSON.parse(fs.readFileSync(resultPath, 'utf-8'));
+    if (result.status === 'rejected') {
+      rejected.push({ name, reason: result.reason, missingComponents: result.missingComponents });
+      continue;
+    }
+    if (result.status === 'needs_authorization') {
+      rejected.push({ name, reason: 'needs_authorization' });
+      continue;
+    }
+    completed.push({
+      name: result.screenName || name,
+      nodeId: result.nodeId,
+      verdict: result.comparison?.verdict,
+      matchPct: result.comparison?.matchPct,
+      iterations: result.comparison?.iterations,
+    });
+  } catch (e) {
+    failed.push({ name, error: `parse_error: ${e.message}` });
+  }
+}
+
+const screenStatus = failed.length === 0 && rejected.length === 0 ? 'complete' : 'complete_with_failures';
+const output = { status: screenStatus, screens: completed, failed, rejected };
+fs.writeFileSync(
+  path.join(baseDir, 'build-screens.json'),
+  JSON.stringify(output, null, 2)
+);
+
+const summary = {
+  status: screenStatus,
+  completed: completed.length,
+  failed: failed.length,
+  rejected: rejected.length,
+  matched: completed.filter(s => s.verdict === 'match').length,
+  minorDiff: completed.filter(s => s.verdict === 'minor_diff').length,
+};
+console.log(JSON.stringify(summary));

--- a/plugins/figma-from-code/skills/figma-from-code/collect-tier-results.js
+++ b/plugins/figma-from-code/skills/figma-from-code/collect-tier-results.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const args = process.argv.slice(2);
+const tierIdx = args.indexOf('--tier');
+const componentsIdx = args.indexOf('--components');
+
+if (tierIdx === -1 || componentsIdx === -1) {
+  console.error('Usage: collect-tier-results.js --tier <N> --components "Comp1,Comp2,..."');
+  process.exit(1);
+}
+
+const tier = parseInt(args[tierIdx + 1], 10);
+const components = args[componentsIdx + 1].split(',').map(s => s.trim()).filter(Boolean);
+const baseDir = '.temp/figma-from-code';
+const resultsDir = path.join(baseDir, 'build-results');
+const statePath = path.join(baseDir, 'state.json');
+
+const completed = [];
+const failed = [];
+let matched = 0;
+let minorDiff = 0;
+let mismatched = 0;
+let noRef = 0;
+
+for (const name of components) {
+  const resultPath = path.join(resultsDir, `${name}.json`);
+  if (!fs.existsSync(resultPath)) {
+    failed.push({ name, error: 'no_result_file' });
+    continue;
+  }
+  try {
+    const result = JSON.parse(fs.readFileSync(resultPath, 'utf-8'));
+    if (result.status === 'rejected' || result.status === 'needs_authorization') {
+      failed.push({ name, error: result.status, reason: result.reason });
+      continue;
+    }
+    const entry = {
+      name: result.componentName || name,
+      nodeId: result.nodeId,
+      figmaScreenshot: result.figmaScreenshot,
+    };
+    if (result.comparison) {
+      entry.verdict = result.comparison.verdict;
+      entry.matchPct = result.comparison.matchPct;
+    }
+    completed.push(entry);
+    if (entry.verdict === 'match') matched++;
+    else if (entry.verdict === 'minor_diff') minorDiff++;
+    else if (entry.verdict === 'no_app_reference') noRef++;
+    else mismatched++;
+  } catch (e) {
+    failed.push({ name, error: `parse_error: ${e.message}` });
+  }
+}
+
+const tierSummary = { tier: `tier${tier}`, completed, failed };
+fs.writeFileSync(
+  path.join(baseDir, `build-tier${tier}.json`),
+  JSON.stringify(tierSummary, null, 2)
+);
+
+const state = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+if (!state.builtComponents) state.builtComponents = {};
+for (const c of completed) {
+  if (c.nodeId) state.builtComponents[c.name] = c.nodeId;
+}
+state.tierProgress = state.tierProgress || {};
+// Honest status: a tier is only "complete" when nothing failed. Otherwise record
+// "complete_with_failures" plus the failed component names so state.json reflects
+// reality — the orchestrator and any resume must not treat a partial tier as done.
+state.tierProgress[`tier${tier}`] = failed.length === 0 ? 'complete' : 'complete_with_failures';
+state.tierFailures = state.tierFailures || {};
+if (failed.length === 0) {
+  delete state.tierFailures[`tier${tier}`];
+} else {
+  state.tierFailures[`tier${tier}`] = failed.map(f => f.name);
+}
+fs.writeFileSync(statePath, JSON.stringify(state, null, 2));
+
+// Merge this tier's completed node IDs INTO the existing builtComponents.json
+// rather than overwriting it from state.json. Mid-Phase-3, state.json lags behind
+// the orchestrator's in-memory registry (it does not yet hold icons or freshly
+// built earlier tiers), so rewriting from it would truncate the registry that the
+// next tier depends on. Merging preserves everything already on disk.
+const builtPath = path.join(baseDir, 'builtComponents.json');
+let built = {};
+if (fs.existsSync(builtPath)) {
+  try {
+    built = JSON.parse(fs.readFileSync(builtPath, 'utf-8'));
+  } catch {
+    built = {};
+  }
+}
+for (const c of completed) {
+  if (c.nodeId) built[c.name] = c.nodeId;
+}
+fs.writeFileSync(builtPath, JSON.stringify(built, null, 2));
+
+const summary = {
+  tierStatus: failed.length === 0 ? 'complete' : 'complete_with_failures',
+  completed: completed.length,
+  failed: failed.length,
+  failedComponents: failed.map(f => f.name),
+  matched,
+  minorDiff,
+  mismatched,
+  noRef,
+};
+console.log(JSON.stringify(summary));

--- a/plugins/figma-from-code/skills/figma-from-code/evaluation-report.md
+++ b/plugins/figma-from-code/skills/figma-from-code/evaluation-report.md
@@ -1,0 +1,386 @@
+# `figma-from-code` Skill Evaluation Report
+
+Generated: 2026-05-22
+
+Three independent subagents evaluated the skill from different angles:
+
+1. **Context Reduction** — opportunities to reduce the orchestrator's token load
+2. **Artifact Analysis** — redundancies, unnecessary data, and organizational issues in produced files
+3. **Inconsistency Detection** — conflicting commands and internal contradictions
+
+---
+
+## Agent 1 — Orchestrator Context Reduction
+
+**Root cause:** Sub-skill SKILL.md files serve two audiences (orchestrator dispatch + subagent execution), so the orchestrator loads ~5–10x more content than it needs.
+
+### High-Impact Findings
+
+| Finding                                                                                                                                                               | Est. Token Savings | Risk     |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | -------- |
+| `build-screens/SKILL.md`: orchestrator loads ~650 lines, needs ~100 (full workflow, fixSizing, pitfalls, error tables are subagent-only)                              | ~5,000–5,500       | Medium   |
+| `discovery-components/SKILL.md`: ~260 lines loaded, ~30 needed (steps 1–11 internal workflow)                                                                         | ~1,800–2,000       | Medium   |
+| `build-tier/SKILL.md`: JS "Icon creation reference" code blocks loaded but never used by orchestrator or received by subagent                                         | ~400–500           | Medium   |
+| Orchestrator itself: "Screenshot Scale Convention" (subagent-only), 4 "NOT orchestrator" file rows, standalone "Checkpoint Protocol" (redundant with per-phase notes) | ~170–200           | Very low |
+
+**Total estimated savings:** ~8,000–9,800 tokens per pipeline run.
+
+### Structural Fix
+
+Add an `## Orchestrator Interface` section at the top of each sub-skill containing only:
+
+1. The subagent prompt template
+2. Required inputs table
+3. Output files table (summary files only)
+4. Skip/resume rules
+
+Direct the orchestrator to read only that section. Subagents continue to read the full file.
+
+### Full Findings
+
+#### Finding 1 — `build-screens/SKILL.md`: Orchestrator loads ~650 lines but only needs ~100
+
+The orchestrator reads `8-build-screens/SKILL.md` to dispatch Phase 4. Orchestrator-relevant content is only ~100 lines:
+
+| Section                                           | Orchestrator needs? |
+| ------------------------------------------------- | ------------------- |
+| Subagent Prompt Template (~30 lines)              | Yes                 |
+| Required Inputs table (~20 lines)                 | Yes                 |
+| Output Files table (~10 lines)                    | Yes                 |
+| Pre-Existing Screens Rule (~30 lines)             | Yes                 |
+| Skip/Resume (~5 lines)                            | Yes                 |
+| Step 0–7 full workflow (~350 lines)               | No                  |
+| `fixSizing()` variant + code block (~30 lines)    | No                  |
+| Common Pitfalls table (~25 lines)                 | No                  |
+| Error Handling table (~25 lines)                  | No                  |
+| Step 2c–2e Figma code patterns (~80 lines)        | No                  |
+| Step 4 sizing check + verdict table (~50 lines)   | No                  |
+| Step 5 fix-loop per-iteration process (~50 lines) | No                  |
+
+#### Finding 2 — `build-tier/SKILL.md`: "Icon creation reference" JS code is dead weight
+
+Lines ~83–140 contain full JavaScript code blocks for icon creation. The orchestrator dispatches the icon preamble as a pre-written text prompt — it never executes or adapts this code. The preamble subagent receives only the text prompt, not the build-tier SKILL.md.
+
+**Fix:** Embed the JS code into the "Icon Preamble Subagent Prompt Template" itself so the subagent actually receives it.
+
+#### Finding 3 — `build-tier/SKILL.md`: Result format JSON schemas not needed by orchestrator
+
+The orchestrator collects tier results by running `collect-tier-results.js` and reading its one-line JSON stdout — it does not parse per-component schemas directly.
+
+#### Finding 4 — `build-tier/SKILL.md`: "Handling Library Components" table is subagent implementation detail
+
+The "Handling Library Components" table instructs subagents on how to handle icons/routers during per-tier builds. The orchestrator doesn't need this.
+
+#### Finding 5 — Orchestrator SKILL.md: "Screenshot Scale Convention" section
+
+The orchestrator never calls `get_screenshot` or `screenshot.js` directly (explicitly stated in the skill header). This section is purely for subagents. Same convention is already documented in `step-4-compare.md`.
+
+#### Finding 6 — Per-Agent Output Files table lists files the orchestrator explicitly doesn't read
+
+Four entries with explicit `NOT orchestrator` annotations still consume context. Remove them — they remain documented in their respective sub-skills.
+
+#### Finding 7 — Standalone "Checkpoint Protocol" section is redundant
+
+Each of the 5 checkpointed phases already has an inline checkpoint instruction. The standalone general policy section adds minimal value.
+
+#### Finding 8 — "Orchestrator Behavior Between Tiers" is orchestrator logic inside a sub-skill
+
+`build-tier/SKILL.md` has a section describing state.json merge, spot-check, and checkpoint behavior that belongs in the orchestrator. Editing this behavior requires updating two places.
+
+#### Finding 9 — `build-component/SKILL.md` and `build-screens/SKILL.md`: Divergent `fixSizing()` implementations
+
+Two slightly different `fixSizing()` implementations across sub-skills. Not an orchestrator context issue, but creates maintenance risk. A shared `figma-utils.md` reference file would prevent drift.
+
+#### Finding 10 — `discovery-components/SKILL.md`: Orchestrator loads extensive internal workflow detail
+
+~260 lines loaded, ~30 needed. Steps 1–11 (crawl, normalize, scanner commands, Figma inspection, `.figma.json` writing) are subagent implementation details.
+
+---
+
+## Agent 2 — Artifact Redundancy & Organization
+
+### Bugs (would cause failures)
+
+#### Finding 1 — `builtComponents.json` Triple Redundancy + Stale Bug (CRITICAL)
+
+`builtComponents` exists in five places simultaneously:
+
+1. `state.json → builtComponents`
+2. `builtComponents.json` (materialized snapshot)
+3. `discovery-summary.json → builtComponents` (seed)
+4. Every `build-results/{Name}.json → nodeId`
+5. Every `build-tier{N}.json → completed[].nodeId`
+
+**Critical bug:** `builtComponents.json` is materialized once after the icon preamble and never updated after Phase 3 tier builds. Phase 4 screen-build subagents read it from disk — meaning they see only preamble icons, not any components built in Phase 3. Phase 4 Step 0 prerequisite checks will fail for virtually every screen.
+
+**Fix:** Either re-write `builtComponents.json` after every tier, or eliminate the file entirely and deliver `builtComponents` inline in all subagent prompts (tier-builds already do this). The inline approach is cleaner.
+
+#### Finding 3 — `preExistingScreens` Missing from `state.json` Schema (CRITICAL)
+
+`8-build-screens` references `state.json → preExistingScreens` as a required input for the authorization gate. This field does not appear in the state.json schema and is never populated in Phase 0a. Every build-screens subagent receives `preExistingScreens: undefined`, silently disabling the pre-existing screen protection.
+
+**Fix:** Add a `preExistingScreens` capture step to Phase 0a (alongside `preExistingComponents`), add the field to the state.json schema, and pass it explicitly to build-screens subagents.
+
+#### Finding 4 — Normalization Re-Read Is an Undocumented Implicit Side Effect (BUG RISK)
+
+The orchestrator says after Phase 0b: _"re-read `discovery-summary.json` (the normalization script should update it)"_. But `normalize-component-map.js` is documented to write only to `component-map.json`. If the script doesn't update the summary, `buildOrder` retains pre-normalization names (e.g., `Check` instead of `Icon/Check`), causing Phase 3 subagents to reference wrong component names.
+
+**Fix:** Either have the orchestrator explicitly re-run the summary generation step after normalization, or document that the normalize script must also update `discovery-summary.json`.
+
+### Design Smells
+
+#### Finding 2 — `state.json` Duplicates Every Phase Summary
+
+`state.json` has absorbed the complete output of every phase summary file:
+
+| state.json field        | Also in                                                                    |
+| ----------------------- | -------------------------------------------------------------------------- |
+| `buildOrder`            | `discovery-summary.json`                                                   |
+| `preExistingComponents` | `discovery-summary.json`                                                   |
+| `builtComponents`       | `discovery-summary.json` + `builtComponents.json`                          |
+| `iconDiscovery`         | `icons-summary.json`                                                       |
+| `figmaNodes`            | `structure-summary.json`                                                   |
+| `variableMapPath`       | Always `".temp/figma-from-code/variables.json"` — a constant, never varies |
+
+**Fix:** Slim `state.json` to progress tracking only:
+
+```json
+{
+  "fileKey": "...",
+  "startedAt": "...",
+  "phases": { "phase0a": "complete", ... },
+  "tierProgress": { "tier1": "complete", ... }
+}
+```
+
+#### Finding 5 — `tokens-summary.json` Contains Only Constants
+
+`variableMapPath` and `resolvedColorsPath` are hardcoded constants that never vary. Including them in state.json implies they could be dynamic. Remove these fields from both the summary and state.json.
+
+#### Finding 6 — Unused Fields in Tier and Structure Summaries
+
+`build-tier{N}.json → completed[].figmaScreenshot` and `structure-summary.json → foundationsScreenshot` are not consumed by any downstream phase. Strip them or move to a `debug-info` key.
+
+#### Finding 7 — Phase 5 Output Split Across Two Directories
+
+`report.md` → `.temp/figma-validation/`  
+`validation-summary.json` → `.temp/figma-from-code/`
+
+The orchestrator's output files table only lists the summary. The split is unexplained and someone debugging must know to look in a second location.
+
+**Fix:** Either copy the report into `.temp/figma-from-code/validation-report.md`, or document both paths in the orchestrator's output table.
+
+#### Finding 8 — No Aggregate Precapture Summary
+
+Every other phase that produces parallel sub-results has a single-file aggregate summary (`build-tier{N}.json`, `build-screens.json`). Phase 2.5 has no `precapture-summary.json`, making resume and debugging harder.
+
+#### Finding 9 — `code.json` Lives in the Source Tree, Not `.temp/`
+
+`build-component` Step 1 writes `code.json` to `<source-dir>/components/{Name}/.figma/code.json`. This is a pipeline intermediate, not a persistent record — but it lives alongside the intentionally persistent `figma.json`. It will pollute git diffs and may contain stale analysis from previous runs.
+
+**Fix:** Write to `.temp/figma-from-code/analysis/{Name}/code.json`. Add `**/.figma/code.json` to `.gitignore` as a minimum mitigation.
+
+#### Finding 10 — `discovery-summary.json` Naming Inconsistency
+
+All other summary files follow a noun pattern: `icons-summary.json`, `tokens-summary.json`, `structure-summary.json`, `validation-summary.json`. Phase 0a uses a verb: `discovery-summary.json`. Since Phase 0b is also "discovery", this is ambiguous.
+
+**Fix:** Rename to `components-summary.json`.
+
+#### Finding 11 — Mixed `builtComponents` Delivery Modes
+
+- Tier-build subagents: receive inline `{JSON.stringify(builtComponents)}`
+- Icon preamble subagent: reads `builtComponents.json` from disk
+- Screen-build subagents: reads `builtComponents.json` from disk
+- Validate subagent: receives inline from orchestrator
+
+**Fix:** Standardize on inline delivery for all subagents. Eliminate `builtComponents.json` entirely.
+
+#### Finding 12 — `build-tier{N}.json` Drops Match Score Data
+
+The tier summary captures only name + nodeId per component. Match scores (matchPct, iterations, fixes) exist only in per-component `build-results/{Name}.json`. Phase 5 must re-read all individual files; the tier summary provides no shortcut.
+
+**Fix:** Either enrich `build-tier{N}.json` to include `matchPct` per component (enabling Phase 5 to prioritize fix loops), or remove the file and have Phase 5 scan `build-results/` directly.
+
+---
+
+## Agent 3 — Inconsistencies & Conflicting Commands
+
+### Critical (workflow-breaking)
+
+#### C1 — `preExistingScreens` referenced in build-screens but never collected or stored
+
+**Conflict:**
+
+`8-build-screens/SKILL.md` Required Inputs:
+
+> `preExistingScreens | Immutable snapshot of screen frames that existed in Figma BEFORE this orchestrator run started | state.json → preExistingScreens (Phase 0a snapshot)`
+
+`figma-from-code/SKILL.md` state.json schema only defines `builtComponents` and `preExistingComponents`. `preExistingScreens` does not appear anywhere in the schema, and no Phase 0a step captures it.
+
+**Impact:** Every build-screens subagent receives `preExistingScreens: undefined`. The authorization gate ("stop if screen is pre-existing") silently becomes a no-op, allowing pre-existing Figma screens to be overwritten without user authorization.
+
+**Resolution:** Add a `preExistingScreens` capture step to Phase 0a, add the field to the state.json schema, and pass it explicitly in Phase 4 dispatch.
+
+---
+
+#### C2 — `discovery-summary.json` not updated by normalization script, but orchestrator expects it to be
+
+**Conflict:**
+
+`figma-from-code/SKILL.md` Phase 0b:
+
+> _"After normalization, re-read `discovery-summary.json` **(the normalization script should update it)** and refresh `buildOrder` in state."_
+
+`figma-from-code/1-discovery-components/SKILL.md` Step 4:
+
+```bash
+node ${CLAUDE_SKILL_DIR}/1-discovery-components/normalize-component-map.js \
+  .temp/figma-from-code/component-map.json \
+  .temp/figma-from-code/icons.json \
+  --write
+```
+
+> _"The `--write` flag writes back to `component-map.json`."_
+
+The normalization script only updates `component-map.json`. The summary is generated by a separate `node -e "..."` script in Step 10 and is not touched by normalization.
+
+**Impact:** After normalization, `discovery-summary.json` still has pre-normalization names (e.g., `Check` instead of `Icon/Check`). The orchestrator re-reads the stale summary and stores wrong names in `buildOrder`. All of Phase 3 uses incorrect component names.
+
+**Resolution:** Have the orchestrator explicitly re-run the summary generation step after normalization, rather than relying on an undocumented implicit side effect.
+
+---
+
+#### C3 — `builtComponents.json` read by preamble subagent but materialized only after preamble completes
+
+**Conflict (within `6-build-tier/SKILL.md`):**
+
+Icon Preamble Subagent Prompt Template:
+
+> _"Steps: 1. Read `icons.json` and **`builtComponents.json`**; 2. Filter out icons/assets already in `builtComponents`"_
+
+After the preamble subagent completes:
+
+> _"3. Materialize `builtComponents.json`"_
+
+The orchestrator only materializes `builtComponents.json` _after_ the preamble completes. On any run, the file does not exist when the preamble subagent tries to read it.
+
+**Impact:** The preamble subagent fails to find the file. The skip-already-built logic silently fails, potentially recreating all icons including pre-existing ones — triggering unauthorized modifications.
+
+**Resolution:** Materialize `builtComponents.json` from `state.json → builtComponents` **before** dispatching the preamble subagent. Move step 3 to the pre-preamble setup block.
+
+---
+
+### Moderate
+
+#### M1 — `build-screens.json` aggregate: who writes it?
+
+`figma-from-code/SKILL.md` Per-Agent Output Files:
+
+> `build-screens.json  # Phase 4: screen summary (written by collect-screen-results.js)`
+
+`8-build-screens/SKILL.md` Step 7 "Aggregate output":
+
+> _"Across all screens, write `.temp/figma-from-code/build-screens.json`:"_ (followed by schema)
+
+The build-screens skill uses the verb "write" with no qualifier, suggesting individual subagents write it — but each subagent handles only one screen and has no visibility into others. Only the orchestrator (via `collect-screen-results.js`) can write the aggregate.
+
+**Resolution:** Update build-screens Step 7 header to "Aggregate output (**written by orchestrator** via `collect-screen-results.js`)" and frame the schema as expected format, not a write instruction.
+
+---
+
+#### M2 — Per-screen result filename: `{N}` vs `{screenName}`
+
+`figma-from-code/SKILL.md` Per-Agent Output Files:
+
+> `build-results/screens/{N}.json`
+
+`8-build-screens/SKILL.md` Subagent Prompt Template:
+
+> `7. Write results to .temp/figma-from-code/build-results/screens/**{screenName}**.json`
+
+**Impact:** When the orchestrator runs `collect-screen-results.js`, it cannot find files if names don't match. One convention completely breaks the collector.
+
+**Resolution:** Standardize on `{screenName}` in both files.
+
+---
+
+#### M3 — `pw-server.pid` referenced in Phase 5 but never documented as created
+
+`9-validate/SKILL.md` Step 3:
+
+```bash
+kill $(cat .temp/figma-from-code/pw-server.pid 2>/dev/null) 2>/dev/null
+```
+
+No skill or orchestrator step documents that `browser-server.js` writes a PID file. `pw-endpoint.txt` is documented; `pw-server.pid` is not.
+
+**Impact:** The kill command silently fails. The `2>/dev/null` suppresses the error, leaving the Playwright server running indefinitely as an orphaned process.
+
+**Resolution:** Either document that `browser-server.js` writes `pw-server.pid` (and verify it does), or replace with `pkill -f browser-server.js`.
+
+---
+
+#### M4 — discovery-assets skip/resume is ambiguous
+
+`2-discovery-assets/SKILL.md` Skip/Resume:
+
+> _"If called with `resume: true`, check whether `icons.json` exists. If it does, **skip and read the existing file**."_
+
+Ambiguous: does "skip" mean skip only the extraction step, or skip the entire skill including writing `icons-summary.json`? If the whole skill skips, a deleted `icons-summary.json` with intact `icons.json` creates a situation where Phase 0b is incomplete but the skill refuses to regenerate the summary.
+
+**Resolution:** Rewrite as: _"If `icons.json` exists, skip step 2 (extraction) only. Always execute steps 3–5 (summarize + write `icons-summary.json` + report)."_
+
+---
+
+#### M5 — State.json write instructions embedded inside a sub-skill
+
+`figma-from-code/SKILL.md`:
+
+> _"**Subagents do not modify state.json.** Each writes its own output file. The orchestrator reads those files and updates state."_
+
+`6-build-tier/SKILL.md` — "Orchestrator Behavior Between Tiers":
+
+> _"2. Merge new node IDs into `builtComponents` in state.json; 4. Update `tierProgress.tier{N}` and `phase3` status"_
+
+Subagents dispatched with "Follow the `6-build-tier/SKILL.md`" read this section and may interpret the state.json write instructions as their own responsibility, creating potential race conditions.
+
+**Resolution:** Move "Orchestrator Behavior Between Tiers" to a clearly separated appendix with header "**ORCHESTRATOR ONLY — do not execute as a subagent**", or split it into a separate file the orchestrator reads.
+
+---
+
+### Minor
+
+| ID  | Issue                                                                                                                                                                             | Resolution                                                                                              |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| N1  | `preExistingComponents` authorization rule absent from setup-tokens, setup-structure, precapture, and discovery-assets (those phases don't touch nodes, but gap sets bad pattern) | Add one-line note: "This phase is read-only with respect to Figma components"                           |
+| N2  | "Pre-Existing Components Rule" vs "Pre-Existing Screens Rule" — parallel but separately named; resolving C1 is the prerequisite                                                   | After fixing C1, unify as "Pre-Existing Nodes Rule"                                                     |
+| N3  | Sub-skills don't specify expected model; orchestrator dispatch table does, but standalone invocations have no guidance                                                            | Add "Expected model: opus/sonnet" one-liner to each sub-skill header                                    |
+| N4  | Phase 0a has no explicit checkpoint block while Phase 0b does                                                                                                                     | Add `**Checkpoint:** report tier count, component counts, and pre-existing component count` to Phase 0a |
+| N5  | `.temp/figma-validation/report.md` not listed in orchestrator Per-Agent Output Files table                                                                                        | Add the path with a note explaining the two-directory split                                             |
+
+---
+
+## Priority Order
+
+### Fix immediately (breaks workflow)
+
+1. **C3** — Materialize `builtComponents.json` before dispatching the preamble subagent, not after
+2. **C1 / Finding 3** — Capture `preExistingScreens` in Phase 0a; add to state.json schema; pass to Phase 4
+3. **C2 / Finding 4** — Explicitly re-run summary generation after normalization; remove the "should update it" assumption
+
+### Fix soon (causes incorrect behavior)
+
+4. **Finding 1 / M2** — Standardize per-screen result filename on `{screenName}`; `collect-screen-results.js` cannot find files otherwise
+5. **Finding 1 (artifact)** — Eliminate `builtComponents.json`; standardize on inline delivery for all subagents to fix the Phase 4 staleness bug
+6. **M5** — Move "Orchestrator Behavior Between Tiers" out of the sub-skill to prevent subagents from attempting state.json writes
+
+### Improve when refactoring
+
+7. **Finding 1 (context)** — Add `## Orchestrator Interface` sections to `build-screens`, `discovery-components`, `build-tier` (~8,000–9,800 token savings)
+8. **Finding 2** — Slim `state.json` to progress tracking only
+9. **M3** — Fix `pw-server.pid` kill pattern
+10. **M4** — Clarify discovery-assets skip/resume language
+11. **Finding 9** — Move `code.json` out of source tree into `.temp/`
+12. **M1** — Clarify who writes `build-screens.json`
+13. **Finding 7** — Document or unify Phase 5 output directory split
+14. Remaining minor findings (N1–N5, Finding 6, Finding 10, Finding 12)

--- a/plugins/figma-from-code/skills/figma-from-code/skill-graph.md
+++ b/plugins/figma-from-code/skills/figma-from-code/skill-graph.md
@@ -1,0 +1,86 @@
+# figma-from-code Skill Graph
+
+Recursive set of all skills called (directly or transitively) by `figma-from-code`.
+
+## Recursive tree
+
+```
+figma-from-code (orchestrator — thin dispatcher, never calls use_figma)
+├── 1-discovery-components                     (Phase 0a, subagent)
+│   ├── site-component-map                     (provides map-components.js)
+│   └── figma-component-dependency-map         (build-order reference)
+│       └── figma:figma-generate-library       (plugin skill)
+├── 2-discovery-assets                         (Phase 0b, subagent)
+├── 3-setup-tokens                             (Phase 1, subagent)
+│   ├── figma-setup-variables                  (variable collection creation)
+│   │   ├── figma:figma-generate-library       (plugin)
+│   │   └── figma:figma-use                    (plugin — for use_figma)
+│   └── resolve-colors.js                      (CSS color resolution)
+├── 4-setup-structure                          (Phase 2, subagent)
+│   ├── figma-setup-file-structure             (pages + foundations)
+│   │   ├── figma:figma-generate-library       (plugin)
+│   │   └── figma:figma-use                    (plugin)
+│   └── use_figma (tier frames, screens frame) (inline in subagent)
+├── 5-precapture                               (Phase 2.5, haiku subagents)
+│   └── site-component-map                     (script source)
+├── 6-build-tier                               (Phase 3, opus subagents)
+│   ├── icon preamble subagent                 (sonnet)
+│   ├── 7-build-component                      (per component, opus)
+│   │   └── 10-validator/compare.js (bundled)              (pixel diff)
+│   └── collect-tier-results.js                (result aggregation)
+├── 8-build-screens                            (Phase 4, opus subagents)
+│   ├── site-component-map                     (route reference)
+│   └── collect-screen-results.js              (result aggregation)
+└── 9-validate                                 (Phase 5, subagent)
+    ├── 10-validator                           (full validation workflow)
+    │   ├── 10-validator/compare.js (bundled)
+    │   └── site-component-map                 (component app map)
+    └── cleanup use_figma                      (inline in subagent)
+```
+
+## Flat deduplicated list (17 skills)
+
+### Project-local (15)
+
+1. `1-discovery-components`
+2. `2-discovery-assets`
+3. `3-setup-tokens`
+4. `4-setup-structure`
+5. `figma-setup-variables`
+6. `figma-setup-file-structure`
+7. `5-precapture`
+8. `6-build-tier`
+9. `7-build-component`
+10. `8-build-screens`
+11. `9-validate`
+12. `10-validator`
+13. `figma-component-dependency-map`
+14. `10-validator/compare.js (bundled)`
+15. `site-component-map`
+
+### Plugin skills (2)
+
+16. `figma:figma-generate-library`
+17. `figma:figma-use`
+
+## Convergence points
+
+Shared utility skills with the highest fan-in:
+
+- `site-component-map` — pulled in by 5 skills (discovery-components, precapture, build-tier, build-screens, validator)
+- `figma:figma-generate-library` — pulled in by 3 skills (component-dependency-map, setup-variables, setup-file-structure)
+- `10-validator/compare.js (bundled)` — pulled in by 2 skills (build-component, validator)
+- `figma:figma-use` — pulled in by 2 skills (setup-variables, setup-file-structure)
+
+## Context optimization
+
+The orchestrator never reads files larger than ~3KB. Large files are read only by the subagents that need them:
+
+| File                   | Size  | Read by                                                   |
+| ---------------------- | ----- | --------------------------------------------------------- |
+| `component-map.json`   | ~48KB | discovery-components, build-tier, build-screens subagents |
+| `icons.json`           | ~18KB | discovery-assets, icon preamble subagent                  |
+| `variables.json`       | ~17KB | Phase 3 build subagents                                   |
+| `resolved-colors.json` | ~63KB | Phase 3 build subagents                                   |
+
+The orchestrator reads only summary files (~500B–3KB each).

--- a/plugins/figma-from-code/skills/figma-from-code/skill-tree.md
+++ b/plugins/figma-from-code/skills/figma-from-code/skill-tree.md
@@ -1,0 +1,165 @@
+# figma-from-code — Full Skill Tree
+
+```
+figma-from-code (Orchestrator — thin dispatcher, never calls use_figma)
+│
+├── Phase 0a — Component Discovery ───────────────────────────────────
+│   └── Subagent (sonnet): 1-discovery-components
+│       ├── 1. mkdir -p .temp/figma-from-code/
+│       ├── 2. curl → verify dev server
+│       ├── 3. node map-components.js --crawl --max-crawl 30
+│       ├── 4. node normalize-component-map.js (align names w/ Figma conventions)
+│       ├── 5. node discover-code-components.js (static import scan)
+│       ├── 6. get_metadata → match Figma components by name
+│       │   └── use_figma → read-only inspection (pages, variable collections)
+│       ├── 7. Seed .figma/figma.json per matched component
+│       ├── 8. Write updated component-map.json (with figmaNodeId per component)
+│       ├── 9. Write discovery-summary.json (~3KB) ← ORCHESTRATOR READS THIS
+│       └── 10. Report (tiers, existing vs missing components)
+│       → Orchestrator reads discovery-summary.json, merges into state.json
+│
+├── Phase 0b — Icon & Asset Discovery ────────────────────────────────
+│   └── Subagent (sonnet): 2-discovery-assets
+│       ├── 1. mkdir -p .temp/figma-from-code/
+│       ├── 2. node extract-icons.js --scan {sourceDir}
+│       ├── 3. Read icons.json summary fields
+│       ├── 4. Write icons-summary.json (~500B) ← ORCHESTRATOR READS THIS
+│       └── 5. Report
+│       → Orchestrator reads icons-summary.json, merges iconDiscovery into state
+│       → Orchestrator runs normalize-component-map.js (re-reads discovery-summary)
+│
+├── Phase 1 — Tokens (Variables) ─────────────────────────────────────
+│   └── Subagent (sonnet): 3-setup-tokens
+│       ├── Skill: figma-setup-variables
+│       │   ├── Read CSS → parse custom properties from :root
+│       │   ├── Read tailwind.config.js (color mappings, radius, spacing)
+│       │   ├── use_figma → create Palette collection
+│       │   ├── use_figma → create Semantic collection
+│       │   └── use_figma → create Spacing collection
+│       ├── use_figma → extract CSS var → Figma variable ID map → variables.json
+│       ├── node resolve-colors.js → resolved-colors.json
+│       ├── Write tokens-summary.json (~500B) ← ORCHESTRATOR READS THIS
+│       └── Report
+│       → Orchestrator reads tokens-summary.json, updates variableMapPath in state
+│
+├── Phase 2 — File Structure ─────────────────────────────────────────
+│   └── Subagent (sonnet): 4-setup-structure
+│       ├── Skill: figma-setup-file-structure
+│       │   ├── use_figma → rename/create pages (Foundations, Components, Screens)
+│       │   ├── use_figma → Color Palette frame
+│       │   ├── use_figma → Semantic Colors frame
+│       │   └── use_figma → Spacing Scale frame
+│       ├── use_figma → create Icons frame + tier frames on Components page
+│       ├── use_figma → create Screens container on Screens page
+│       ├── get_screenshot → verify Foundations page
+│       ├── Write structure-summary.json (~500B) ← ORCHESTRATOR READS THIS
+│       └── Report
+│       → Orchestrator reads structure-summary.json, merges figmaNodes into state
+│
+├── Phase 2.5 — Pre-capture Reference Material ───────────────────────
+│   └── Skill: 5-precapture
+│       ├── curl → verify dev server
+│       ├── node browser-server.js & → shared Playwright WebSocket server
+│       ├── Build manifest files per route group
+│       ├── Dispatch parallel HAIKU subagents (one per route group):
+│       │   └── Each subagent:
+│       │       ├── node screenshot.js --batch {group}-screenshots.json
+│       │       ├── node extract-text.js --batch {group}-text.json
+│       │       └── Write precapture-{group}.json
+│       ├── Dispatch precapture-screens agent (full-page screenshots)
+│       └── → Orchestrator reads small precapture results, updates state
+│
+├── Phase 3 — Build Components (tier by tier) ────────────────────────
+│   └── Skill: 6-build-tier
+│       │
+│       ├── PREAMBLE: Icon & Asset Components
+│       │   └── Subagent (sonnet): icon preamble ← NEW dispatch
+│       │       ├── Read icons.json (SVG data — stays in subagent context only)
+│       │       ├── Read builtComponents.json (skip already-built)
+│       │       ├── use_figma → createNodeFromSvg per icon (~7/batch)
+│       │       ├── use_figma → createNodeFromSvg per SVG asset
+│       │       └── Write icon-preamble-results.json
+│       │       → Orchestrator reads results, merges into builtComponents
+│       │
+│       └── PER TIER (sequential — each tier depends on lower tiers):
+│           ├── Filter already-built components
+│           ├── Dispatch parallel OPUS subagents (one per component):
+│           │   └── Skill: 7-build-component (full 7-step workflow)
+│           │       ├── Step 1: Analyze (sonnet subagent → code.json)
+│           │       ├── Step 2: Build (opus inline → use_figma)
+│           │       ├── Step 3: Screenshot (get_screenshot → figma.png)
+│           │       ├── Step 4: Compare (haiku subagent → verdict)
+│           │       ├── Step 5: Fix Loop (opus subagent, fresh context, up to 3 iterations)
+│           │       ├── Step 6: Finalize tracking files
+│           │       └── Step 7: Write build-results/{ComponentName}.json
+│           │
+│           ├── node collect-tier-results.js ← NEW (replaces per-file reads)
+│           │   └── Reads all build-results, writes build-tier{N}.json, updates state
+│           └── CHECKPOINT with user before next tier
+│
+├── Phase 4 — Build Screens ──────────────────────────────────────────
+│   └── Skill: 8-build-screens (subagent-only mode)
+│       ├── Dispatch parallel OPUS subagents (one per screen):
+│       │   └── Each subagent:
+│       │       ├── Step 0: PREREQ GATE — verify all components exist
+│       │       ├── Step 1: Analyze screen (page source, computed styles)
+│       │       ├── Step 2: use_figma → build 1440×900 screen frame
+│       │       ├── Step 3: get_screenshot → figma.png
+│       │       ├── Step 4: Compare (sizing check + pixel diff)
+│       │       ├── Step 5: Fix loop (up to 3 iterations)
+│       │       ├── Step 6: Write figma-screen.json
+│       │       └── Step 7: Write build-results/screens/{screenName}.json
+│       │
+│       ├── node collect-screen-results.js ← NEW (replaces per-file reads)
+│       │   └── Reads all screen results, writes build-screens.json
+│       └── CHECKPOINT with user
+│
+└── Phase 5 — Validate + Fix ─────────────────────────────────────────
+    └── Subagent (opus): 9-validate
+        ├── Skill: 10-validator
+        │   ├── Phase 1: Inventory (use_figma → query components)
+        │   ├── Phase 1e: Variant resolution (use_figma)
+        │   ├── Phase 2: Screenshots (parallel SONNET subagents per tier)
+        │   │   └── Each: app screenshot + Figma screenshot + compare.js
+        │   ├── Phase 3: Structural checks (variables, pages, screens)
+        │   ├── Phase 4: Write report.md
+        │   └── Phase 5: Fix loop (up to 3 iterations, built-during-run only)
+        ├── use_figma → cleanup Components page layout (move strays, re-stack)
+        ├── kill browser-server.js
+        ├── Write validation-summary.json (~500B) ← ORCHESTRATOR READS THIS
+        └── Report
+        → Orchestrator reads validation-summary.json, presents final verdict
+```
+
+## Legend
+
+| Symbol             | Meaning                                                  |
+| ------------------ | -------------------------------------------------------- |
+| `HAIKU subagents`  | Pre-capture agents (fast, no judgment needed)            |
+| `OPUS subagents`   | Component + screen builds + validation (creative work)   |
+| `SONNET subagents` | Analysis, token setup, structure, icon preamble          |
+| `use_figma`        | Figma MCP plugin call (runs in subagents only)           |
+| `get_screenshot`   | Figma MCP screenshot (runs in subagents only)            |
+| `get_metadata`     | Figma MCP metadata (file-level, read-only)               |
+| `node *.js`        | Shell script (Playwright, pixel diff, result collection) |
+| `PREREQ GATE`      | Hard reject if child components missing                  |
+| `INSTANCE GATE`    | Hard reject if design-system instances missing           |
+| `CHECKPOINT`       | Pause for user confirmation                              |
+| `← NEW`            | Added in the context optimization refactor               |
+
+## Context budget
+
+| What the orchestrator reads         | Size      |
+| ----------------------------------- | --------- |
+| SKILL.md (this file)                | ~8KB      |
+| state.json                          | ~7KB      |
+| discovery-summary.json              | ~3KB      |
+| icons-summary.json                  | ~500B     |
+| tokens-summary.json                 | ~500B     |
+| structure-summary.json              | ~500B     |
+| collect-tier-results.js stdout (×6) | ~600B     |
+| collect-screen-results.js stdout    | ~100B     |
+| validation-summary.json             | ~500B     |
+| **Total data context**              | **~21KB** |
+
+Previous architecture loaded ~310KB of data into the orchestrator's context.

--- a/plugins/figma-from-code/skills/figma-setup-file-structure/SKILL.md
+++ b/plugins/figma-from-code/skills/figma-setup-file-structure/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: figma-setup-file-structure
+description: Create the project's Figma file page skeleton and foundations documentation frames. Run after figma-setup-variables and before component builds. This is Phase 2 of the code-to-Figma workflow.
+---
+
+# Skill: Set Up Figma File Structure
+
+Creates the page layout and foundations documentation for the project's Figma file. This is Phase 2 of the code-to-Figma workflow — it must run after variables exist (Phase 1) and before components are built (Phase 3).
+
+## When to Use
+
+After `figma-setup-variables` has created the variable collections, before starting component work.
+
+## Prerequisites
+
+- Variable collections (`Palette`, `Semantic`, `Spacing`) must already exist in the file
+- `figma:figma-use` skill MUST be loaded before any `use_figma` calls
+
+## Required Inputs
+
+- `fileKey`: The Figma file key
+
+## Page Structure to Create
+
+Rename/create pages in this exact order:
+
+| Page Name | Purpose |
+|-----------|---------|
+| `🎨 Foundations` | Color swatches, type specimens, spacing scale |
+| `📦 Components` | All component sets (built in Phase 3) |
+| `📄 Screens` | Assembled page screens (built in Phase 4) |
+
+If pages already exist with these names, skip creation.
+
+## Foundations Page Content
+
+On the `🎨 Foundations` page, create three documentation frames stacked vertically with 80px gaps. All content is driven by the Figma variables created in Phase 1 — never hardcode color values.
+
+### Frame 1: Color Palette (y=0)
+
+Name: `Color Palette`  
+Width: 1200, height: auto  
+Background: white  
+Padding: 48px all sides  
+Layout: VERTICAL, gap 40px
+
+**Building the palette dynamically:**
+1. Query all variables in the `Palette` collection via `figma.variables.getLocalVariablesAsync()`
+2. Group variables by color family (the prefix before the `/` in the variable name, e.g., `gray`, `teal`)
+3. For each color family, create a horizontal row:
+   - Scale label: Inter Semi Bold 12px, `#64748b`, width 60px (the family name)
+   - One swatch per step (50→950): 40×40px rectangle, cornerRadius 6, filled with the bound Palette variable
+   - Tooltip text below showing the step number
+
+### Frame 2: Semantic Colors (y = Frame1.height + 80)
+
+Name: `Semantic Colors`  
+Width: 1200, height: auto  
+Background: white, padding 48px, vertical layout gap 32px
+
+**Building semantic swatches dynamically:**
+1. Query all variables in the `Semantic` collection
+2. Group by the token's first path segment (e.g., `background`, `primary`, `border`, `sidebar`)
+3. For each group, create a horizontal row with a label and swatches
+4. Each swatch: 48×48px, cornerRadius 6, filled with the bound Semantic variable, label below (12px, `#64748b`, truncated to 14 chars)
+
+### Frame 3: Spacing Scale (y = Frame2.y + Frame2.height + 80)
+
+Name: `Spacing Scale`  
+Width: 1200, height: auto  
+Background: white, padding 48px, vertical layout gap 20px
+
+Title: "Spacing Scale" (Inter Bold 24px)
+
+Two sub-sections side by side (horizontal layout):
+
+**Spacing:**  
+Query all `spacing/*` variables from the `Spacing` collection. For each value:
+- Horizontal row: colored rectangle (width = value px, height 24px), label "spacing/{n} = {value}px" (Inter Regular 13px, `#334155`)
+
+**Border Radius:**  
+Query all `radius/*` variables from the `Spacing` collection. For each value:
+- Row: 32×32px white rectangle with border (`#e2e8f0`), cornerRadius = value, label "radius/{name} = {value}px"
+
+## How to Execute
+
+Load `figma:figma-use`, then work in small incremental `use_figma` calls:
+
+1. **Call 1** — Set up pages (rename existing Page 1, create Components and Screens if missing)
+2. **Call 2** — Create Color Palette frame (query Palette variables, build rows dynamically)
+3. **Call 3** — Continue Color Palette if needed (may require multiple calls for large palettes)
+4. **Call 4** — Create Semantic Colors frame (query Semantic variables, build rows dynamically)
+5. **Call 5** — Create Spacing Scale frame (query Spacing variables, build rows dynamically)
+6. **Call 6** — Screenshot all three frames for verification
+
+After each call, `return` the created node IDs and take an inline `screenshot()`.
+
+## Variable Binding in Swatches
+
+Bind swatch fills to variables rather than hardcoding hex values:
+
+```javascript
+const vars = await figma.variables.getLocalVariablesAsync();
+const colorVar = vars.find(v => v.name === "Palette/{family}/{step}");
+const swatch = figma.createRectangle();
+swatch.fills = [figma.variables.setBoundVariableForPaint(
+  { type: "SOLID", color: { r: 0, g: 0, b: 0 } }, "color", colorVar
+)];
+```
+
+## Feeds Into
+
+`figma:figma-generate-library` Phase 3 (components). The Components page must exist before components are placed on it. The Foundations page gives the library skill a reference for what tokens are available.

--- a/plugins/figma-from-code/skills/figma-setup-variables/SKILL.md
+++ b/plugins/figma-from-code/skills/figma-setup-variables/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: figma-setup-variables
+description: Extract design tokens from the project's CSS and Tailwind config and create Figma variable collections. Run this before figma:figma-generate-library so Phase 1 (tokens) is already done.
+---
+
+# Skill: Set Up Figma Variables from Code
+
+Extracts design tokens from the project's CSS and Tailwind configuration and creates Figma variable collections. This is Phase 1 of the code-to-Figma workflow — run it first so the library build can skip straight to components.
+
+## When to Use
+
+Before running `figma:figma-generate-library` on a fresh Figma file, or when design tokens have changed and Figma variables need syncing.
+
+## Required Inputs
+
+| Input | Description |
+|-------|-------------|
+| `fileKey` | The Figma file key |
+| `cssPath` | Path to the main CSS file containing custom properties (e.g., `src/index.css`) |
+| `tailwindConfigPath` (optional) | Path to the Tailwind config file (e.g., `tailwind.config.js`) |
+
+## Token Sources
+
+| File | What it contains |
+|------|-----------------|
+| `{cssPath}` | All CSS custom properties — palette colors and semantic aliases |
+| `{tailwindConfigPath}` | Color names mapped to CSS variables, border radius extensions (if using Tailwind) |
+
+## Token Discovery Process
+
+Rather than hardcoding token values, extract them dynamically from the project files:
+
+1. **Read the CSS file** and parse all `--variable-name: value` declarations from `:root` or theme blocks
+2. **Categorize variables** into:
+   - **Palette colors**: Raw color scales (e.g., `--gray-50` through `--gray-950`) — group by color family
+   - **Semantic tokens**: Aliases that reference palette colors or define contextual colors (e.g., `--background`, `--primary`, `--foreground`)
+   - **Spacing/sizing**: Numeric values for radius, spacing, gaps
+3. **If Tailwind config exists**, read it to discover:
+   - Color name mappings to CSS variables
+   - Border radius extensions
+   - Spacing scale extensions
+
+## Collections to Create
+
+### 1. `Palette` (mode: `Value`)
+Raw color scales extracted from CSS — scopes set to `[]` (hidden from property pickers, used only for aliasing).
+
+Groups are discovered dynamically from CSS variable naming patterns (e.g., `--{color}-{step}` where step is 50→950).
+
+### 2. `Semantic` (mode: `Light`)
+Alias tokens that components bind to — scopes set appropriately based on usage:
+
+| Token pattern | Scope |
+|--------------|-------|
+| `background`, `card/*`, `popover/*`, `sidebar/*` fills | `FRAME_FILL, SHAPE_FILL` |
+| `foreground`, `*-foreground` | `TEXT_FILL` |
+| `border/*`, `ring/*`, `outline/*` | `STROKE_COLOR` |
+
+Where a semantic token's value maps to a palette variable, create an alias reference. Where it's a standalone hex value, use a direct color.
+
+### 3. `Spacing` (mode: `Value`)
+Float variables extracted from CSS or Tailwind config. Radius scope: `CORNER_RADIUS`. Spacing scope: `GAP, WIDTH_HEIGHT`.
+
+## How to Execute
+
+Load `figma:figma-use` (mandatory), then write a `use_figma` script that:
+1. Creates each collection with the correct mode name
+2. Creates variables in the correct order (Palette first, then Semantic aliases)
+3. Sets `scopes` explicitly on every variable — never leave as `ALL_SCOPES`
+4. Sets WEB code syntax: `var(--variable-name)` matching the CSS variable name
+
+Work in batches of ~50 variables per call to stay under the incremental limit.
+
+## Feeds Into
+
+`figma:figma-generate-library` Phase 1. Once this runs, tell the library skill that token collections already exist so it can proceed directly to Phase 2 (file structure) and Phase 3 (components).

--- a/plugins/figma-from-code/workflows/figma-from-code.js
+++ b/plugins/figma-from-code/workflows/figma-from-code.js
@@ -1,0 +1,1266 @@
+export const meta = {
+  name: 'figma-from-code',
+  description: 'Rebuild Figma file from codebase — discover, tokenize, build components, assemble screens, validate',
+  whenToUse: 'When the user wants to run the figma-from-code pipeline as a workflow with parallel execution and progress tracking',
+  phases: [
+    { title: 'Hydrate', detail: 'Load state from prior phases (when starting mid-pipeline)' },
+    { title: 'Discovery', detail: 'Browser crawl + icon scan (parallel)' },
+    { title: 'Normalize', detail: 'Align component names with Figma conventions' },
+    { title: 'Setup', detail: 'Tokens + file structure (parallel)' },
+    { title: 'Pre-capture', detail: 'Screenshot all components and screens' },
+    { title: 'Build Icons', detail: 'Create icon/asset components from SVG' },
+    { title: 'Build Components', detail: 'Per-component builds, tiers sequential, all components within a tier in parallel' },
+    { title: 'Build Screens', detail: 'Compose screens from built components (parallel)' },
+    { title: 'Validate', detail: 'Compare Figma vs app, fix mismatches' },
+  ],
+}
+
+// Where the figma-from-code skill tree is installed in the consuming project.
+// Override via args.skillDir if you place it elsewhere. The orchestrator points
+// subagents at `${SKILL}/<stage>/SKILL.md` and runs `node ${SKILL}/<stage>/<script>.js`,
+// so this must resolve (relative to the project root) to the copied skill tree.
+const SKILL = (typeof args !== 'undefined' && args && args.skillDir) || '.claude/skills/figma-from-code'
+const TEMP = '.temp/figma-from-code'
+
+// Model policy (per-agent `model:` opt; omitting it inherits the session model = opus):
+//   opus   — build, fix, screen, validate, discover-components. Vision/codegen/tier-graph
+//            reasoning where a weaker model measurably hurts quality.
+//   sonnet — analyze, compare, and the mechanical-but-non-trivial setup/discovery agents
+//            (setup-*, precapture, discover-assets, icon-preamble, tier-frame).
+//   haiku  — pure file I/O / shell wrappers with no judgment (hydrate-state, materialize-*,
+//            normalize, collect-tier, update-state-*, cleanup).
+// Keep this in sync when adding agents; don't silently leave bookkeeping agents on opus.
+
+const PHASE_ORDER = [
+  'phase0a', 'phase0b', 'phase1', 'phase2', 'phase2_5', 'phase3', 'phase4', 'phase5'
+]
+
+const WAVE_MEMBERS = {
+  wave1: ['phase0a', 'phase0b'],
+  wave2: ['phase1', 'phase2'],
+  wave3: ['phase2_5'],
+  wave4: ['phase3'],
+  wave5: ['phase4'],
+  wave6: ['phase5'],
+}
+
+function shouldRunPhase(phaseId, startPhase, endPhase) {
+  const idx = PHASE_ORDER.indexOf(phaseId)
+  const startIdx = startPhase ? PHASE_ORDER.indexOf(startPhase) : 0
+  const endIdx = endPhase ? PHASE_ORDER.indexOf(endPhase) : PHASE_ORDER.length - 1
+  return idx >= startIdx && idx <= endIdx
+}
+
+function shouldRunWave(waveName, startPhase, endPhase) {
+  return WAVE_MEMBERS[waveName].some(p => shouldRunPhase(p, startPhase, endPhase))
+}
+
+// --- Schemas ---
+
+const HYDRATION_SCHEMA = {
+  type: 'object',
+  properties: {
+    fileKey: { type: 'string' },
+    tiers: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          tier: { type: 'number' },
+          label: { type: 'string' },
+          components: { type: 'array', items: { type: 'string' } }
+        },
+        required: ['tier', 'label', 'components']
+      }
+    },
+    builtComponents: { type: 'object', additionalProperties: { type: 'string' } },
+    preExistingComponents: { type: 'object', additionalProperties: { type: 'string' } },
+    preExistingScreens: { type: 'object', additionalProperties: { type: 'string' } },
+    existingCollections: { type: 'array', items: { type: 'string' } },
+    existingPages: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: { name: { type: 'string' }, id: { type: 'string' } },
+        required: ['name', 'id']
+      }
+    },
+    figmaNodes: { type: 'object', additionalProperties: { type: 'string' } },
+    screens: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          screenName: { type: 'string' },
+          route: { type: 'string' },
+          pageSourceFile: { type: 'string' },
+          keyComponents: { type: 'array', items: { type: 'string' } }
+        },
+        required: ['screenName', 'route']
+      }
+    }
+  },
+  required: ['fileKey', 'tiers', 'builtComponents', 'figmaNodes']
+}
+
+const DISCOVERY_SCHEMA = {
+  type: 'object',
+  properties: {
+    success: { type: 'boolean' },
+    componentCount: { type: 'number' },
+    tierCount: { type: 'number' },
+    tiers: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          tier: { type: 'number' },
+          label: { type: 'string' },
+          components: { type: 'array', items: { type: 'string' } }
+        },
+        required: ['tier', 'label', 'components']
+      }
+    },
+    builtComponents: { type: 'object', additionalProperties: { type: 'string' } },
+    preExistingComponents: { type: 'object', additionalProperties: { type: 'string' } },
+    preExistingScreens: { type: 'object', additionalProperties: { type: 'string' } },
+    existingCollections: { type: 'array', items: { type: 'string' } },
+    existingPages: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: { name: { type: 'string' }, id: { type: 'string' } },
+        required: ['name', 'id']
+      }
+    }
+  },
+  required: ['success', 'tierCount', 'tiers']
+}
+
+const ASSETS_SCHEMA = {
+  type: 'object',
+  properties: {
+    success: { type: 'boolean' },
+    iconCount: { type: 'number' },
+    assetCount: { type: 'number' },
+    icons: { type: 'array', items: { type: 'string' } },
+    assets: { type: 'array', items: { type: 'string' } }
+  },
+  required: ['success', 'iconCount']
+}
+
+const NORMALIZE_SCHEMA = {
+  type: 'object',
+  properties: {
+    success: { type: 'boolean' },
+    renameCount: { type: 'number' },
+    updatedTiers: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          tier: { type: 'number' },
+          label: { type: 'string' },
+          components: { type: 'array', items: { type: 'string' } }
+        },
+        required: ['tier', 'label', 'components']
+      }
+    }
+  },
+  required: ['success']
+}
+
+const TOKENS_SCHEMA = {
+  type: 'object',
+  properties: {
+    success: { type: 'boolean' },
+    variableCount: { type: 'number' },
+    collections: { type: 'array', items: { type: 'string' } },
+    variableMapPath: { type: 'string' }
+  },
+  required: ['success']
+}
+
+const STRUCTURE_SCHEMA = {
+  type: 'object',
+  properties: {
+    success: { type: 'boolean' },
+    foundationsPageId: { type: 'string' },
+    componentsPageId: { type: 'string' },
+    screensPageId: { type: 'string' },
+    foundationsFrameId: { type: 'string' },
+    iconsFrameId: { type: 'string' },
+    screensFrameId: { type: 'string' }
+  },
+  required: ['success', 'componentsPageId', 'iconsFrameId', 'screensFrameId']
+}
+
+const PRECAPTURE_SCHEMA = {
+  type: 'object',
+  properties: {
+    success: { type: 'boolean' },
+    componentsCaptured: { type: 'number' },
+    screensCaptured: { type: 'number' },
+    skipped: { type: 'number' },
+    failed: { type: 'number' },
+    screens: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          screenName: { type: 'string' },
+          route: { type: 'string' },
+          pageSourceFile: { type: 'string' },
+          keyComponents: { type: 'array', items: { type: 'string' } }
+        },
+        required: ['screenName', 'route']
+      }
+    }
+  },
+  required: ['success']
+}
+
+const PREAMBLE_SCHEMA = {
+  type: 'object',
+  properties: {
+    success: { type: 'boolean' },
+    created: { type: 'object', additionalProperties: { type: 'string' } },
+    totalCreated: { type: 'number' },
+    totalSkipped: { type: 'number' },
+    totalFailed: { type: 'number' }
+  },
+  required: ['success', 'created']
+}
+
+const COMPONENT_RESULT_SCHEMA = {
+  type: 'object',
+  properties: {
+    componentName: { type: 'string' },
+    status: { type: 'string', enum: ['built', 'partial_match', 'needs_authorization', 'rejected', 'failed'] },
+    nodeId: { type: 'string' },
+    verdict: { type: 'string' },
+    matchPct: { type: 'number' },
+    iterations: { type: 'number' }
+  },
+  required: ['componentName', 'status']
+}
+
+const ANALYZE_SCHEMA = {
+  type: 'object',
+  properties: {
+    componentName: { type: 'string' },
+    status: { type: 'string', enum: ['proceed', 'needs_authorization', 'rejected', 'failed'] },
+    sourceFile: { type: 'string' },
+    sourceDir: { type: 'string' },
+    route: { type: 'string' },
+    selector: { type: 'string' },
+    hasVariants: { type: 'boolean' },
+    liveInspection: { type: 'string' },
+    missingChildren: { type: 'array', items: { type: 'string' } }
+  },
+  required: ['componentName', 'status']
+}
+
+const BUILD_SCHEMA = {
+  type: 'object',
+  properties: {
+    componentName: { type: 'string' },
+    status: { type: 'string', enum: ['built', 'failed'] },
+    reason: { type: 'string' },
+    nodeId: { type: 'string' },
+    screenshotNodeId: { type: 'string' },
+    type: { type: 'string' },
+    variants: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: { name: { type: 'string' }, nodeId: { type: 'string' } },
+        required: ['name']
+      }
+    }
+  },
+  required: ['componentName', 'status']
+}
+
+const COMPARE_SCHEMA = {
+  type: 'object',
+  properties: {
+    componentName: { type: 'string' },
+    nodeId: { type: 'string' },
+    verdict: { type: 'string' },
+    matchPct: { type: 'number' },
+    borderMatchPct: { type: 'number' },
+    needsFix: { type: 'boolean' },
+    missingInstances: { type: 'array', items: { type: 'string' } }
+  },
+  required: ['componentName', 'verdict', 'needsFix']
+}
+
+const TIER_FRAME_SCHEMA = {
+  type: 'object',
+  properties: {
+    success: { type: 'boolean' },
+    tier: { type: 'number' },
+    tierFrameId: { type: 'string' }
+  },
+  required: ['success', 'tierFrameId']
+}
+
+const SCREEN_SCHEMA = {
+  type: 'object',
+  properties: {
+    screenName: { type: 'string' },
+    status: { type: 'string', enum: ['built', 'rejected', 'needs_authorization', 'failed'] },
+    nodeId: { type: 'string' },
+    verdict: { type: 'string' },
+    matchPct: { type: 'number' },
+    missingComponents: { type: 'array', items: { type: 'string' } }
+  },
+  required: ['screenName', 'status']
+}
+
+const VALIDATION_SCHEMA = {
+  type: 'object',
+  properties: {
+    success: { type: 'boolean' },
+    fileKey: { type: 'string' },
+    componentsCompared: { type: 'number' },
+    comparable: { type: 'number' },
+    match: { type: 'number' },
+    minorDiff: { type: 'number' },
+    mismatch: { type: 'number' },
+    noAppReference: { type: 'number' },
+    matchRate: { type: 'number' },
+    fixedDuringValidation: { type: 'number' },
+    averageMatchPct: { type: 'number' },
+    overallVerdict: { type: 'string' },
+    reportPath: { type: 'string' }
+  },
+  required: ['success', 'overallVerdict']
+}
+
+const STATE_UPDATE_SCHEMA = {
+  type: 'object',
+  properties: { success: { type: 'boolean' } },
+  required: ['success']
+}
+
+// --- Args ---
+
+const {
+  fileKey,                                   // REQUIRED — the target Figma file key (no default)
+  sourceDir = 'src/',                        // component/source root, relative to project root
+  devServerUrl = 'http://localhost:5173',    // running dev server (Vite default; override per project)
+  startPhase = 'phase3',
+  endPhase = null
+} = args || {}
+
+if (!fileKey) {
+  log('ERROR: fileKey is required. Pass it via args: { fileKey: "your-file-key" }')
+  return { error: 'fileKey is required' }
+}
+
+// Validate phase args up front — a typo would otherwise make indexOf return -1,
+// silently running the entire pipeline (startPhase) or nothing at all (endPhase).
+if (startPhase && PHASE_ORDER.indexOf(startPhase) === -1) {
+  log('ERROR: invalid startPhase "' + startPhase + '". Valid phases: ' + PHASE_ORDER.join(', '))
+  return { error: 'invalid startPhase: ' + startPhase }
+}
+if (endPhase && PHASE_ORDER.indexOf(endPhase) === -1) {
+  log('ERROR: invalid endPhase "' + endPhase + '". Valid phases: ' + PHASE_ORDER.join(', '))
+  return { error: 'invalid endPhase: ' + endPhase }
+}
+if (startPhase && endPhase && PHASE_ORDER.indexOf(endPhase) < PHASE_ORDER.indexOf(startPhase)) {
+  log('ERROR: endPhase "' + endPhase + '" precedes startPhase "' + startPhase + '"')
+  return { error: 'endPhase precedes startPhase' }
+}
+
+const needsHydration = startPhase && startPhase !== 'phase0a'
+
+// --- Mutable orchestration state ---
+
+let tiers = []
+let builtComponents = {}
+let preExistingComponents = {}
+let preExistingScreens = {}
+let existingCollections = []
+let existingPages = []
+let figmaNodes = {}
+let screens = []
+
+// --- Run-wide failure tracking (surfaced in the final summary) ---
+
+let failedComponents = []
+let skippedTiers = []
+let failedScreens = []
+let validationVerdict = null
+
+// --- Helpers ---
+
+// Retry an agent-producing thunk until isOk(result) is true or attempts run out.
+// Used ONLY for idempotent infrastructure agents (frame creation, registry writes,
+// result collection) whose transient failure has outsized downstream blast radius.
+async function withRetry(label, attempts, isOk, fn) {
+  let result = null
+  for (let i = 1; i <= attempts; i++) {
+    result = await fn()
+    if (isOk(result)) return result
+    if (i < attempts) log('  retry ' + i + '/' + (attempts - 1) + ' — ' + label)
+  }
+  return result
+}
+
+const STAGE_DIR = SKILL + '/7-build-component/prompts/stages'
+
+function analyzePrompt(componentName) {
+  return [
+    'Stage 1 (analyze) for the Figma component "' + componentName + '".',
+    '',
+    'Read and follow ONLY: ' + STAGE_DIR + '/analyze.md',
+    '',
+    'Inputs:',
+    '  {componentName} = ' + componentName,
+    '  {fileKey}       = ' + fileKey,
+    '  {devServerUrl}  = ' + devServerUrl,
+    '',
+    'Resolve {sourceFile}/{sourceDir} from ' + TEMP + '/component-map.json. Read ' + TEMP + '/builtComponents.json and state.json -> preExistingComponents for the gates.',
+    'Write code.json to {sourceDir}/.figma/code.json. Do NOT call use_figma.',
+    'Return: componentName, status, sourceFile, sourceDir, route, selector, hasVariants, liveInspection, missingChildren.',
+  ].join('\n')
+}
+
+function buildStagePrompt(componentName, tierDef, parentFrameId, sourceDir) {
+  return [
+    'Stage 2 (build) for the Figma component "' + componentName + '".',
+    '',
+    'Read and follow ONLY: ' + STAGE_DIR + '/build.md',
+    '',
+    'Inputs:',
+    '  {componentName} = ' + componentName,
+    '  {fileKey}       = ' + fileKey,
+    '  {parentFrameId} = ' + parentFrameId + '   (the Tier ' + tierDef.tier + ' frame — build INTO this node)',
+    '  {sourceDir}     = ' + sourceDir + '   (holds .figma/code.json from stage 1)',
+    '  {screenshotDir} = ' + TEMP + '/screenshots/' + componentName + '/',
+    '',
+    'Build fresh into {parentFrameId}; never reuse an off-page master. Write .figma/figma.json and capture figma.png.',
+    'Return: componentName, status, reason, nodeId, screenshotNodeId, type, variants.',
+  ].join('\n')
+}
+
+function comparePrompt(componentName, sourceDir, nodeId, screenshotNodeId) {
+  return [
+    'Stage 3 (compare) for the Figma component "' + componentName + '".',
+    '',
+    'Read and follow ONLY: ' + STAGE_DIR + '/compare.md',
+    '',
+    'Inputs:',
+    '  {componentName}     = ' + componentName,
+    '  {fileKey}           = ' + fileKey,
+    '  {sourceDir}         = ' + sourceDir,
+    '  {nodeId}            = ' + nodeId,
+    '  {screenshotNodeId}  = ' + screenshotNodeId,
+    '  {screenshotDir}     = ' + TEMP + '/screenshots/' + componentName + '/',
+    '',
+    'Run 4a/4b/4c, finalize tracking, and write ' + TEMP + '/build-results/' + componentName + '.json. Do NOT fix.',
+    'Return: componentName, nodeId, verdict, matchPct, borderMatchPct, needsFix, missingInstances.',
+  ].join('\n')
+}
+
+function fixPrompt(componentName, sourceFile, sourceDir, nodeId, screenshotNodeId, verdict, missingInstances) {
+  return [
+    'Stage 4 (fix) for the Figma component "' + componentName + '". The compare stage flagged a non-passing verdict.',
+    '',
+    'Read and follow ONLY: ' + STAGE_DIR + '/fix.md',
+    '',
+    'Inputs:',
+    '  {componentName}     = ' + componentName,
+    '  {fileKey}           = ' + fileKey,
+    '  {sourceFile}        = ' + sourceFile,
+    '  {sourceDir}         = ' + sourceDir,
+    '  {nodeId}            = ' + nodeId,
+    '  {screenshotNodeId}  = ' + screenshotNodeId,
+    '  {verdict}           = ' + verdict,
+    '  {missingInstances}  = ' + JSON.stringify(missingInstances || []),
+    '  {screenshotDir}     = ' + TEMP + '/screenshots/' + componentName + '/',
+    '',
+    'Run the fix loop (<=3 iterations), re-finalize tracking, and OVERWRITE ' + TEMP + '/build-results/' + componentName + '.json.',
+    'Return: componentName, status, nodeId, verdict, matchPct, iterations.',
+  ].join('\n')
+}
+
+// Runs the 4-stage chain (analyze → build → compare → fix) for one component
+// sequentially. Returns a COMPONENT_RESULT_SCHEMA-shaped object. The caller runs
+// these chains concurrently across a tier; the runtime's global concurrency cap
+// (min(16, cores-2)) bounds how many use_figma build stages run at once.
+async function buildOneComponent(componentName, tierDef, parentFrameId) {
+  const analysis = await agent(
+    analyzePrompt(componentName),
+    { label: 'analyze-' + componentName, phase: 'Build Components', model: 'sonnet', schema: ANALYZE_SCHEMA }
+  )
+  if (!analysis || analysis.status !== 'proceed') {
+    return {
+      componentName: componentName,
+      status: (analysis && analysis.status) || 'failed',
+      verdict: 'not_built',
+      matchPct: 0,
+      iterations: 0
+    }
+  }
+
+  const built = await agent(
+    buildStagePrompt(componentName, tierDef, parentFrameId, analysis.sourceDir),
+    { label: 'build-' + componentName, phase: 'Build Components', schema: BUILD_SCHEMA }
+  )
+  if (!built || built.status !== 'built' || !built.nodeId) {
+    return {
+      componentName: componentName,
+      status: 'failed',
+      verdict: (built && built.reason) || 'build_failed',
+      matchPct: 0,
+      iterations: 0
+    }
+  }
+
+  const compared = await agent(
+    comparePrompt(componentName, analysis.sourceDir, built.nodeId, built.screenshotNodeId || built.nodeId),
+    { label: 'compare-' + componentName, phase: 'Build Components', model: 'sonnet', schema: COMPARE_SCHEMA }
+  )
+
+  if (!compared || !compared.needsFix) {
+    return {
+      componentName: componentName,
+      status: 'built',
+      nodeId: built.nodeId,
+      verdict: (compared && compared.verdict) || 'no_app_reference',
+      matchPct: (compared && compared.matchPct) ?? 0,
+      iterations: 0
+    }
+  }
+
+  const fixed = await agent(
+    fixPrompt(componentName, analysis.sourceFile, analysis.sourceDir, built.nodeId, built.screenshotNodeId || built.nodeId, compared.verdict, compared.missingInstances),
+    { label: 'fix-' + componentName, phase: 'Build Components', schema: COMPONENT_RESULT_SCHEMA }
+  )
+  return {
+    componentName: componentName,
+    status: (fixed && fixed.status) || 'partial_match',
+    nodeId: (fixed && fixed.nodeId) || built.nodeId,
+    verdict: (fixed && fixed.verdict) || compared.verdict,
+    matchPct: (fixed && fixed.matchPct) ?? compared.matchPct ?? 0,
+    iterations: (fixed && fixed.iterations) ?? 0
+  }
+}
+
+// === STATE HYDRATION (when starting mid-pipeline) ===
+
+if (needsHydration) {
+  phase('Hydrate')
+  log('Starting mid-pipeline — hydrating state from prior phases')
+
+  const hydrated = await agent(
+    [
+      'Read the figma-from-code state files and return all orchestration data.',
+      '',
+      'Read these files from .temp/figma-from-code/:',
+      '  - state.json (main state ledger)',
+      '  - discovery-summary.json (build order and component counts)',
+      '  - precapture-screens.json (screen list, if it exists)',
+      '',
+      'From state.json, extract and return:',
+      '  - fileKey',
+      '  - buildOrder.tiers as tiers',
+      '  - builtComponents',
+      '  - preExistingComponents',
+      '  - preExistingScreens',
+      '  - existingCollections',
+      '  - existingPages',
+      '  - figmaNodes',
+      '',
+      'From precapture-screens.json (if it exists), extract the screen list.',
+      'Each screen needs: screenName, route, pageSourceFile, keyComponents.',
+      'If precapture-screens.json does not exist, return screens as an empty array.',
+      '',
+      'If state.json does not exist, return { fileKey: "", tiers: [], builtComponents: {}, figmaNodes: {} }',
+      'to signal that prior phases have not been run.',
+    ].join('\n'),
+    { label: 'hydrate-state', phase: 'Hydrate', model: 'haiku', schema: HYDRATION_SCHEMA }
+  )
+
+  if (!hydrated || !hydrated.fileKey || !Array.isArray(hydrated.tiers) || hydrated.tiers.length === 0) {
+    log('ERROR: No state found (or hydration was skipped). Run from phase0a first, or use the skill orchestrator.')
+    return { error: 'No state.json found — cannot start from ' + startPhase }
+  }
+
+  tiers = hydrated.tiers
+  builtComponents = hydrated.builtComponents || {}
+  preExistingComponents = hydrated.preExistingComponents || {}
+  preExistingScreens = hydrated.preExistingScreens || {}
+  existingCollections = hydrated.existingCollections || []
+  existingPages = hydrated.existingPages || []
+  figmaNodes = hydrated.figmaNodes || {}
+  screens = hydrated.screens || []
+
+  log('Hydrated: ' + tiers.length + ' tiers, ' + Object.keys(builtComponents).length + ' built components, ' + Object.keys(figmaNodes).length + ' figma nodes')
+
+  // Wave 5 (screens) reads builtComponents.json FROM DISK. Hydration loads the
+  // registry into memory only, so a resume starting at/after Phase 3 would leave a
+  // stale/missing on-disk registry and screens would build blind. Materialize it now.
+  await agent(
+    [
+      'Write the hydrated builtComponents registry to disk so downstream build/screen agents read the correct registry.',
+      '',
+      'Write this JSON to ' + TEMP + '/builtComponents.json:',
+      JSON.stringify(builtComponents),
+    ].join('\n'),
+    { label: 'materialize-built-hydrate', phase: 'Hydrate', model: 'haiku', schema: STATE_UPDATE_SCHEMA }
+  )
+}
+
+// === WAVE 1: Discovery (parallel) ===
+
+if (shouldRunWave('wave1', startPhase, endPhase)) {
+  phase('Discovery')
+  log('Wave 1: Discovering components and assets in parallel')
+
+  const [discovery, assets] = await parallel([
+    () => agent(
+      [
+        'Discover the complete component architecture by browser crawling the running dev server and static code scanning. Also inspect the Figma file for existing components, pages, and variable collections.',
+        '',
+        'Read and follow the skill instructions at: ' + SKILL + '/1-discovery-components/SKILL.md',
+        'Figma file key: ' + fileKey,
+        'Source directory: ' + sourceDir,
+        'Dev server URL: ' + devServerUrl,
+        '',
+        'Write component-map.json and discovery-summary.json to ' + TEMP + '/',
+        'Initialize state.json in ' + TEMP + '/ with the state ledger template from the orchestrator skill.',
+        '',
+        'Return: success, componentCount, tierCount, tiers (with tier/label/components), builtComponents, preExistingComponents, preExistingScreens, existingCollections, existingPages.',
+      ].join('\n'),
+      { label: 'discover-components', phase: 'Discovery', schema: DISCOVERY_SCHEMA }
+    ),
+
+    () => agent(
+      [
+        'Discover all Lucide icons and SVG assets imported across the codebase via static code analysis.',
+        '',
+        'Read and follow the skill instructions at: ' + SKILL + '/2-discovery-assets/SKILL.md',
+        'Source directory: ' + sourceDir,
+        '',
+        'Write icons.json and icons-summary.json to ' + TEMP + '/',
+        '',
+        'Return: success, iconCount, assetCount, icons (list of icon names), assets (list of asset names).',
+      ].join('\n'),
+      { label: 'discover-assets', phase: 'Discovery', model: 'sonnet', schema: ASSETS_SCHEMA }
+    ),
+  ])
+
+  if (!discovery || !discovery.success) {
+    log('ERROR: Component discovery failed')
+    return { error: 'Phase 0a (component discovery) failed', details: discovery }
+  }
+  if (!assets || !assets.success) {
+    log('ERROR: Asset discovery failed')
+    return { error: 'Phase 0b (asset discovery) failed', details: assets }
+  }
+
+  tiers = discovery.tiers || []
+  builtComponents = discovery.builtComponents || {}
+  preExistingComponents = discovery.preExistingComponents || {}
+  preExistingScreens = discovery.preExistingScreens || {}
+  existingCollections = discovery.existingCollections || []
+  existingPages = discovery.existingPages || []
+
+  log('Discovered ' + (discovery.componentCount || 0) + ' components across ' + discovery.tierCount + ' tiers')
+  log('Found ' + assets.iconCount + ' icons, ' + (assets.assetCount || 0) + ' assets')
+
+  // --- Normalization (needs both 0a + 0b) ---
+  phase('Normalize')
+  log('Running component name normalization')
+
+  const normResult = await agent(
+    [
+      'Run the component name normalization script to align scanner names with Figma conventions, re-read the updated discovery-summary.json, persist the Phase 0a + 0b results to the state ledger, and return the refreshed build order.',
+      '',
+      'Run this command:',
+      '  node ' + SKILL + '/1-discovery-components/normalize-component-map.js ' + TEMP + '/component-map.json ' + TEMP + '/icons.json --write',
+      '',
+      'After the script completes, read ' + TEMP + '/discovery-summary.json (it was regenerated by the script) and extract the updated tiers from the buildOrder field.',
+      '',
+      'Then update ' + TEMP + '/state.json (read it, merge these fields, write it back):',
+      '  phases.phase0a: "complete"',
+      '  phases.phase0b: "complete"',
+      '  buildOrder: { tierCount: <count of updated tiers>, tiers: <updated tiers from discovery-summary.json> }',
+      '  builtComponents: ' + JSON.stringify(builtComponents),
+      '  preExistingComponents: ' + JSON.stringify(preExistingComponents),
+      '  preExistingScreens: ' + JSON.stringify(preExistingScreens),
+      '  existingCollections: ' + JSON.stringify(existingCollections),
+      '  existingPages: ' + JSON.stringify(existingPages),
+      '',
+      'Return: success, renameCount (from script stdout), updatedTiers (the refreshed tiers array).',
+    ].join('\n'),
+    { label: 'normalize', phase: 'Normalize', model: 'haiku', schema: NORMALIZE_SCHEMA }
+  )
+
+  if (normResult && normResult.updatedTiers && normResult.updatedTiers.length > 0) {
+    tiers = normResult.updatedTiers
+  }
+  log('Normalization: ' + (normResult ? normResult.renameCount || 0 : 0) + ' components renamed')
+}
+
+// === WAVE 2: Tokens + Structure (parallel) ===
+
+if (shouldRunWave('wave2', startPhase, endPhase)) {
+  phase('Setup')
+  log('Wave 2: Setting up tokens and file structure in parallel')
+
+  const [tokens, structure] = await parallel([
+    () => agent(
+      [
+        'Create Figma variable collections (Palette, Semantic, Spacing) and extract the CSS-to-Figma variable map.',
+        '',
+        'Read and follow the skill instructions at: ' + SKILL + '/3-setup-tokens/SKILL.md',
+        'Figma file key: ' + fileKey,
+        'Existing collections (skip if already present): ' + JSON.stringify(existingCollections),
+        '',
+        'Write tokens-summary.json and variables.json to ' + TEMP + '/',
+        'Update state.json: set phases.phase1 to "complete" and variableMapPath.',
+        '',
+        'Return: success, variableCount, collections (list of collection names), variableMapPath.',
+      ].join('\n'),
+      { label: 'setup-tokens', phase: 'Setup', model: 'sonnet', schema: TOKENS_SCHEMA }
+    ),
+
+    () => agent(
+      [
+        'Create the Figma file page skeleton (Foundations, Components, Screens pages) and container frames (Icons frame, Screens frame).',
+        '',
+        'Read and follow the skill instructions at: ' + SKILL + '/4-setup-structure/SKILL.md',
+        'Figma file key: ' + fileKey,
+        'Existing pages (skip if already present): ' + JSON.stringify(existingPages),
+        '',
+        'Create ONLY the page skeleton and container frames: the three pages, an empty Foundations container frame, the Icons frame, and the Screens frame. Do NOT build the Foundations documentation content (Color Palette / Semantic Colors / Spacing Scale swatches) — that depends on the Phase 1 variables and is built in a dedicated step after this one.',
+        '',
+        'Write structure-summary.json to ' + TEMP + '/',
+        'Update state.json: set phases.phase2 to "complete" and all figmaNodes page/frame IDs.',
+        '',
+        'Return: success, foundationsPageId, componentsPageId, screensPageId, foundationsFrameId, iconsFrameId, screensFrameId.',
+      ].join('\n'),
+      { label: 'setup-structure', phase: 'Setup', model: 'sonnet', schema: STRUCTURE_SCHEMA }
+    ),
+  ])
+
+  if (!tokens || !tokens.success) {
+    log('ERROR: Token setup failed')
+    return { error: 'Phase 1 (tokens) failed', details: tokens }
+  }
+  if (!structure || !structure.success) {
+    log('ERROR: File structure setup failed')
+    return { error: 'Phase 2 (file structure) failed', details: structure }
+  }
+
+  figmaNodes = {
+    ...figmaNodes,
+    foundationsPageId: structure.foundationsPageId,
+    componentsPageId: structure.componentsPageId,
+    screensPageId: structure.screensPageId,
+    foundationsFrameId: structure.foundationsFrameId,
+    iconsFrameId: structure.iconsFrameId,
+    screensFrameId: structure.screensFrameId,
+  }
+
+  log('Tokens: ' + (tokens.variableCount || 0) + ' variables in ' + (tokens.collections || []).join(', '))
+  log('Structure: pages and frames created')
+
+  // Foundations documentation (color swatches, semantic colors, spacing scale)
+  // depends on the Phase 1 variables, so it CANNOT live inside the parallel
+  // structure agent above — that races tokens and sees no variables yet,
+  // leaving an empty placeholder frame that nothing ever fills. Build it here,
+  // after the Wave 2 barrier, now that the Palette/Semantic/Spacing collections
+  // exist and the Foundations container frame has been created.
+  const FOUNDATIONS_DOCS_SCHEMA = {
+    type: 'object',
+    properties: {
+      success: { type: 'boolean' },
+      framesCreated: { type: 'array', items: { type: 'string' } },
+      swatchesCreated: { type: 'number' },
+    },
+    required: ['success'],
+  }
+
+  const foundationsDocs = await agent(
+    [
+      'Build the Foundations documentation frames — Color Palette, Semantic Colors, and Spacing Scale — on the Foundations page, now that the Phase 1 variable collections exist. Bind every swatch fill to its Figma variable; never hardcode hex values.',
+      '',
+      'First invoke the figma:figma-use skill (mandatory before any use_figma call).',
+      'Read and follow the "Foundations Page Content" section of: .claude/skills/figma-setup-file-structure/SKILL.md',
+      '',
+      'Figma file key: ' + fileKey,
+      'Foundations page ID: ' + (figmaNodes.foundationsPageId || ''),
+      'Foundations container frame (build the documentation frames inside/below it; do not duplicate it): ' + (figmaNodes.foundationsFrameId || ''),
+      'Variable collections available: ' + JSON.stringify(tokens.collections || ['Palette', 'Semantic', 'Spacing']),
+      '',
+      'Query the Palette/Semantic/Spacing variables via figma.variables.getLocalVariablesAsync() and build the three frames dynamically as the skill specifies.',
+      'Be idempotent: if non-empty Color Palette / Semantic Colors / Spacing Scale frames already exist on the page, skip rebuilding them.',
+      '',
+      'Return: success, framesCreated (frame names), swatchesCreated (count).',
+    ].join('\n'),
+    { label: 'setup-foundations-docs', phase: 'Setup', model: 'sonnet', schema: FOUNDATIONS_DOCS_SCHEMA }
+  )
+
+  if (foundationsDocs && foundationsDocs.success) {
+    log('Foundations docs: ' + (foundationsDocs.framesCreated || []).join(', ') + ' (' + (foundationsDocs.swatchesCreated || 0) + ' swatches)')
+  } else {
+    log('WARNING: Foundations documentation step did not complete — color/spacing docs may be missing')
+  }
+}
+
+// === WAVE 3: Pre-capture ===
+
+if (shouldRunWave('wave3', startPhase, endPhase)) {
+  phase('Pre-capture')
+  log('Wave 3: Capturing app screenshots for all components and screens')
+
+  const precapture = await agent(
+    [
+      'Capture app screenshots and structured text content for all components and screens from the running dev server.',
+      '',
+      'Read and follow the skill instructions at: ' + SKILL + '/5-precapture/SKILL.md',
+      'Figma file key: ' + fileKey,
+      'Dev server URL: ' + devServerUrl,
+      '',
+      'Build manifests from ' + TEMP + '/component-map.json.',
+      'Capture all screenshottable components and all discovered routes.',
+      '',
+      'Write precapture-all.json and precapture-screens.json to ' + TEMP + '/',
+      'Update state.json: set phases.phase2_5 to "complete".',
+      '',
+      'IMPORTANT: Also return the list of captured screens with their metadata.',
+      'For each screen, extract: screenName, route, pageSourceFile (from component-map.json routes/tree), keyComponents.',
+      '',
+      'Return: success, componentsCaptured, screensCaptured, skipped, failed, screens (array of screen objects).',
+    ].join('\n'),
+    { label: 'precapture', phase: 'Pre-capture', model: 'sonnet', schema: PRECAPTURE_SCHEMA }
+  )
+
+  if (!precapture || !precapture.success) {
+    log('ERROR: Pre-capture failed')
+    return { error: 'Phase 2.5 (pre-capture) failed', details: precapture }
+  }
+
+  screens = precapture.screens || []
+  log('Pre-captured ' + (precapture.componentsCaptured || 0) + ' components, ' + (precapture.screensCaptured || 0) + ' screens')
+}
+
+// === WAVE 4: Component Builds (tiers sequential; components within a tier in parallel) ===
+
+if (shouldRunWave('wave4', startPhase, endPhase)) {
+
+  // --- Icon Preamble ---
+  phase('Build Icons')
+  log('Wave 4: Building icon and asset components')
+
+  // Materialize builtComponents.json before preamble
+  await withRetry(
+    'materialize-built',
+    2,
+    function(r) { return r && r.success },
+    function() {
+      return agent(
+        [
+          'Write the current builtComponents registry to disk so Phase 3 agents can read it.',
+          '',
+          'Write this JSON to ' + TEMP + '/builtComponents.json:',
+          JSON.stringify(builtComponents),
+        ].join('\n'),
+        { label: 'materialize-built', phase: 'Build Icons', model: 'haiku', schema: STATE_UPDATE_SCHEMA }
+      )
+    }
+  )
+
+  const preamble = await agent(
+    [
+      'Build all Figma icon and asset components from SVG data before tier processing.',
+      '',
+      'Read and follow the skill instructions at: ' + SKILL + '/6-build-tier/icon-preamble/SKILL.md',
+      'Figma file key: ' + fileKey,
+      'Icons frame node ID: ' + (figmaNodes.iconsFrameId || ''),
+      '',
+      'Read icons.json and builtComponents.json from ' + TEMP + '/',
+      'Skip icons/assets already in builtComponents.json.',
+      'Write icon-preamble-results.json to ' + TEMP + '/',
+      'Update builtComponents.json with newly created icons.',
+      '',
+      'Return: success, created (map of name to nodeId), totalCreated, totalSkipped, totalFailed.',
+    ].join('\n'),
+    { label: 'icon-preamble', phase: 'Build Icons', model: 'sonnet', schema: PREAMBLE_SCHEMA }
+  )
+
+  if (preamble && preamble.created) {
+    builtComponents = { ...builtComponents, ...preamble.created }
+  }
+  log('Icons: ' + (preamble ? preamble.totalCreated || 0 : 0) + ' created, ' + (preamble ? preamble.totalSkipped || 0 : 0) + ' skipped')
+
+  // Re-materialize from the in-memory registry so Tier 1 build agents are
+  // guaranteed to see the icons even if the preamble agent didn't persist the file.
+  await withRetry(
+    'materialize-built-post-icons',
+    2,
+    function(r) { return r && r.success },
+    function() {
+      return agent(
+        [
+          'Write the current builtComponents registry (now including icons) to disk.',
+          '',
+          'Write this JSON to ' + TEMP + '/builtComponents.json:',
+          JSON.stringify(builtComponents),
+        ].join('\n'),
+        { label: 'materialize-built-post-icons', phase: 'Build Icons', model: 'haiku', schema: STATE_UPDATE_SCHEMA }
+      )
+    }
+  )
+
+  // --- Per-Component Tier Builds. Tiers run sequentially (tier N+1 instances
+  //     tier N). Within a tier, all components run concurrently as independent
+  //     analyze→build→compare→fix chains, bounded by the runtime's global
+  //     concurrency cap — no manual batching, no per-batch barrier. The registry
+  //     is materialized ONCE per tier (single writer) after the tier's barrier. ---
+  for (let i = 0; i < tiers.length; i++) {
+    const tierDef = tiers[i]
+    phase('Build Components')
+
+    // Skip components already built (Phase 0a Figma inspection or a prior run)
+    const toBuild = tierDef.components.filter(function(name) { return !builtComponents[name] })
+    const alreadyBuilt = tierDef.components.length - toBuild.length
+
+    log('Tier ' + tierDef.tier + ' (' + tierDef.label + '): ' + toBuild.length + ' to build, ' + alreadyBuilt + ' already built')
+
+    // Nothing to build in this tier — skip entirely (do not create an empty frame)
+    if (toBuild.length === 0) {
+      log('Tier ' + tierDef.tier + ': nothing to build — skipping')
+      continue
+    }
+
+    // Create the tier frame on the Components page. Idempotent (reuses an existing
+    // frame by name) so retrying a transient failure is safe.
+    const frameResult = await withRetry(
+      'tier-' + tierDef.tier + '-frame',
+      3,
+      function(r) { return r && r.tierFrameId },
+      function() {
+        return agent(
+          [
+            'Create the container frame for Tier ' + tierDef.tier + ' on the Components page in Figma. Do not build any components — only create the frame and return its node ID.',
+            '',
+            'Figma file key: ' + fileKey,
+            'Components page ID: ' + (figmaNodes.componentsPageId || ''),
+            'Tier: ' + tierDef.tier,
+            'Tier label: ' + tierDef.label,
+            '',
+            'First invoke the figma:figma-use skill, then via use_figma:',
+            '  - setCurrentPageAsync to the Components page',
+            '  - compute y = (existingFrames.length ? maxBottom + 80 : 200) where maxBottom = max(f.y + f.height) over the page children',
+            '  - create a HORIZONTAL auto-layout frame named "Tier ' + tierDef.tier + ' — ' + tierDef.label + '" with itemSpacing 80, padding 48 on all sides, white fill, x = 0, y = computed, appended to the page',
+            '',
+            'If a frame named "Tier ' + tierDef.tier + ' — ' + tierDef.label + '" already exists on the page, reuse it instead of creating a duplicate.',
+            '',
+            'Return: success, tier, tierFrameId (the frame node ID).',
+          ].join('\n'),
+          { label: 'tier-' + tierDef.tier + '-frame', phase: 'Build Components', model: 'sonnet', schema: TIER_FRAME_SCHEMA }
+        )
+      }
+    )
+
+    if (!frameResult || !frameResult.tierFrameId) {
+      // The tier frame gates every component in this tier AND every later tier that
+      // instances them. Skipping silently would orphan the rest of the build and
+      // still report success. Persist what we have and hard-return so the user can
+      // cleanly resume from phase3 (already-built components are skipped on resume).
+      skippedTiers.push(tierDef.tier)
+      log('ERROR: Tier ' + tierDef.tier + ' frame creation failed after retries — persisting state and stopping')
+      await agent(
+        [
+          'Write the current builtComponents registry to disk so a resume can skip already-built components.',
+          '',
+          'Write this JSON to ' + TEMP + '/builtComponents.json:',
+          JSON.stringify(builtComponents),
+        ].join('\n'),
+        { label: 'materialize-built-abort', phase: 'Build Components', model: 'haiku', schema: STATE_UPDATE_SCHEMA }
+      )
+      return {
+        error: 'Tier ' + tierDef.tier + ' frame creation failed',
+        fileKey: fileKey,
+        builtComponents: Object.keys(builtComponents).length,
+        skippedTiers: skippedTiers,
+        resumeHint: 'Re-run with startPhase: "phase3" to resume (built components are skipped).',
+      }
+    }
+
+    const tierFrameId = frameResult.tierFrameId
+    figmaNodes['tier' + tierDef.tier + 'FrameId'] = tierFrameId
+
+    let tierBuilt = 0
+    let tierFailed = 0
+
+    const results = await parallel(
+      toBuild.map(function(componentName) {
+        return function() {
+          return buildOneComponent(componentName, tierDef, tierFrameId)
+        }
+      })
+    )
+
+    results.forEach(function(r, idx) {
+      const name = toBuild[idx]
+      if (!r) {
+        // Thunk threw or was skipped — count it as a failure, never a silent vanish.
+        tierFailed++
+        failedComponents.push({ componentName: name, status: 'no_result', tier: tierDef.tier })
+        log('  ' + name + ': no_result (build chain threw or was skipped)')
+        return
+      }
+      if (r.nodeId && (r.status === 'built' || r.status === 'partial_match')) {
+        builtComponents[r.componentName] = r.nodeId
+        tierBuilt++
+      } else {
+        tierFailed++
+        failedComponents.push({ componentName: name, status: r.status, verdict: r.verdict, tier: tierDef.tier })
+        log('  ' + name + ': ' + r.status + (r.verdict ? ' (' + r.verdict + ')' : ''))
+      }
+    })
+
+    // Materialize the registry ONCE per tier (single writer, after the barrier —
+    // no read/write races) so the next tier can resolve this tier's components.
+    await withRetry(
+      'materialize-tier-' + tierDef.tier,
+      2,
+      function(r) { return r && r.success },
+      function() {
+        return agent(
+          [
+            'Write the current builtComponents registry to disk so the next tier can resolve children as instances.',
+            '',
+            'Write this JSON to ' + TEMP + '/builtComponents.json:',
+            JSON.stringify(builtComponents),
+          ].join('\n'),
+          { label: 'materialize-tier-' + tierDef.tier, phase: 'Build Components', model: 'haiku', schema: STATE_UPDATE_SCHEMA }
+        )
+      }
+    )
+
+    // Collect tier results into build-tier{N}.json and mark tierProgress complete.
+    // collect-tier-results.js now MERGES completed node IDs into builtComponents.json
+    // (it no longer rewrites the registry from the incomplete state.json), so the
+    // previous repair-overwrite step is gone.
+    await withRetry(
+      'collect-tier-' + tierDef.tier,
+      2,
+      function(r) { return r && r.success },
+      function() {
+        return agent(
+          [
+            'Finalize Tier ' + tierDef.tier + ' results.',
+            '',
+            'Run: node ' + SKILL + '/collect-tier-results.js --tier ' + tierDef.tier + ' --components "' + tierDef.components.join(',') + '"',
+            'This writes ' + TEMP + '/build-tier' + tierDef.tier + '.json, sets tierProgress.tier' + tierDef.tier + ' to "complete" (or "complete_with_failures" if any component failed, recording the failed names), and merges completed node IDs into builtComponents.json.',
+            '',
+            'Return: success.',
+          ].join('\n'),
+          { label: 'collect-tier-' + tierDef.tier, phase: 'Build Components', model: 'haiku', schema: STATE_UPDATE_SCHEMA }
+        )
+      }
+    )
+
+    log('Tier ' + tierDef.tier + ' complete: ' + tierBuilt + ' built, ' + tierFailed + ' failed')
+  }
+
+  // Update state with all Phase 3 results
+  await agent(
+    [
+      'Update ' + TEMP + '/state.json with Phase 3 completion.',
+      '',
+      'Set these fields:',
+      '  phases.phase3: ' + (failedComponents.length === 0 ? '"complete"' : '"complete_with_failures"'),
+      '  phase3Failures: ' + JSON.stringify(failedComponents.map(function(f) { return f.componentName || f.name })),
+      '  builtComponents: ' + JSON.stringify(builtComponents),
+      '  figmaNodes: ' + JSON.stringify(figmaNodes),
+      '',
+      'Read the current state.json, merge these fields, and write it back.',
+    ].join('\n'),
+    { label: 'update-state-phase3', phase: 'Build Components', model: 'haiku', schema: STATE_UPDATE_SCHEMA }
+  )
+
+  log('Phase 3 complete: ' + Object.keys(builtComponents).length + ' total built components, ' + failedComponents.length + ' failed')
+}
+
+// === WAVE 5: Screen Builds (parallel) ===
+
+if (shouldRunWave('wave5', startPhase, endPhase)) {
+  phase('Build Screens')
+
+  if (screens.length === 0) {
+    log('No screens to build — skipping Wave 5')
+  } else {
+    log('Wave 5: Building ' + screens.length + ' screens in parallel')
+
+    const rawScreenResults = await parallel(
+      screens.map(function(screen) {
+        return function() {
+          return agent(
+            [
+              'Build a Figma screen frame by composing built component instances, then validate visually.',
+              '',
+              'Read and follow the skill instructions at: ' + SKILL + '/8-build-screens/SKILL.md',
+              'Figma file key: ' + fileKey,
+              '',
+              'Screen name: ' + screen.screenName,
+              'Route: ' + screen.route,
+              'Page source file: ' + (screen.pageSourceFile || ''),
+              'Screens frame node ID: ' + (figmaNodes.screensFrameId || ''),
+              'App screenshot: ' + TEMP + '/screenshots/screens/' + screen.screenName + '/app.png',
+              'Text content: ' + TEMP + '/screenshots/screens/' + screen.screenName + '/text.json',
+              'Screenshot dir: ' + TEMP + '/screenshots/screens/' + screen.screenName + '/',
+              'Key components: ' + (screen.keyComponents || []).join(', '),
+              '',
+              'Read builtComponents.json from ' + TEMP + '/ for component instance lookup.',
+              'Pre-existing screens (DO NOT MODIFY without authorization): ' + JSON.stringify(preExistingScreens),
+              '',
+              'Follow all 7 steps: verify components, analyze source + screenshot, build via use_figma,',
+              'screenshot, compare, fix loop (up to 3 iterations), write result.',
+              '',
+              'Write result to ' + TEMP + '/build-results/screens/' + screen.screenName + '.json',
+              '',
+              'Return: screenName, status (built/rejected/needs_authorization/failed), nodeId, verdict, matchPct, missingComponents.',
+            ].join('\n'),
+            { label: 'screen-' + screen.screenName, phase: 'Build Screens', schema: SCREEN_SCHEMA }
+          )
+        }
+      })
+    )
+
+    // A null result means the screen's thunk threw or was skipped — record it as a
+    // failure rather than dropping it silently via .filter(Boolean).
+    rawScreenResults.forEach(function(r, idx) {
+      if (!r) failedScreens.push({ screenName: screens[idx].screenName, status: 'no_result' })
+    })
+    const screenResults = rawScreenResults.filter(Boolean)
+    const builtScreens = screenResults.filter(function(s) { return s.status === 'built' })
+    screenResults
+      .filter(function(s) { return s.status !== 'built' })
+      .forEach(function(s) { failedScreens.push({ screenName: s.screenName, status: s.status, verdict: s.verdict }) })
+
+    log('Screens: ' + builtScreens.length + ' built, ' + failedScreens.length + ' failed/rejected')
+
+    if (failedScreens.length > 0) {
+      log('Failed screens: ' + failedScreens.map(function(s) { return s.screenName + ' (' + s.status + ')' }).join(', '))
+    }
+
+    // Update state
+    await agent(
+      [
+        'Update ' + TEMP + '/state.json with Phase 4 completion.',
+        '',
+        'Set phases.phase4: ' + (failedScreens.length === 0 ? '"complete"' : '"complete_with_failures"') + '.',
+        'Set phase4Failures: ' + JSON.stringify(failedScreens.map(function(s) { return s.screenName })) + '.',
+        'Read the current state.json, merge these fields, and write it back.',
+      ].join('\n'),
+      { label: 'update-state-phase4', phase: 'Build Screens', model: 'haiku', schema: STATE_UPDATE_SCHEMA }
+    )
+  }
+}
+
+// === WAVE 6: Validation ===
+
+if (shouldRunWave('wave6', startPhase, endPhase)) {
+  phase('Validate')
+  log('Wave 6: Validating all built components against app screenshots')
+
+  const validation = await agent(
+    [
+      'Validate every built Figma component against its app screenshot. Run fix loops on mismatches for components built during this run. Clean up the Components page layout.',
+      '',
+      'Read and follow the skill instructions at: ' + SKILL + '/9-validate/SKILL.md',
+      'Figma file key: ' + fileKey,
+      'Dev server URL: ' + devServerUrl,
+      '',
+      'Inputs:',
+      '  builtComponents: ' + JSON.stringify(builtComponents),
+      '  preExistingComponents (validate read-only, no fix loop): ' + JSON.stringify(preExistingComponents),
+      '  figmaNodes: ' + JSON.stringify(figmaNodes),
+      '  buildOrder tierCount: ' + tiers.length,
+      '',
+      'Write validation-summary.json to ' + TEMP + '/ (include fileKey "' + fileKey + '" so the validated target is auditable; compute overallVerdict from the counts per the SKILL rule).',
+      'Write re-measured scores back into each .temp/figma-from-code/build-results/<name>.json under a "validation" block (SKILL step 1b) so build-results and the summary cannot diverge.',
+      'Write full report to .temp/figma-validation/report.md',
+      'Update state.json: set phases.phase5 to "complete".',
+      'Stop the Playwright server if running.',
+      '',
+      'Return: success, fileKey, componentsCompared, comparable, match, minorDiff, mismatch, noAppReference, matchRate, fixedDuringValidation, averageMatchPct, overallVerdict, reportPath.',
+    ].join('\n'),
+    { label: 'validate', phase: 'Validate', schema: VALIDATION_SCHEMA }
+  )
+
+  if (validation) {
+    validationVerdict = validation.overallVerdict || null
+    log('Validation: ' + validation.overallVerdict)
+    log('  Compared: ' + (validation.componentsCompared || 0) + ', Match: ' + (validation.match || 0) + ', Minor: ' + (validation.minorDiff || 0) + ', Mismatch: ' + (validation.mismatch || 0))
+    if (validation.fixedDuringValidation > 0) {
+      log('  Fixed during validation: ' + validation.fixedDuringValidation)
+    }
+  }
+}
+
+// === CLEANUP: stop the browser/Playwright server regardless of which phases ran ===
+// The validate wave stops it on success, but a run ended early via endPhase (or one
+// where validation didn't reach the teardown step) would otherwise orphan the server
+// and hold its port. This step is idempotent — a no-op if nothing is running.
+await agent(
+  [
+    'Stop the figma-from-code Playwright server if it is still running so its port is freed. This is a best-effort, idempotent cleanup — if nothing is running, do nothing and still return success.',
+    '',
+    'Run: kill $(cat ' + TEMP + '/pw-server.pid 2>/dev/null) 2>/dev/null; rm -f ' + TEMP + '/pw-server.pid ' + TEMP + '/pw-endpoint.txt',
+    'Ignore any "no such process" / kill failure (the server was already stopped).',
+    '',
+    'Return: success.',
+  ].join('\n'),
+  { label: 'cleanup-browser-server', model: 'haiku', schema: STATE_UPDATE_SCHEMA }
+)
+
+// === FINAL SUMMARY ===
+
+const validationOk = validationVerdict === null || !/mismatch|fail/i.test(String(validationVerdict))
+const overallSuccess =
+  failedComponents.length === 0 &&
+  skippedTiers.length === 0 &&
+  failedScreens.length === 0 &&
+  validationOk
+
+const summary = {
+  fileKey: fileKey,
+  overallSuccess: overallSuccess,
+  totalComponents: Object.keys(builtComponents).length,
+  totalTiers: tiers.length,
+  totalScreens: screens.length,
+  failedComponentCount: failedComponents.length,
+  failedComponents: failedComponents,
+  skippedTiers: skippedTiers,
+  failedScreens: failedScreens,
+  validationVerdict: validationVerdict,
+  figmaNodes: figmaNodes,
+  phasesRun: {
+    startPhase: startPhase || 'phase0a',
+    endPhase: endPhase || 'phase5',
+  },
+}
+
+log(
+  'Workflow complete: ' + summary.totalComponents + ' components, ' + summary.totalScreens + ' screens, ' +
+  failedComponents.length + ' failed components' +
+  (skippedTiers.length ? ', ' + skippedTiers.length + ' skipped tier(s)' : '') +
+  (failedScreens.length ? ', ' + failedScreens.length + ' failed screen(s)' : '')
+)
+if (!overallSuccess) {
+  log('⚠ Completed with issues — see failedComponents / skippedTiers / failedScreens / validationVerdict in the result.')
+}
+
+return summary

--- a/plugins/figma-from-code/workflows/figma-from-code.test.js
+++ b/plugins/figma-from-code/workflows/figma-from-code.test.js
@@ -1,0 +1,274 @@
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(__dirname, 'figma-from-code.js'), 'utf-8');
+
+let passed = 0;
+let failed = 0;
+let warnings = 0;
+
+function pass(msg) { console.log('  \x1b[32m✓\x1b[0m', msg); passed++; }
+function fail(msg) { console.error('  \x1b[31m✗\x1b[0m', msg); failed++; }
+function warn(msg) { console.warn('  \x1b[33m⚠\x1b[0m', msg); warnings++; }
+
+// --- 1. Meta block ---
+
+console.log('\n1. Meta block');
+
+const metaMatch = src.match(/export const meta = (\{[\s\S]*?\n\})/m);
+if (!metaMatch) {
+  fail('No meta block found');
+} else {
+  pass('Meta block present');
+
+  let meta;
+  try {
+    meta = eval('(' + metaMatch[1] + ')');
+    pass('Meta block is a pure literal');
+  } catch (e) {
+    fail('Meta block parse error: ' + e.message);
+  }
+
+  if (meta) {
+    if (meta.name && typeof meta.name === 'string') {
+      pass('meta.name: "' + meta.name + '"');
+    } else {
+      fail('meta.name missing or not a string');
+    }
+
+    if (meta.description && typeof meta.description === 'string') {
+      pass('meta.description present');
+    } else {
+      fail('meta.description missing or not a string');
+    }
+
+    if (Array.isArray(meta.phases) && meta.phases.length > 0) {
+      pass('meta.phases: ' + meta.phases.length + ' entries');
+      for (const p of meta.phases) {
+        if (!p.title) fail('Phase missing title: ' + JSON.stringify(p));
+      }
+    } else {
+      fail('meta.phases missing or empty');
+    }
+
+    // Check for computed values in meta (template literals, function calls, variables)
+    const metaStr = metaMatch[1];
+    if (/`/.test(metaStr)) fail('Meta contains template literals');
+    else if (/\$\{/.test(metaStr)) fail('Meta contains interpolation');
+    else if (/\.\.\.|\.call|\.apply|\.bind/.test(metaStr)) fail('Meta contains spread/call/apply');
+    else pass('Meta has no computed values');
+  }
+}
+
+// --- 2. Forbidden runtime patterns ---
+
+console.log('\n2. Forbidden runtime patterns');
+
+const forbidden = [
+  [/\bDate\.now\s*\(/g, 'Date.now() — breaks resume'],
+  [/\bMath\.random\s*\(/g, 'Math.random() — breaks resume'],
+  [/\bnew Date\s*\(\s*\)/g, 'new Date() — breaks resume'],
+  [/\brequire\s*\(/g, 'require() — no Node.js API in workflow scripts'],
+  [/\bfs\.\w/g, 'fs.* — no filesystem access in workflow script'],
+  [/\bprocess\.\w/g, 'process.* — no Node.js API'],
+  [/\bconsole\.\w/g, 'console.* — use log() instead'],
+];
+
+for (const [pat, msg] of forbidden) {
+  const hits = src.match(pat);
+  if (hits) {
+    fail(msg + ' (' + hits.length + ' occurrence(s))');
+  } else {
+    pass('No ' + msg.split('—')[0].trim());
+  }
+}
+
+// --- 3. TypeScript annotations ---
+
+console.log('\n3. TypeScript annotations');
+
+const lines = src.split('\n');
+let tsCount = 0;
+for (let i = 0; i < lines.length; i++) {
+  const line = lines[i];
+  if (line.includes("type: '") || line.includes('type: "')) continue;
+  if (line.trim().startsWith('//')) continue;
+  if (/:\s+(string|number|boolean|any|void|never)\s*[,;\)\]\}]/.test(line)
+    && !line.includes("'") && !line.includes('"')) {
+    fail('TypeScript annotation at line ' + (i + 1) + ': ' + line.trim());
+    tsCount++;
+  }
+}
+if (tsCount === 0) pass('No TypeScript annotations found');
+
+// --- 4. JavaScript syntax ---
+
+console.log('\n4. JavaScript syntax');
+
+const body = src.replace(/^export const meta[\s\S]*?\n\}/m, '');
+const wrapped = '(async function(agent, parallel, phase, log, args, budget) {' + body + '})';
+try {
+  new Function(wrapped);
+  pass('JavaScript syntax valid (async-wrapped)');
+} catch (e) {
+  fail('Syntax error: ' + e.message);
+}
+
+// --- 5. Schema definitions ---
+
+console.log('\n5. Schema definitions');
+
+const schemaNames = [...src.matchAll(/const (\w+_SCHEMA)\s*=\s*\{/g)].map(m => m[1]);
+if (schemaNames.length === 0) {
+  fail('No schema definitions found');
+} else {
+  pass(schemaNames.length + ' schemas defined');
+}
+
+for (const name of schemaNames) {
+  const usages = (src.match(new RegExp('\\b' + name + '\\b', 'g')) || []).length;
+  if (usages < 2) {
+    warn(name + ' defined but never referenced in an agent() call');
+  } else {
+    pass(name + ' referenced ' + (usages - 1) + ' time(s)');
+  }
+}
+
+// Verify each schema parses as valid JSON-like structure
+for (const name of schemaNames) {
+  const schemaMatch = src.match(new RegExp('const ' + name + '\\s*=\\s*(\\{[\\s\\S]*?\\n\\})'));
+  if (schemaMatch) {
+    try {
+      eval('(' + schemaMatch[1] + ')');
+      pass(name + ' parses as valid object');
+    } catch (e) {
+      fail(name + ' parse error: ' + e.message);
+    }
+  }
+}
+
+// --- 6. Phase consistency ---
+
+console.log('\n6. Phase consistency');
+
+const phaseCalls = [...src.matchAll(/phase\('([^']+)'\)/g)].map(m => m[1]);
+let meta2;
+try { meta2 = eval('(' + metaMatch[1] + ')'); } catch (_) {}
+
+if (meta2) {
+  const metaTitles = new Set(meta2.phases.map(p => p.title));
+  const usedTitles = new Set(phaseCalls);
+
+  for (const p of phaseCalls) {
+    if (metaTitles.has(p)) {
+      pass('phase("' + p + '") matches meta.phases');
+    } else {
+      warn('phase("' + p + '") has no matching meta.phases entry');
+    }
+  }
+
+  for (const t of metaTitles) {
+    if (!usedTitles.has(t)) {
+      warn('meta.phases "' + t + '" never called via phase()');
+    }
+  }
+}
+
+// --- 7. Agent calls ---
+
+console.log('\n7. Agent calls');
+
+const agentCalls = (src.match(/await agent\(/g) || []).length;
+const parallelCalls = (src.match(/await parallel\(/g) || []).length;
+pass(agentCalls + ' agent() calls');
+pass(parallelCalls + ' parallel() calls');
+
+// Check that agent calls inside parallel() use thunk wrappers
+const parallelBlocks = [...src.matchAll(/await parallel\(\[([\s\S]*?)\]\)/g)];
+for (let i = 0; i < parallelBlocks.length; i++) {
+  const block = parallelBlocks[i][1];
+  const bareAgents = block.match(/[^(]\bagent\s*\(/g);
+  const thunks = block.match(/(?:function\s*\(\)|=>\s*\{|=>\s*agent|\(\)\s*=>)/g);
+  if (thunks && thunks.length > 0) {
+    pass('parallel() block ' + (i + 1) + ' uses thunk wrappers');
+  } else {
+    fail('parallel() block ' + (i + 1) + ' may have bare agent() calls (need () => agent(...))');
+  }
+}
+
+// --- 8. Phase skip logic ---
+
+console.log('\n8. Phase skip logic');
+
+if (src.includes('shouldRunPhase') || src.includes('shouldRunWave')) {
+  pass('Phase skip functions defined');
+} else {
+  fail('No phase skip logic found');
+}
+
+if (src.includes('PHASE_ORDER')) {
+  const orderMatch = src.match(/PHASE_ORDER\s*=\s*\[([\s\S]*?)\]/);
+  if (orderMatch) {
+    const phases = orderMatch[1].match(/'[^']+'/g).map(s => s.replace(/'/g, ''));
+    const expected = ['phase0a', 'phase0b', 'phase1', 'phase2', 'phase2_5', 'phase3', 'phase4', 'phase5'];
+    const match = JSON.stringify(phases) === JSON.stringify(expected);
+    if (match) {
+      pass('PHASE_ORDER matches expected sequence');
+    } else {
+      fail('PHASE_ORDER mismatch. Got: ' + JSON.stringify(phases));
+    }
+  }
+} else {
+  fail('No PHASE_ORDER constant found');
+}
+
+// --- 9. State hydration ---
+
+console.log('\n9. State hydration');
+
+if (src.includes('needsHydration')) {
+  pass('State hydration logic present');
+} else {
+  fail('No state hydration logic');
+}
+
+if (src.includes('HYDRATION_SCHEMA')) {
+  pass('HYDRATION_SCHEMA defined');
+} else {
+  fail('No HYDRATION_SCHEMA');
+}
+
+// --- 10. Error handling ---
+
+console.log('\n10. Error handling');
+
+const errorReturns = (src.match(/return \{.*error/g) || []).length;
+if (errorReturns > 0) {
+  pass(errorReturns + ' error return path(s)');
+} else {
+  warn('No error return paths found');
+}
+
+const successChecks = (src.match(/\.success\b/g) || []).length;
+if (successChecks > 0) {
+  pass(successChecks + ' success field checks');
+} else {
+  warn('No success field checks');
+}
+
+// --- Summary ---
+
+console.log('\n' + '─'.repeat(40));
+console.log('Results: ' + passed + ' passed, ' + failed + ' failed, ' + warnings + ' warnings');
+console.log('Lines: ' + lines.length);
+
+if (failed > 0) {
+  console.log('\x1b[31m\nFAILED\x1b[0m');
+  process.exit(1);
+} else if (warnings > 0) {
+  console.log('\x1b[33m\nPASSED with warnings\x1b[0m');
+} else {
+  console.log('\x1b[32m\nPASSED\x1b[0m');
+}


### PR DESCRIPTION
 ## What
  Ports the `figma-from-code` workflow into this repo as a self-contained, reusable marketplace plugin
  (`plugins/figma-from-code/`):
  - `workflows/figma-from-code.js` — the Workflow orchestrator
  - `skills/figma-from-code/` — entry skill + 10 staged sub-skills, step files, prompts, helper scripts
  - `skills/figma-setup-variables/` + `skills/figma-setup-file-structure/` — companion skills the workflow delegates to
  (Phase 1/2)
  - registered in `.claude-plugin/marketplace.json`

  ## Verification
  - All 21 JS files pass `node --check`
  - A full run needs a live Figma file + dev server + Playwright (documented in the README)