### PR TITLE
feat: add new plugins and update documentation for Figma and coding skill

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -11,6 +11,8 @@ Skills are packaged as plugins using the **Claude plugin format** (`.claude-plug
 | Plugin | Description | Required MCPs |
 |--------|-------------|---------------|
 | `creating-prompts` | Meta-skills for creating new agent skills (Claude + Copilot) | — |
+| `figma-from-code` | Rebuilds a Figma design system from a running web app's codebase | Figma |
+| `implement-workflow` | End-to-end feature implementation: design, build, test, self-review, prep a PR | — |
 | `code` | Spec workflow, signatures, instruction-generation, document-feature, create-skill | — |
 | `react` | Modlet pattern, component extraction, registry, reuse, validation | — |
 | `react-mock` | Zod sample data, data model management, feature implementation | — |

--- a/README.md
+++ b/README.md
@@ -14,22 +14,28 @@ Our goal is to bridge the gap between general-purpose AI models and project-spec
 
 ## Repository Structure
 
-Prompts in this repo are organized into **high-level categories** based on what they help the AI accomplish:
+This repo has two kinds of content:
 
-- **`/understanding-code`** – Prompt chains that help AI understand and document existing codebases
-- **`/writing-code`** – Prompt chains that assist with implementing new functionality based on external input (e.g. Jira tickets)
+- **[`/plugins`](./plugins)** – Installable Claude Code / VS Code Copilot **plugins** (skills, agents, hooks). See [PLUGINS.md](./PLUGINS.md) for the full catalog and installation steps.
+- **Standalone prompt chains** – Plain markdown prompts you can paste directly into any AI chat agent, no plugin install required. Organized by what they help the AI accomplish:
+  - **[`/understanding-code`](./understanding-code)** – Prompts that help AI understand and document existing codebases
+  - **[`/writing-code`](./writing-code)** – Prompts that assist with implementing new functionality (specs, Jira ticket automation, React patterns)
+  - **[`/writing-stories`](./writing-stories)** – Prompts that turn Figma designs, screenshots, or images into user stories and Jira tickets
+  - **[`/figma`](./figma)** – Figma-to-React skills (design, implement, sync, Code Connect)
+  - **[`/creating-prompts`](./creating-prompts)** – Meta-skill for authoring new agent skills
+  - **[`/crop-image`](./crop-image)** – A single prompt for precisely cropping an image
 
-Each subfolder contains one or more prompts or prompt chains, each with its own `README.md` explaining how to use it.
+Some of these also have a packaged plugin version — where that's the case, the folder's `README.md` links to it. Use whichever fits your workflow: paste the prompt directly, or install the plugin for the maintained, auto-loading version. Every subfolder has its own `README.md` explaining what it contains and how to run it.
 
 ## What's Inside
 
-Here are a few currently available prompt chains:
+A few examples of what's available (see [PLUGINS.md](./PLUGINS.md) for the full, current plugin catalog):
 
 ### 1. Developer Docs Generator
 
-**Path:** `understanding-code/instruction-generation`
+**Plugin:** `code` → `instruction-generation` skill
 
-Generates a `copilot-instruction.md` file that helps AI tools operate effectively within your codebase. Ideal for onboarding AI tools (or humans) with deep, structured context.
+Generates a `copilot-instructions.md` file that helps AI tools operate effectively within your codebase. Ideal for onboarding AI tools (or humans) with deep, structured context.
 
 **Features:**
 
@@ -38,7 +44,7 @@ Generates a `copilot-instruction.md` file that helps AI tools operate effectivel
 - Extracts coding patterns and naming conventions
 - Documents features and domain logic
 
-→ [View prompt chain](./understanding-code/instruction-generation/README.md)
+→ [View the `code` plugin](./plugins/code/README.md)
 
 ### 2. Jira Ticket Automation
 
@@ -59,16 +65,22 @@ Takes a Jira ticket number and walks the AI through implementing the described f
 
 ### Requirements
 
-- [GitHub Copilot Chat](https://github.com/features/copilot) or an equivalent AI chat agent with tool access
+- [Claude Code](https://claude.com/claude-code) or [GitHub Copilot Chat](https://github.com/features/copilot) (or an equivalent AI agent with tool access)
 - MCP (Model Context Protocol) server access if required (for Jira, Figma, attachments, etc.)
 - A valid codebase or ticket to operate on
 
-### Getting Started
+### Getting Started — Plugins (recommended)
+
+1. Add the marketplace: `claude plugin marketplace add bitovi/ai-enablement-prompts --scope project`
+2. Install the plugin(s) you need, e.g. `claude plugin install code@bitovi-ai-enablement --scope project`
+3. Full instructions, the plugin catalog, and VS Code Copilot / Copilot CLI setup are in [PLUGINS.md](./PLUGINS.md).
+
+### Getting Started — Standalone Prompt Chains
 
 1. Open the repo: https://github.com/bitovi/ai-enablement-prompts
 2. Navigate to the prompt folder you're interested in.
-3. Read the `README.md` for that prompt chain to understand the flow and inputs.
-4. Open Copilot Chat and paste the example input provided.
+3. Read the `README.md` for that prompt chain to understand the flow, inputs, and whether a packaged plugin version is also available.
+4. Open your AI agent's chat and paste the example input provided.
 5. Provide the necessary parameters:
    - `{TICKET_NUMBER}` for Jira-based prompts
    - `{OUTPUT_FOLDER}` for saving generated results

--- a/creating-prompts/README.md
+++ b/creating-prompts/README.md
@@ -1,0 +1,9 @@
+# Creating Prompts
+
+Meta-skill for authoring new agent skills, for both Claude Code and VS Code Copilot.
+
+| Folder | Also available as |
+|---|---|
+| [`create-skill/`](./create-skill) | [`creating-prompts`](../plugins/creating-prompts) plugin (also duplicated in the [`code`](../plugins/code) plugin) |
+
+Paste the skill directly into your AI agent, or install a plugin for the maintained, auto-loading version — see [PLUGINS.md](../PLUGINS.md).

--- a/creating-prompts/create-skill/README.md
+++ b/creating-prompts/create-skill/README.md
@@ -1,0 +1,16 @@
+# create-skill
+
+> **Also available as a plugin.** These meta-skills are also packaged as the `create-skill-claude` and `create-skill-copilot` skills in the [`creating-prompts` plugin](../../plugins/creating-prompts) (also bundled in the [`code` plugin](../../plugins/code)) — install one for the maintained, auto-loading version (see [PLUGINS.md](../../PLUGINS.md)). This standalone copy still works if you'd rather install it manually.
+
+## What this is
+
+A meta-skill that teaches an AI agent how to create new agent skills — one variant tuned for Claude Code ([`claude/SKILL.md`](./claude/SKILL.md)), one for VS Code Copilot ([`copilot/SKILL.md`](./copilot/SKILL.md)). The Claude variant has some additional capabilities not supported in Copilot, but works for both tools.
+
+## How to run it
+
+Install these skills manually by placing them at:
+
+- Claude — `~/.claude/skills/create-skill/SKILL.md` (copy from [`claude/SKILL.md`](./claude/SKILL.md))
+- Copilot — `~/.github/skills/create-skill/SKILL.md` (copy from [`copilot/SKILL.md`](./copilot/SKILL.md))
+
+Or, to get the packaged version, install the `creating-prompts` plugin (see [PLUGINS.md](../../PLUGINS.md)), then ask your agent to "create a skill" — the right variant loads automatically, or invoke `/creating-prompts:create-skill-claude` / `/creating-prompts:create-skill-copilot` directly in Claude Code.

--- a/creating-prompts/create-skill/claude/README.md
+++ b/creating-prompts/create-skill/claude/README.md
@@ -1,0 +1,11 @@
+# Claude Variant
+
+The Claude Code variant of the `create-skill` meta-skill.
+
+## What's here
+
+[`SKILL.md`](./SKILL.md) — guides an AI agent through clarifying a skill's purpose, placing it under `.claude/skills/<skill-name>/`, and writing its `SKILL.md`, including Claude-specific capabilities (subagents, hooks) not available in the Copilot variant.
+
+## How to run it
+
+See the parent [`create-skill/README.md`](../README.md) for how to install and invoke this variant.

--- a/creating-prompts/create-skill/copilot/README.md
+++ b/creating-prompts/create-skill/copilot/README.md
@@ -1,0 +1,11 @@
+# Copilot Variant
+
+The VS Code Copilot variant of the `create-skill` meta-skill.
+
+## What's here
+
+[`SKILL.md`](./SKILL.md) — guides an AI agent through creating a new Agent Skill under `.github/skills/` following the VS Code Agent Skills standard, including when a skill is (and isn't) the right tool versus custom instructions or plain markdown docs.
+
+## How to run it
+
+See the parent [`create-skill/README.md`](../README.md) for how to install and invoke this variant.

--- a/creating-prompts/create-skill/readme.md
+++ b/creating-prompts/create-skill/readme.md
@@ -1,7 +1,0 @@
-Install these skills in either:
-
-- Claude - `~/.claude/skills/create-skill/SKILL.md`.
-- Copilot - `~/.github/skills/create-skill/SKILL.md`.
-
-
-The claude path should work for both Claude and Copilot, however the claude-based `create-skill` has some additional capabilities that are not supported in Copilot.

--- a/crop-image/README.md
+++ b/crop-image/README.md
@@ -1,0 +1,22 @@
+# Crop Image
+
+A single prompt that precisely crops an image to a described object or region, using a 5×5 grid analysis to calculate crop coordinates without needing pixel-perfect vision.
+
+## What this does
+
+Given an image and a description of what to crop, the prompt:
+
+1. Reads the image's dimensions
+2. Overlays a 5×5 grid and identifies which cells contain the target object's top-left and bottom-right corners
+3. Converts that grid range into pixel coordinates
+4. Performs the crop
+
+## How to run it
+
+Paste the contents of [`crop-image.md`](./crop-image.md) into your AI agent, filling in:
+
+- `{input_path_name}` – path to the source image
+- `{description_of_object_to_crop}` – what to crop to (e.g. "the navigation bar")
+- `{cropped_path_name}` – where to save the cropped image
+
+Your agent needs the ability to view the image and run a crop/image-metadata tool.

--- a/figma/README.md
+++ b/figma/README.md
@@ -1,0 +1,14 @@
+# Figma Skills
+
+Figma-to-React skills, written in the [VS Code Agent Skills](https://code.visualstudio.com/docs/copilot/copilot-customization) `SKILL.md` format. These are plain markdown — paste one into any AI chat agent directly, no plugin install required.
+
+Most of them are also available as a packaged, installable plugin — see each subfolder's `README.md` for the link, or install straight from [PLUGINS.md](../PLUGINS.md).
+
+| Folder | Also available as |
+|---|---|
+| [`create-react-modlet/`](./create-react-modlet) | `react` plugin |
+| [`figma-component-sync/`](./figma-component-sync) | `figma-react` plugin |
+| [`figma-connect-component/`](./figma-connect-component) | `figma-react` plugin |
+| [`figma-design-react/`](./figma-design-react) | `figma-react` plugin |
+| [`figma-explore/`](./figma-explore) | Standalone only — no plugin equivalent yet |
+| [`figma-implement-component/`](./figma-implement-component) | `figma-react` plugin |

--- a/figma/create-react-modlet/README.md
+++ b/figma/create-react-modlet/README.md
@@ -1,0 +1,11 @@
+# create-react-modlet
+
+> **Also available as a plugin.** This skill is also packaged as the [`create-react-modlet` skill](../../plugins/react/skills/create-react-modlet/SKILL.md) in the [`react` plugin](../../plugins/react) — install it for the maintained, auto-loading version (see [PLUGINS.md](../../PLUGINS.md)). This standalone copy still works if you'd rather paste it directly into any AI chat agent.
+
+## What this is
+
+A skill that creates React components, hooks, or utilities following the modlet pattern — self-contained folders with an `index.ts`, implementation, tests, stories, and optional types.
+
+## How to run it
+
+Paste the contents of [`SKILL.md`](./SKILL.md) into your AI agent and ask it to create a component/hook. Or, to get the packaged version, install the `react` plugin (see [PLUGINS.md](../../PLUGINS.md)) and invoke `/react:create-react-modlet` in Claude Code.

--- a/figma/figma-component-sync/README.md
+++ b/figma/figma-component-sync/README.md
@@ -1,0 +1,11 @@
+# figma-component-sync
+
+> **Also available as a plugin.** This skill is also packaged as the [`figma-component-sync` skill](../../plugins/figma-react/skills/figma-component-sync/SKILL.md) in the [`figma-react` plugin](../../plugins/figma-react) — install it for the maintained, auto-loading version (see [PLUGINS.md](../../PLUGINS.md)). This standalone copy still works if you'd rather paste it directly into any AI chat agent.
+
+## What this is
+
+A skill that checks an existing React component against its Figma design source, reporting visual and structural differences to accept, ignore, or fix.
+
+## How to run it
+
+Requires Figma MCP configured in your agent. Paste the contents of [`SKILL.md`](./SKILL.md) into your AI agent and ask it to audit a component against its Figma design. Or, to get the packaged version, install the `figma-react` plugin (see [PLUGINS.md](../../PLUGINS.md)) and invoke `/figma-react:figma-component-sync` in Claude Code.

--- a/figma/figma-component-sync/examples/README.md
+++ b/figma/figma-component-sync/examples/README.md
@@ -1,0 +1,12 @@
+# Examples
+
+Reference templates for the two files the `figma-component-sync` skill generates during a sync.
+
+## What's here
+
+- [`figma-context-template.md`](./figma-context-template.md) — expected shape of `figma-context.md`, the raw Figma MCP output saved before comparison
+- [`comparison-template.md`](./comparison-template.md) — expected shape of `comparison.md`, the per-file difference report with accept/ignore/fix decisions
+
+## How to run it
+
+Not run directly — the parent [`SKILL.md`](../SKILL.md) follows these templates when generating its own output files. Use them to see the expected format if you're inspecting or debugging a sync run.

--- a/figma/figma-connect-component/README.md
+++ b/figma/figma-connect-component/README.md
@@ -1,0 +1,11 @@
+# figma-connect-component
+
+> **Also available as a plugin.** This skill is also packaged as the [`figma-connect-component` skill](../../plugins/figma-react/skills/figma-connect-component/SKILL.md) in the [`figma-react` plugin](../../plugins/figma-react) — install it for the maintained, auto-loading version (see [PLUGINS.md](../../PLUGINS.md)). This standalone copy still works if you'd rather paste it directly into any AI chat agent.
+
+## What this is
+
+A skill that generates a Figma Code Connect mapping (`.figma.tsx`) linking an existing React component to its Figma counterpart, so Figma Dev Mode shows real code snippets.
+
+## How to run it
+
+Requires Figma MCP configured in your agent. Paste the contents of [`SKILL.md`](./SKILL.md) into your AI agent and ask it to "connect this component to Figma". Or, to get the packaged version, install the `figma-react` plugin (see [PLUGINS.md](../../PLUGINS.md)) and invoke `/figma-react:figma-connect-component` in Claude Code.

--- a/figma/figma-design-react/README.md
+++ b/figma/figma-design-react/README.md
@@ -1,0 +1,11 @@
+# figma-design-react
+
+> **Also available as a plugin.** This skill is also packaged as the [`figma-design-react` skill](../../plugins/figma-react/skills/figma-design-react/SKILL.md) in the [`figma-react` plugin](../../plugins/figma-react) — install it for the maintained, auto-loading version (see [PLUGINS.md](../../PLUGINS.md)). This standalone copy still works if you'd rather paste it directly into any AI chat agent.
+
+## What this is
+
+A skill that analyzes a Figma design and proposes React component architecture and a props API — variants, structure, and prop types — without writing any implementation code.
+
+## How to run it
+
+Requires Figma MCP configured in your agent. Paste the contents of [`SKILL.md`](./SKILL.md) into your AI agent along with a Figma URL and ask it to plan the component. Or, to get the packaged version, install the `figma-react` plugin (see [PLUGINS.md](../../PLUGINS.md)) and invoke `/figma-react:figma-design-react` in Claude Code.

--- a/figma/figma-explore/README.md
+++ b/figma/figma-explore/README.md
@@ -1,0 +1,28 @@
+# figma-explore
+
+Explores a Figma file via the Figma REST API to discover all pages, components, and component sets — useful for files too large for the Figma MCP tools, which require a specific node ID up front.
+
+> Still an active, standalone skill — not yet packaged as an installable plugin.
+
+## What's here
+
+- [`SKILL.md`](./SKILL.md) — the skill definition ([VS Code Agent Skills](https://code.visualstudio.com/docs/copilot/copilot-customization) format)
+- [`figma-extract-all.js`](./figma-extract-all.js) — a Node script that discovers and extracts a Figma file's structure via batched REST API calls
+
+## How to run it
+
+1. Set `FIGMA_ACCESS_TOKEN` in your environment or `.env` — needs the `file_content:read` scope. Get one from [Figma's developer settings](https://www.figma.com/developers/api#access-tokens).
+2. Make sure you have Node.js 18+ (used for native `fetch`).
+3. Either ask your AI agent to explore a Figma URL (it will find and run the script via the skill), or run it directly:
+   ```bash
+   node figma/figma-explore/figma-extract-all.js <figmaFileUrl> [options]
+   ```
+
+Options:
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--list-only` | Quick discovery only (1 API call) | Full extraction |
+| `--output <dir>` | Output directory for JSON files | `.temp/figma-explore` |
+| `--batch-size <n>` | Components per batch request | 30 |
+| `--delay <ms>` | Delay between batches (rate limiting) | 1000 |

--- a/figma/figma-implement-component/README.md
+++ b/figma/figma-implement-component/README.md
@@ -1,0 +1,11 @@
+# figma-implement-component
+
+> **Also available as a plugin.** This skill is also packaged as the [`figma-implement-component` skill](../../plugins/figma-react/skills/figma-implement-component/SKILL.md) in the [`figma-react` plugin](../../plugins/figma-react) — install it for the maintained, auto-loading version (see [PLUGINS.md](../../PLUGINS.md)). This standalone copy still works if you'd rather paste it directly into any AI chat agent.
+
+## What this is
+
+A skill that implements a React component from a Figma design — either after `figma-design-react` has analyzed it, or directly from a Figma URL. Delegates to `create-react-modlet` for folder structure, then adds the Figma-specific implementation and stories for each variant.
+
+## How to run it
+
+Requires Figma MCP configured in your agent. Paste the contents of [`SKILL.md`](./SKILL.md) into your AI agent along with a Figma URL and ask it to build the component. Or, to get the packaged version, install the `figma-react` plugin (see [PLUGINS.md](../../PLUGINS.md)) and invoke `/figma-react:figma-implement-component` in Claude Code.

--- a/figma/figma-implement-component/reference/README.md
+++ b/figma/figma-implement-component/reference/README.md
@@ -1,0 +1,12 @@
+# Reference
+
+Supporting reference material for the `figma-implement-component` skill's step files.
+
+## What's here
+
+- [`output-files.md`](./output-files.md) — the expected modlet folder structure once implementation is complete
+- [`quality-checklist.md`](./quality-checklist.md) — checklist to verify before marking a component implementation done
+
+## How to run it
+
+Not run directly — linked from the parent [`SKILL.md`](../SKILL.md) and consulted at the end of the step sequence in [`steps/`](../steps).

--- a/figma/figma-implement-component/steps/README.md
+++ b/figma/figma-implement-component/steps/README.md
@@ -1,0 +1,21 @@
+# Steps
+
+The step-by-step instructions the `figma-implement-component` skill works through in order, one file per step.
+
+## What's here
+
+- [`00-todo-setup.md`](./00-todo-setup.md) — create a todo list to track progress
+- [`01-design-analysis.md`](./01-design-analysis.md) — verify or generate design analysis files
+- [`02-modlet-structure.md`](./02-modlet-structure.md) — create the component folder via `create-react-modlet`
+- [`03-readme.md`](./03-readme.md) — write the README documenting the Figma-to-code mapping
+- [`04-types.md`](./04-types.md) — define the TypeScript props interface
+- [`05-implementation.md`](./05-implementation.md) — implement the component matching Figma exactly
+- [`06-stories.md`](./06-stories.md) — create Storybook stories for every variant
+- [`08-tests.md`](./08-tests.md) — create unit tests
+- [`09-exports.md`](./09-exports.md) — create `index.ts` re-exports
+- [`10-verification.md`](./10-verification.md) — run tests and check visual rendering
+- [`11-playwright.md`](./11-playwright.md) — verify Storybook against the Figma design with Playwright MCP
+
+## How to run it
+
+Not run directly — the parent [`SKILL.md`](../SKILL.md) works through these in order, starting at Step 0.

--- a/understanding-code/README.md
+++ b/understanding-code/README.md
@@ -1,0 +1,10 @@
+# Understanding Code
+
+Prompt chains that help AI understand and document existing codebases.
+
+| Item | Also available as |
+|---|---|
+| [`signatures.prompt.md`](./signatures.prompt.md) | `signatures` skill in the [`code` plugin](../plugins/code) — standalone file still works, paste it directly |
+| [`instruction-generation/`](./instruction-generation) | `instruction-generation` skill in the [`code` plugin](../plugins/code) — **this one has actually moved**; the standalone files were removed, see the folder's README |
+
+See [PLUGINS.md](../PLUGINS.md) to install the `code` plugin.

--- a/writing-code/README.md
+++ b/writing-code/README.md
@@ -1,0 +1,11 @@
+# Writing Code
+
+Prompt chains that assist with implementing new functionality.
+
+| Folder | What it does | Also available as |
+|---|---|---|
+| [`generate-feature/`](./generate-feature) | Automates implementing a Jira ticket end-to-end, pulling context from Jira, Figma, and file attachments | Standalone only — no plugin equivalent yet |
+| [`specs/`](./specs) | Build, review, and implement markdown specs (plan → check → implement → incorporate answers) | [`code` plugin](../plugins/code) |
+| [`react/`](./react) | React modlet pattern and Figma-to-React component design | [`react`](../plugins/react) and [`figma-react`](../plugins/figma-react) plugins |
+
+See each subfolder's `README.md` for details, or [PLUGINS.md](../PLUGINS.md) to install a plugin version.

--- a/writing-code/react/README.md
+++ b/writing-code/react/README.md
@@ -1,0 +1,8 @@
+# React
+
+Both skills here are also packaged as installable plugins. Paste them directly into any AI chat agent, or install the plugin for the maintained, auto-loading version — see [PLUGINS.md](../../PLUGINS.md).
+
+| Folder | Also available as |
+|---|---|
+| [`create-react-modlet/`](./create-react-modlet) | `create-react-modlet` skill in the [`react` plugin](../../plugins/react) |
+| [`figma-design-react/`](./figma-design-react) | `figma-design-react` skill in the [`figma-react` plugin](../../plugins/figma-react) |

--- a/writing-code/react/create-react-modlet/README.md
+++ b/writing-code/react/create-react-modlet/README.md
@@ -1,0 +1,11 @@
+# create-react-modlet
+
+> **Also available as a plugin.** This skill is also packaged as the [`create-react-modlet` skill](../../../plugins/react/skills/create-react-modlet/SKILL.md) in the [`react` plugin](../../../plugins/react) — install it for the maintained, auto-loading version (see [PLUGINS.md](../../../PLUGINS.md)). This standalone copy still works if you'd rather paste it directly into any AI chat agent.
+
+## What this is
+
+A skill that creates React components, hooks, or utilities following the modlet pattern — self-contained folders with an `index.ts`, implementation, tests, stories, and optional types.
+
+## How to run it
+
+Paste the contents of [`SKILL.md`](./SKILL.md) into your AI agent and ask it to create a component/hook. Or, to get the packaged version, install the `react` plugin (see [PLUGINS.md](../../../PLUGINS.md)) and invoke `/react:create-react-modlet` in Claude Code.

--- a/writing-code/react/figma-design-react/README.md
+++ b/writing-code/react/figma-design-react/README.md
@@ -1,0 +1,11 @@
+# figma-design-react
+
+> **Also available as a plugin.** This skill is also packaged as the [`figma-design-react` skill](../../../plugins/figma-react/skills/figma-design-react/SKILL.md) in the [`figma-react` plugin](../../../plugins/figma-react) — install it for the maintained, auto-loading version (see [PLUGINS.md](../../../PLUGINS.md)). This standalone copy still works if you'd rather paste it directly into any AI chat agent.
+
+## What this is
+
+A skill that analyzes a Figma design and proposes React component architecture and a props API — variants, structure, and prop types — without writing any implementation code.
+
+## How to run it
+
+Requires Figma MCP configured in your agent. Paste the contents of [`SKILL.md`](./SKILL.md) into your AI agent along with a Figma URL and ask it to plan the component. Or, to get the packaged version, install the `figma-react` plugin (see [PLUGINS.md](../../../PLUGINS.md)) and invoke `/figma-react:figma-design-react` in Claude Code.

--- a/writing-code/specs/README.md
+++ b/writing-code/specs/README.md
@@ -1,0 +1,16 @@
+# Specs
+
+> **Also available as a plugin.** These four prompts are also packaged as the `spec`, `spec-check`, `spec-implement`, and `spec-answered-questions` skills in the [`code` plugin](../../plugins/code) — install it for the maintained, auto-loading version (see [PLUGINS.md](../../PLUGINS.md)). These standalone copies still work if you'd rather paste them directly into any AI chat agent.
+
+## What this is
+
+A four-step spec workflow for planning and implementing a change with an AI agent:
+
+1. [`spec.prompt.md`](./spec.prompt.md) — build a detailed implementation plan, gathering context from any linked Jira/Figma URLs, ending with numbered clarifying questions
+2. [`spec-check.prompt.md`](./spec-check.prompt.md) — review the spec for contradictions, redundancy, and completeness against the codebase
+3. [`spec-implement.prompt.md`](./spec-implement.prompt.md) — implement the spec phase-by-phase, pausing for review after each step, then verify build/tests/lint
+4. [`spec-answered-questions.prompt.md`](./spec-answered-questions.prompt.md) — incorporate your answers (and any other edits, treated as feedback) back into the spec
+
+## How to run it
+
+Paste each `.prompt.md` file's contents into your AI agent in order, once the previous step is done. Or, to get the packaged version, install the `code` plugin (see [PLUGINS.md](../../PLUGINS.md)) and invoke `/code:spec`, `/code:spec-check`, `/code:spec-implement`, or `/code:spec-answered-questions` in Claude Code — or just ask your agent to "build a spec for X" / "review this spec" / "implement this spec".

--- a/writing-stories/README.md
+++ b/writing-stories/README.md
@@ -1,0 +1,13 @@
+# Writing Stories
+
+Prompt chains that turn Figma designs, screenshots, or plain images into development-ready user stories and Jira tickets.
+
+| Folder | What it does |
+|---|---|
+| [`from-figma/`](./from-figma) | 5-step pipeline: Figma page → screen analysis → shell stories → full stories with Gherkin acceptance criteria |
+| [`from-figma-alt/`](./from-figma-alt) | Alternate, shorter version of the `from-figma` pipeline |
+| [`from-images/`](./from-images) | Same pipeline as `from-figma`, but starting from plain screenshots instead of a live Figma file |
+| [`subtasks-spa-rest-sql/`](./subtasks-spa-rest-sql) | Work-in-progress prompts for splitting a user story into frontend/API/migration subtasks for a SPA + REST + SQL stack |
+| [`to-jira/`](./to-jira) | Pushes a completed story into Jira as an epic plus child stories |
+
+None of these are packaged as plugins yet — they remain standalone prompt chains. Each subfolder's `README.md` covers prerequisites and usage.

--- a/writing-stories/subtasks-spa-rest-sql/README.md
+++ b/writing-stories/subtasks-spa-rest-sql/README.md
@@ -1,0 +1,23 @@
+# Subtasks: SPA + REST + SQL
+
+**Status: work in progress / draft.** This is a set of in-progress notes for a future prompt chain, not a finished, ready-to-paste one yet.
+
+## What this is for
+
+A planned series of prompts that break a user story into technical subtasks for apps with this architecture:
+
+- A frontend SPA that handles routing and a data layer making REST requests
+- A REST service layer supporting CRUD plus pagination/filtering/sorting/relationship-inclusion
+- An ORM-based service layer
+- A SQL data layer with a migration utility
+
+The intended flow: take a story (in the format produced by [`writing-stories/from-figma`](../from-figma)) plus its Figma images/analysis, and produce subtasks for:
+
+- [`0a-setup-instructions.md`](./0a-setup-instructions.md), [`0b-setup-data-model.md`](./0b-setup-data-model.md), [`0c-setup-api-docs.md`](./0c-setup-api-docs.md) — one-time setup context
+- [`1-data-migrations.md`](./1-data-migrations.md) — data migration subtasks
+- [`2-api-changes.md`](./2-api-changes.md) — API layer subtasks
+- [`3-frontend.md`](./3-frontend.md) — frontend subtasks
+
+## How to run it
+
+Read [`plan.md`](./plan.md) first — it lays out the open questions and design direction. Treat the numbered files as a starting point to finish and adapt for your stack, not a ready-to-paste prompt chain.

--- a/writing-stories/to-jira/README.md
+++ b/writing-stories/to-jira/README.md
@@ -1,0 +1,14 @@
+# Story to Jira
+
+Creates a Jira epic and its child stories from the markdown output of the [`from-figma`](../from-figma) story-writing pipeline.
+
+## What this does
+
+Reads `<project-root>/.results/stories/shell-stories.md` (produced by [`writing-stories/from-figma/4-shell-stories.md`](../from-figma/4-shell-stories.md)) and uses it to create a Jira epic — with Problem, Impact, Solution, User Journeys, and References sections — plus its child stories.
+
+## How to run it
+
+Requires an Atlassian/Jira MCP server configured in your AI agent. Paste the contents of [`story-to-jira.md`](./story-to-jira.md) into your agent and provide:
+
+- `<project-key>` – the Jira project the stories should be created in
+- `<jira-site-id>` – optional, if you have access to more than one Jira site


### PR DESCRIPTION
## Summary

Audits and fixes the repo's documentation so external users can tell what every folder contains and how to run it, without needing to cross-reference the code.

- **Root docs were out of sync with the repo.** `README.md`'s "Repository Structure" section only listed 2 of 7 top-level content categories and never mentioned `/plugins` at all, despite that being the primary distribution mechanism. `PLUGINS.md`'s catalog table was missing 2 of the 9 actual plugins (`figma-from-code`, `implement-workflow`).
- **Every folder now has a `README.md`** with a "what's here" and "how to run it" section — including previously undocumented folders (`crop-image/`, `figma/figma-explore/`, `writing-stories/subtasks-spa-rest-sql/`, `writing-stories/to-jira/`) and supporting-asset subfolders (`reference/`, `steps/`, `examples/`, the `create-skill` `claude`/`copilot` variants).
- **Cross-linked standalone prompts to their plugin equivalents.** Several standalone prompt chains (`figma/*`, `writing-code/specs/`, `writing-code/react/`, `creating-prompts/create-skill/`) already have a packaged, actively-maintained plugin version, but nothing said so. Each now links to its plugin counterpart with neutral "also available as a plugin" framing — both formats remain valid (standalone = paste into any chat agent, no install; plugin = maintained, auto-loading version for Claude Code / Copilot) rather than presenting the standalone copy as deprecated.
- Fixed a case-only filename bug (`creating-prompts/create-skill/readme.md` → `README.md`) for consistency with every other folder in the repo.

## Test plan

- [x] Verified every markdown link added or changed resolves to a real file
- [x] Verified every content folder (prompt chain, skill, or plugin) has a `README.md`, excluding plugin `skills/`/`agents/` containers which correctly use `SKILL.md`/agent `.md` per this repo's own plugin conventions
- [x] Confirmed no stray "legacy"/"superseded" language remains outside of unrelated pre-existing content in `plugins/figma-from-code`'s internal engineering notes
